### PR TITLE
docs: fix native install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,6 @@ Each gate validates structural criteria (minimum sources indexed, findings submi
 ### Install natively (SIFT Workstation, Debian/Ubuntu)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/calebevans/mulder/main/install.sh | bash
-```
-
-One command. It prints what it will do, asks once, then installs the OS packages you are missing (via `apt`, asking for your sudo password), mulder itself (via `pipx`, no sudo), and the forensic data and helper tools (~2.1 GB, no sudo). On a stock SIFT Workstation the only OS package missing is `yara` — SIFT ships the `python3-yara` module but not the binary.
-
-Prefer to run the steps yourself:
-
-```bash
 sudo apt install git sleuthkit yara p7zip-full binutils
 pipx install "mulder-dfir[forensics]"
 mulder setup


### PR DESCRIPTION
## Summary
- Remove the abandoned `curl | bash` installer (from closed PR #16) from the Quick Start section
- The manual `pipx install` steps below it were already correct and are now the primary instruction
- `install.sh` still exists on main — removing it is left for a separate PR

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm the pipx install instructions match the current workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Shbyh4kqq96iJXZVd9MVGR