### PR TITLE
chore: bump CI action versions (setup-uv v10, pypi-publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install dependencies
         run: uv sync --locked --extra dev
@@ -67,7 +67,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install dependencies
         run: uv sync --locked --extra dev --python ${{ matrix.python-version }}
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10
 
       - name: Install dependencies
         run: uv sync --locked --extra dev
@@ -67,7 +67,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10
 
       - name: Install dependencies
         run: uv sync --locked --extra dev --python ${{ matrix.python-version }}
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10
         with:
           python-version: "3.12"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10
         with:
           python-version: "3.12"
 
@@ -80,4 +80,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.2
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

- Bump `astral-sh/setup-uv` from v7 → v10 across `ci.yml` (×3) and `publish.yml` (×1). v10 disables automatic caching for sensitive events, protecting against cache poisoning.
- Update `pypa/gh-action-pypi-publish` from pinned `v1.14.2` → rolling `release/v1` tag for automatic minor/patch updates.

All other GitHub Actions (`actions/checkout`, `actions/setup-python`, Docker actions, `actions/attest-build-provenance`, `actions/upload-artifact`, `actions/download-artifact`) were verified current — no changes needed.

## Test plan

- [ ] CI passes on this PR (the workflows exercise themselves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Shbyh4kqq96iJXZVd9MVGR