### PR TITLE
Stop publishing container images on every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,48 +116,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to GitHub Container Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=pr
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push container image
+      - name: Build container image
         id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          load: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          load: true
+          tags: mulder:ci-smoke
           cache-from: type=gha
           cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min' || '' }}
 
@@ -168,8 +144,7 @@ jobs:
       - name: Smoke-test 'mulder setup --verify' inside the image
         run: |
           set -euo pipefail
-          tag=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
-          docker run --rm --user mulder --entrypoint mulder "$tag" \
+          docker run --rm --user mulder --entrypoint mulder mulder:ci-smoke \
             setup --verify --json > verify.json
           python3 - <<'PY'
           import json
@@ -184,11 +159,3 @@ jobs:
           assert not shadowed, shadowed
           assert report["exit"] == 0, report["exit"]
           PY
-
-      - name: Generate artifact attestation
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,23 @@
+name: Cleanup container images
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Mondays at 06:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete untagged images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Clean up untagged container images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-untagged: true
+          validate: true
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI was pushing a dev-tagged image to GHCR on every main push, leaving behind untagged SHAs each time the tag moved. Container images are now only published via the existing release.yml workflow when a GitHub release is created (with full multi-platform support).

The CI container job is kept as a build-only smoke test. A weekly cleanup workflow prunes orphaned untagged images while preserving architecture manifests referenced by tagged multi-platform releases.


Claude-Session: https://claude.ai/code/session_01HbcMK4GjjDjNJAZVFb2uqb