### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ On first run mulder creates a working directory at `~/.mulder/workspace` (overri
 ### Run with Docker (everything preinstalled)
 
 ```bash
-docker pull ghcr.io/calebevans/mulder:1.4.0
+docker pull ghcr.io/calebevans/mulder:1.4.1
 ```
 
 ```bash
@@ -83,7 +83,7 @@ docker run -it --privileged \
   -v /path/to/evidence:/evidence:ro \
   -v ~/mulder-cases:/home/mulder/.mulder/cases \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
-  ghcr.io/calebevans/mulder:1.4.0
+  ghcr.io/calebevans/mulder:1.4.1
 ```
 
 ```bash

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -216,7 +216,7 @@ To expose mulder's tools to Claude Desktop or any other MCP client, add:
 The pre-built container image includes all forensic tools, dependencies, and the Mulder server:
 
 ```bash
-docker pull ghcr.io/calebevans/mulder:1.4.0
+docker pull ghcr.io/calebevans/mulder:1.4.1
 ```
 
 ## Running a Container
@@ -257,7 +257,7 @@ docker run -it --privileged \
   -v /path/to/evidence:/evidence:ro \
   -v ~/mulder-cases:/home/mulder/.mulder/cases \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
-  ghcr.io/calebevans/mulder:1.4.0
+  ghcr.io/calebevans/mulder:1.4.1
 ```
 
 ### Using Google Cloud Vertex AI
@@ -273,7 +273,7 @@ docker run -it --privileged \
   -e ANTHROPIC_VERTEX_PROJECT_ID=your-gcp-project-id \
   -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-creds.json \
   -v ~/.config/gcloud/application_default_credentials.json:/tmp/gcloud-creds.json:ro \
-  ghcr.io/calebevans/mulder:1.4.0
+  ghcr.io/calebevans/mulder:1.4.1
 ```
 
 Model IDs are passed through to the SDK exactly as specified, with no automatic translation or mapping. When using Vertex, you must provide the full Vertex model ID including the `@version` suffix (e.g. `--model claude-opus-4-6@20250514`). If you omit `--model`, the built-in defaults (`claude-opus-4-6` for planner/analyst, `claude-haiku-4-5` for executor) are used.
@@ -299,7 +299,7 @@ docker run -it --privileged \
   -e AWS_REGION=us-east-1 \
   -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-  ghcr.io/calebevans/mulder:1.4.0
+  ghcr.io/calebevans/mulder:1.4.1
 ```
 
 Model IDs are passed through to the SDK exactly as specified, with no automatic translation or mapping. When using Bedrock, you must provide the full Bedrock model ID with the `us.anthropic.` prefix (e.g. `--model us.anthropic.claude-opus-4-6`). If you omit `--model`, the built-in defaults (`claude-opus-4-6` for planner/analyst, `claude-haiku-4-5` for executor) are used.

--- a/src/mulder/__init__.py
+++ b/src/mulder/__init__.py
@@ -1,3 +1,3 @@
 """Mulder: custom MCP server for SANS SIFT Workstation forensic investigations."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
## Summary
- Bump `__version__` in `src/mulder/__init__.py` from `1.4.0` to `1.4.1`
- Update all Docker image tag references in `README.md` and `docs/usage-guide.md` from `1.4.0` to `1.4.1`

## Test plan
- [x] Pre-commit passes (ruff, ruff-format, mypy)
- [x] No remaining `1.4.0` references in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Shbyh4kqq96iJXZVd9MVGR