### PR TITLE
[critical][fix] 0.1 — Correct resolved-path containment

### DIFF
--- a/src/mulder/path_policy.py
+++ b/src/mulder/path_policy.py
@@ -1,0 +1,61 @@
+"""Resolved filesystem path-containment policy.
+
+The interface deliberately returns the authorized, resolved path.  Callers must
+use that path for the subsequent filesystem operation so a symlink is not
+authorized by its destination and then accessed again through its original
+name.
+
+Resolution falls back to non-strict mode only when a path does not exist, which
+preserves support for probing missing paths without treating other resolution
+errors as safe.  A missing path is allowed only when its prospective resolved
+location is inside an allowed root.  Existing symlinks (including an existing
+prefix of a non-existent path) are followed, so a symlink whose destination
+escapes every allowed root is denied.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+class PathPolicyError(ValueError):
+    """Raised when a path cannot be safely resolved inside an allowed root."""
+
+
+def _resolve(path: Path) -> Path:
+    """Resolve *path*, permitting absence but rejecting other resolution errors."""
+    try:
+        return path.resolve(strict=True)
+    except FileNotFoundError:
+        return path.resolve(strict=False)
+
+
+def resolve_allowed_path(target: Path, allowed_roots: Iterable[Path]) -> Path:
+    """Return *target* resolved inside one of *allowed_roots*.
+
+    Resolution makes containment path-component aware, collapses ``..``,
+    follows existing symlinks, and retains the previous behavior for
+    non-existent paths.  Symlink loops and other resolution failures are
+    denied.
+
+    Raises:
+        PathPolicyError: If resolution fails or the target is outside every
+            allowed root.
+    """
+    try:
+        resolved_target = _resolve(target)
+    except (OSError, RuntimeError) as exc:
+        raise PathPolicyError(f"Cannot resolve path: {target}") from exc
+
+    resolved_roots: list[Path] = []
+    for root in allowed_roots:
+        try:
+            resolved_roots.append(_resolve(root))
+        except (OSError, RuntimeError) as exc:
+            raise PathPolicyError(f"Cannot resolve allowed root: {root}") from exc
+
+    if any(resolved_target.is_relative_to(root) for root in resolved_roots):
+        return resolved_target
+
+    raise PathPolicyError("Access denied: path is outside allowed directories")

--- a/src/mulder/server/tools/artifacts.py
+++ b/src/mulder/server/tools/artifacts.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from mulder.path_policy import PathPolicyError, resolve_allowed_path
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import hash_output, make_tool_call_id
@@ -48,21 +49,15 @@ def _readonly_authorizer(
     return sqlite3.SQLITE_DENY
 
 
-def _validate_path_access(target: Path) -> str | None:
-    """Return an error message if the path is not under an allowed root, else None."""
-    try:
-        resolved = target.resolve()
-    except OSError:
-        return f"Cannot resolve path: {target}"
+def _resolve_artifact_path(target: Path) -> Path:
+    """Resolve *target* within the active evidence or case-storage root."""
     cfg = get_cfg()
-    allowed_roots = [Path(cfg.db_dir).resolve()]
+    allowed_roots = [Path(cfg.db_dir)]
     ctx = get_ctx()
     meta = ctx.db.get_case_metadata()
     if meta and meta.evidence_root:
-        allowed_roots.append(Path(meta.evidence_root).resolve())
-    if not any(str(resolved).startswith(str(root)) for root in allowed_roots):
-        return "Access denied: path is outside allowed directories"
-    return None
+        allowed_roots.append(Path(meta.evidence_root))
+    return resolve_allowed_path(target, allowed_roots)
 
 
 _TOOL_TIMEOUT = 120
@@ -454,13 +449,13 @@ def list_directory(
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
 
-    target = Path(path)
-    path_err = _validate_path_access(target)
-    if path_err:
+    try:
+        target = _resolve_artifact_path(Path(path))
+    except PathPolicyError as exc:
         return {
             "tool_call_id": tc_id,
             "status": "error",
-            "error_message": path_err,
+            "error_message": str(exc),
             "results": [],
             "result_count": 0,
         }
@@ -550,13 +545,13 @@ def read_evidence_file(
     t0 = time.monotonic()
     params = {"file_path": file_path, "max_bytes": max_bytes}
 
-    target = Path(file_path)
-    path_err = _validate_path_access(target)
-    if path_err:
+    try:
+        target = _resolve_artifact_path(Path(file_path))
+    except PathPolicyError as exc:
         return {
             "tool_call_id": tc_id,
             "status": "error",
-            "error_message": path_err,
+            "error_message": str(exc),
         }
     if not target.exists():
         elapsed = (time.monotonic() - t0) * 1000

--- a/tests/test_path_policy.py
+++ b/tests/test_path_policy.py
@@ -1,0 +1,151 @@
+"""Adversarial tests for resolved filesystem path containment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mulder.path_policy import PathPolicyError, resolve_allowed_path
+
+
+def test_allows_root_and_nested_file(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    nested = evidence_root / "host" / "logs" / "security.evtx"
+    nested.parent.mkdir(parents=True)
+    nested.touch()
+
+    assert resolve_allowed_path(evidence_root, [evidence_root]) == evidence_root.resolve()
+    assert resolve_allowed_path(nested, [evidence_root]) == nested.resolve()
+
+
+def test_rejects_sibling_with_same_string_prefix(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    sibling = tmp_path / "evidence-other" / "secrets.txt"
+    evidence_root.mkdir()
+    sibling.parent.mkdir()
+    sibling.touch()
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(sibling, [evidence_root])
+
+
+def test_dotdot_is_checked_after_resolution(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+
+    inside = evidence_root / "host" / ".." / "timeline.csv"
+    outside = evidence_root / ".." / "outside.txt"
+
+    assert resolve_allowed_path(inside, [evidence_root]) == (evidence_root / "timeline.csv")
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(outside, [evidence_root])
+
+
+def test_rejects_existing_symlink_escape(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    outside_root = tmp_path / "outside"
+    evidence_root.mkdir()
+    outside_root.mkdir()
+    secret = outside_root / "secret.txt"
+    secret.touch()
+    escape = evidence_root / "escape"
+    escape.symlink_to(outside_root, target_is_directory=True)
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(escape / "secret.txt", [evidence_root])
+
+
+def test_allows_symlink_whose_destination_is_inside_root(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    real_dir = evidence_root / "real"
+    real_dir.mkdir(parents=True)
+    artifact = real_dir / "artifact.txt"
+    artifact.touch()
+    link = evidence_root / "link"
+    link.symlink_to(real_dir, target_is_directory=True)
+
+    assert resolve_allowed_path(link / "artifact.txt", [evidence_root]) == artifact.resolve()
+
+
+def test_nonexistent_descendant_is_provisionally_allowed(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    missing = evidence_root / "not-created" / "artifact.txt"
+
+    assert not missing.exists()
+    assert resolve_allowed_path(missing, [evidence_root]) == missing.resolve(strict=False)
+
+
+def test_dangling_symlink_is_checked_by_destination(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    dangling_escape = evidence_root / "dangling"
+    dangling_escape.symlink_to(tmp_path / "outside" / "missing.txt")
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(dangling_escape, [evidence_root])
+
+
+def test_accepts_evidence_and_case_roots_but_not_common_parent(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    case_root = tmp_path / "cases"
+    evidence_file = evidence_root / "image.E01"
+    case_file = case_root / "case.sqlite3"
+    unrelated = tmp_path / "other.txt"
+    evidence_root.mkdir()
+    case_root.mkdir()
+    evidence_file.touch()
+    case_file.touch()
+    unrelated.touch()
+    roots = [evidence_root, case_root]
+
+    assert resolve_allowed_path(evidence_file, roots) == evidence_file.resolve()
+    assert resolve_allowed_path(case_file, roots) == case_file.resolve()
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(unrelated, roots)
+
+
+def test_artifact_adapter_uses_configured_evidence_and_case_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mulder.server.tools import artifacts
+
+    evidence_root = tmp_path / "evidence"
+    case_root = tmp_path / "cases"
+    evidence_root.mkdir()
+    case_root.mkdir()
+    evidence_file = evidence_root / "artifact.txt"
+    case_file = case_root / "case.sqlite3"
+    evidence_file.touch()
+    case_file.touch()
+
+    metadata = SimpleNamespace(evidence_root=str(evidence_root))
+    db = SimpleNamespace(get_case_metadata=lambda: metadata)
+    monkeypatch.setattr(artifacts, "get_cfg", lambda: SimpleNamespace(db_dir=case_root))
+    monkeypatch.setattr(artifacts, "get_ctx", lambda: SimpleNamespace(db=db))
+
+    assert artifacts._resolve_artifact_path(evidence_file) == evidence_file.resolve()
+    assert artifacts._resolve_artifact_path(case_file) == case_file.resolve()
+
+
+def test_file_root_does_not_authorize_sibling_prefix(tmp_path: Path) -> None:
+    evidence_image = tmp_path / "image.E01"
+    sibling = tmp_path / "image.E01.backup"
+    evidence_image.touch()
+    sibling.touch()
+
+    assert resolve_allowed_path(evidence_image, [evidence_image]) == evidence_image.resolve()
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(sibling, [evidence_image])
+
+
+def test_symlink_loop_fails_closed(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    loop = evidence_root / "loop"
+    loop.symlink_to(loop)
+
+    with pytest.raises(PathPolicyError, match="Cannot resolve path"):
+        resolve_allowed_path(loop, [evidence_root])


### PR DESCRIPTION
- **BLUF:** Prevent artifact access from escaping the configured evidence root.
- **Priority:** Critical — A containment bypass can expose or mutate evidence outside the case boundary.
- **Changes:** Canonicalize paths and reject sibling-prefix, traversal, symlink, and non-existing escape cases.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 1/37; prerequisite diffs may overlap until earlier PRs land.