### PR TITLE
Use mode=max for Docker build cache to cache all stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=min' || '' }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}
 
       # The image ships every asset already provisioned under /opt, so
       # `setup --verify` must find all of them and exit 0. --user mulder,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=min
+          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4


### PR DESCRIPTION
mode=min only caches the final runtime layer. With 11 builder stages (libewf, bulk_extractor, hayabusa, suricata, etc.), every intermediate compilation was rebuilt from scratch on each run. mode=max caches all stages so subsequent builds can reuse them.

