### PR TITLE
[critical][feature] 0.2 — Introduce typed tool outcomes and coverage metadata

### DIFF
--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -2,9 +2,91 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+
+class ToolOutcomeStatus(str, Enum):
+    """Machine-readable execution state for a forensic tool result.
+
+    The legacy MCP response ``status`` remains ``success`` or ``error`` for
+    backwards compatibility.  This enum carries the more precise state needed
+    to decide what conclusions the result can support.
+    """
+
+    SUCCESS_NONEMPTY = "SUCCESS_NONEMPTY"
+    SUCCESS_EMPTY = "SUCCESS_EMPTY"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    UNAVAILABLE = "UNAVAILABLE"
+    UNSUPPORTED_VERSION = "UNSUPPORTED_VERSION"
+    FAILED = "FAILED"
+    TIMED_OUT = "TIMED_OUT"
+    PARTIAL = "PARTIAL"
+    SAMPLED = "SAMPLED"
+
+
+class FallbackAttempt(BaseModel):
+    """One earlier adapter attempt retained when a fallback produced a result."""
+
+    adapter: str
+    status: ToolOutcomeStatus
+    reason: str | None = None
+    tool_version: str | None = None
+    parser_version: str | None = None
+
+
+class CoverageMetadata(BaseModel):
+    """Structured scope and implementation provenance for a tool outcome.
+
+    ``examined`` values describe content successfully examined, rather than
+    content merely discovered or attempted.  Unknown values stay ``None``;
+    callers must not turn an unknown total into an implicit complete result.
+    """
+
+    bytes_examined: int | None = Field(default=None, ge=0)
+    bytes_total: int | None = Field(default=None, ge=0)
+    rows_examined: int | None = Field(default=None, ge=0)
+    rows_total: int | None = Field(default=None, ge=0)
+    truncation_reason: str | None = None
+    sample_reason: str | None = None
+    tool_version: str | None = None
+    parser_version: str | None = None
+    fallback_lineage: list[FallbackAttempt] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_scope_bounds(self) -> CoverageMetadata:
+        """Reject coverage that claims to examine more than the known total."""
+        if (
+            self.bytes_examined is not None
+            and self.bytes_total is not None
+            and self.bytes_examined > self.bytes_total
+        ):
+            raise ValueError("bytes_examined cannot exceed bytes_total")
+        if (
+            self.rows_examined is not None
+            and self.rows_total is not None
+            and self.rows_examined > self.rows_total
+        ):
+            raise ValueError("rows_examined cannot exceed rows_total")
+        return self
+
+
+class ToolOutcome(BaseModel):
+    """Versioned, serializable execution semantics for an MCP tool response."""
+
+    schema_version: Literal[1] = 1
+    status: ToolOutcomeStatus
+    coverage: CoverageMetadata = Field(default_factory=CoverageMetadata)
+    reason: str | None = None
+
+    @model_validator(mode="after")
+    def _check_status_metadata(self) -> ToolOutcome:
+        """Require the scope explanation that makes sampled results auditable."""
+        if self.status is ToolOutcomeStatus.SAMPLED and not self.coverage.sample_reason:
+            raise ValueError("SAMPLED outcomes require coverage.sample_reason")
+        return self
 
 
 class WindowRow(BaseModel):

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, ParamSpec
 from uuid import uuid4
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, has_ctx
 
 current_batch_id: ContextVar[str | None] = ContextVar("current_batch_id", default=None)
@@ -269,9 +270,24 @@ def windowed_response(
             duration_ms=elapsed_ms,
             batch_id=current_batch_id.get(),
         )
+    if total > cap:
+        outcome_status = ToolOutcomeStatus.SAMPLED
+    elif total == 0:
+        outcome_status = ToolOutcomeStatus.SUCCESS_EMPTY
+    else:
+        outcome_status = ToolOutcomeStatus.SUCCESS_NONEMPTY
+    outcome = ToolOutcome(
+        status=outcome_status,
+        coverage=CoverageMetadata(
+            rows_examined=len(results),
+            rows_total=total,
+            sample_reason=(f"response capped at {cap} windows" if total > cap else None),
+        ),
+    )
     resp: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "success",
+        "outcome": outcome.model_dump(mode="json"),
         "results": results,
         "source": source,
         "result_count": len(results),
@@ -303,8 +319,14 @@ def tool_response(
     results: dict[str, object] | list[object],
     source: str | None = None,
     elapsed_ms: float = 0,
+    outcome: ToolOutcome | None = None,
 ) -> dict[str, object]:
     """Build an audited success response and log the tool call.
+
+    ``outcome`` is the precise, versioned execution contract.  When omitted,
+    it defaults to ``SUCCESS_NONEMPTY`` so adoption can proceed tool by tool;
+    callers returning empty, sampled, or partial data must pass it explicitly.
+    The legacy top-level ``status`` is retained for existing clients.
 
     When *source* is provided (indicating data has been indexed into the
     case DB), returns a compact response with only a preview of the output.
@@ -314,6 +336,8 @@ def tool_response(
     When *source* is None, returns the full results (for read/reference
     tools whose output is not indexed elsewhere).
     """
+    precise_outcome = outcome or ToolOutcome(status=ToolOutcomeStatus.SUCCESS_NONEMPTY)
+
     if has_ctx():
         ctx = get_ctx()
         ctx.audit.log_tool_call(
@@ -329,6 +353,7 @@ def tool_response(
         return {
             "tool_call_id": tc_id,
             "status": "success",
+            "outcome": precise_outcome.model_dump(mode="json"),
             "results": results,
             "source": source,
         }
@@ -352,6 +377,7 @@ def tool_response(
     resp: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "success",
+        "outcome": precise_outcome.model_dump(mode="json"),
         "source": source,
         "preview": preview + ("..." if len(preview) >= _PREVIEW_CHAR_LIMIT else ""),
         "hint": (
@@ -375,8 +401,31 @@ def error_response(
     elapsed_ms: float = 0,
     error_type: str = "unknown",
     suggestion: str | None = None,
+    outcome_status: ToolOutcomeStatus | None = None,
+    coverage: CoverageMetadata | None = None,
 ) -> dict[str, object]:
-    """Build an audited error response and log the tool call."""
+    """Build an audited error response and log the tool call.
+
+    Common legacy error types are mapped to precise outcome states.  A caller
+    can supply ``outcome_status`` and ``coverage`` when it knows more.
+    """
+    if outcome_status is None:
+        if error_type == "timeout":
+            outcome_status = ToolOutcomeStatus.TIMED_OUT
+        elif error_type in {
+            "binary_missing",
+            "file_not_found",
+            "hive_not_found",
+            "no_filelist",
+        }:
+            outcome_status = ToolOutcomeStatus.UNAVAILABLE
+        else:
+            outcome_status = ToolOutcomeStatus.FAILED
+    outcome = ToolOutcome(
+        status=outcome_status,
+        coverage=coverage or CoverageMetadata(),
+        reason=error,
+    )
     if has_ctx():
         ctx = get_ctx()
         ctx.audit.log_tool_call(
@@ -390,6 +439,7 @@ def error_response(
     result: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "error",
+        "outcome": outcome.model_dump(mode="json"),
         "error_type": error_type,
         "error_message": error,
     }

--- a/src/mulder/server/tools/extract/app_files.py
+++ b/src/mulder/server/tools/extract/app_files.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 from typing import Any
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -289,6 +290,9 @@ def index_app_files(
 
     if not all_matches:
         elapsed = (time.monotonic() - t0) * 1000
+        rows_examined = sum(
+            len(chunk.splitlines()) for chunks, _offset in chunk_groups for chunk in chunks
+        )
         return tool_response(
             tc_id,
             "index_app_files",
@@ -303,6 +307,14 @@ def index_app_files(
             },
             source=None,
             elapsed_ms=elapsed,
+            outcome=ToolOutcome(
+                status=ToolOutcomeStatus.SUCCESS_EMPTY,
+                coverage=CoverageMetadata(
+                    rows_examined=rows_examined,
+                    rows_total=rows_examined,
+                    parser_version="fls-text-v1",
+                ),
+            ),
         )
 
     capped = all_matches[:max_files]
@@ -351,6 +363,31 @@ def index_app_files(
         "extensions_used": sorted(ext_set),
     }
 
+    if files_indexed < len(capped):
+        outcome_status = ToolOutcomeStatus.PARTIAL
+    elif len(all_matches) > len(capped):
+        outcome_status = ToolOutcomeStatus.SAMPLED
+    elif files_indexed == 0:
+        outcome_status = ToolOutcomeStatus.SUCCESS_EMPTY
+    else:
+        outcome_status = ToolOutcomeStatus.SUCCESS_NONEMPTY
+
+    coverage = CoverageMetadata(
+        rows_examined=files_indexed,
+        rows_total=len(all_matches),
+        truncation_reason=(
+            f"{len(capped) - files_indexed} selected files were not indexed"
+            if files_indexed < len(capped)
+            else None
+        ),
+        sample_reason=(
+            f"max_files={max_files} limited {len(all_matches)} matching files"
+            if len(all_matches) > len(capped)
+            else None
+        ),
+        parser_version="fls-text-v1",
+    )
+
     return tool_response(
         tc_id,
         "index_app_files",
@@ -358,4 +395,5 @@ def index_app_files(
         results,
         source=None,
         elapsed_ms=elapsed,
+        outcome=ToolOutcome(status=outcome_status, coverage=coverage),
     )

--- a/src/mulder/server/tools/extract/disk_pcap.py
+++ b/src/mulder/server/tools/extract/disk_pcap.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -390,6 +391,9 @@ def analyze_disk_pcaps(
 
     if not all_pcaps:
         elapsed = (time.monotonic() - t0) * 1000
+        rows_examined = sum(
+            len(chunk.splitlines()) for chunks, _offset in chunk_groups for chunk in chunks
+        )
         return tool_response(
             tc_id,
             "analyze_disk_pcaps",
@@ -401,6 +405,14 @@ def analyze_disk_pcaps(
             },
             source=None,
             elapsed_ms=elapsed,
+            outcome=ToolOutcome(
+                status=ToolOutcomeStatus.SUCCESS_EMPTY,
+                coverage=CoverageMetadata(
+                    rows_examined=rows_examined,
+                    rows_total=rows_examined,
+                    parser_version="fls-text-v1",
+                ),
+            ),
         )
 
     max_size_bytes = max_pcap_size_mb * 1024 * 1024
@@ -478,6 +490,25 @@ def analyze_disk_pcaps(
         "credentials": all_credentials[:100],
     }
 
+    incomplete_count = len(pcaps_failed) + len(pcaps_skipped_size)
+    outcome = ToolOutcome(
+        status=(
+            ToolOutcomeStatus.PARTIAL
+            if incomplete_count
+            else ToolOutcomeStatus.SUCCESS_NONEMPTY
+        ),
+        coverage=CoverageMetadata(
+            rows_examined=len(pcaps_analyzed),
+            rows_total=len(all_pcaps),
+            truncation_reason=(
+                f"{incomplete_count} discovered captures were not analyzed"
+                if incomplete_count
+                else None
+            ),
+            parser_version="fls-text-v1",
+        ),
+    )
+
     return tool_response(
         tc_id,
         "analyze_disk_pcaps",
@@ -485,4 +516,5 @@ def analyze_disk_pcaps(
         results,
         source=None,
         elapsed_ms=elapsed,
+        outcome=outcome,
     )

--- a/tests/test_app_files.py
+++ b/tests/test_app_files.py
@@ -268,6 +268,9 @@ class TestIndexAppFilesTool:
         assert result["status"] == "success"
         assert result["results"]["files_discovered"] == 0
         assert "NonExistent/Path" in result["results"]["pattern"]
+        assert result["outcome"]["status"] == "SUCCESS_EMPTY"
+        assert result["outcome"]["coverage"]["rows_examined"] == 8
+        assert result["outcome"]["coverage"]["rows_total"] == 8
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")
@@ -301,6 +304,10 @@ class TestIndexAppFilesTool:
         assert result["results"]["files_discovered"] == 300
         assert result["results"]["files_capped_at"] == 50
         assert mock_extract.call_count == 50
+        assert result["outcome"]["status"] == "SAMPLED"
+        assert result["outcome"]["coverage"]["rows_examined"] == 50
+        assert result["outcome"]["coverage"]["rows_total"] == 300
+        assert "max_files=50" in result["outcome"]["coverage"]["sample_reason"]
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")
@@ -330,6 +337,9 @@ class TestIndexAppFilesTool:
         assert result["status"] == "success"
         assert result["results"]["files_extracted"] == 0
         assert result["results"]["files_skipped_binary"] > 0
+        assert result["outcome"]["status"] == "PARTIAL"
+        assert result["outcome"]["coverage"]["rows_examined"] == 0
+        assert result["outcome"]["coverage"]["rows_total"] > 0
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")

--- a/tests/test_disk_pcap.py
+++ b/tests/test_disk_pcap.py
@@ -245,6 +245,7 @@ class TestAnalyzeDiskPcapsTool:
         )
         assert result["status"] == "error"
         assert result["error_type"] == "no_filelist"
+        assert result["outcome"]["status"] == "UNAVAILABLE"
 
     @patch("mulder.server.tools.extract.disk_pcap.require_binary")
     @patch("mulder.server.tools.extract.disk_pcap._collect_fls_chunks")
@@ -270,6 +271,7 @@ class TestAnalyzeDiskPcapsTool:
         assert result["status"] == "success"
         assert result["results"]["pcaps_discovered"] == 0
         assert result["results"]["pcaps_analyzed"] == 0
+        assert result["outcome"]["status"] == "SUCCESS_EMPTY"
 
     @patch("mulder.server.tools.extract.disk_pcap.extract_and_index")
     @patch("mulder.server.tools.extract.disk_pcap._extract_pcap_via_icat")
@@ -312,6 +314,9 @@ class TestAnalyzeDiskPcapsTool:
         assert result["status"] == "success"
         assert "Captures/huge.pcap" in result["results"]["pcaps_skipped_oversize"]
         assert result["results"]["pcaps_analyzed"] == 0
+        assert result["outcome"]["status"] == "PARTIAL"
+        assert result["outcome"]["coverage"]["rows_examined"] == 0
+        assert result["outcome"]["coverage"]["rows_total"] == 1
 
     @patch("mulder.server.tools.extract.disk_pcap.extract_and_index")
     @patch("mulder.server.tools.extract.disk_pcap._extract_pcap_via_icat")

--- a/tests/test_tool_outcomes.py
+++ b/tests/test_tool_outcomes.py
@@ -1,0 +1,182 @@
+"""Tests for precise, backwards-compatible forensic tool outcomes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from mulder.models import (
+    CoverageMetadata,
+    FallbackAttempt,
+    ToolOutcome,
+    ToolOutcomeStatus,
+)
+from mulder.server.helpers import error_response, tool_response, windowed_response
+
+
+def test_all_outcome_states_serialize_as_stable_strings() -> None:
+    """Every universal status is JSON-safe and round-trips through the schema."""
+    expected = {
+        "SUCCESS_NONEMPTY",
+        "SUCCESS_EMPTY",
+        "NOT_APPLICABLE",
+        "UNAVAILABLE",
+        "UNSUPPORTED_VERSION",
+        "FAILED",
+        "TIMED_OUT",
+        "PARTIAL",
+        "SAMPLED",
+    }
+    assert {status.value for status in ToolOutcomeStatus} == expected
+
+    for status in ToolOutcomeStatus:
+        coverage = CoverageMetadata(
+            sample_reason="bounded fixture" if status is ToolOutcomeStatus.SAMPLED else None
+        )
+        original = ToolOutcome(status=status, coverage=coverage)
+        encoded = json.dumps(original.model_dump(mode="json"))
+        assert ToolOutcome.model_validate_json(encoded) == original
+
+
+def test_json_schema_exposes_status_and_coverage_contract() -> None:
+    """Generated schemas let MCP clients validate the additive envelope."""
+    schema = ToolOutcome.model_json_schema()
+
+    assert set(schema["$defs"]["ToolOutcomeStatus"]["enum"]) == {
+        status.value for status in ToolOutcomeStatus
+    }
+    coverage_properties = schema["$defs"]["CoverageMetadata"]["properties"]
+    assert {
+        "bytes_examined",
+        "bytes_total",
+        "rows_examined",
+        "rows_total",
+        "truncation_reason",
+        "sample_reason",
+        "tool_version",
+        "parser_version",
+        "fallback_lineage",
+    } <= coverage_properties.keys()
+
+
+def test_coverage_serializes_fallback_lineage_and_versions() -> None:
+    """Fallback provenance remains structured instead of becoming prose."""
+    outcome = ToolOutcome(
+        status=ToolOutcomeStatus.SUCCESS_NONEMPTY,
+        coverage=CoverageMetadata(
+            bytes_examined=512,
+            bytes_total=512,
+            rows_examined=8,
+            rows_total=8,
+            tool_version="2.4.1",
+            parser_version="evtx-0.8.1",
+            fallback_lineage=[
+                FallbackAttempt(
+                    adapter="primary-evtx-parser",
+                    status=ToolOutcomeStatus.UNSUPPORTED_VERSION,
+                    reason="unknown chunk format",
+                    parser_version="evtx-0.7.4",
+                )
+            ],
+        ),
+    )
+
+    wire = outcome.model_dump(mode="json")
+    assert wire["schema_version"] == 1
+    assert wire["coverage"]["fallback_lineage"][0]["status"] == "UNSUPPORTED_VERSION"
+    assert wire["coverage"]["parser_version"] == "evtx-0.8.1"
+
+
+@pytest.mark.parametrize(
+    ("field_values", "message"),
+    [
+        ({"bytes_examined": 2, "bytes_total": 1}, "bytes_examined"),
+        ({"rows_examined": 2, "rows_total": 1}, "rows_examined"),
+    ],
+)
+def test_coverage_rejects_impossible_scope(
+    field_values: dict[str, int], message: str
+) -> None:
+    """An adapter cannot claim to examine more than its known input scope."""
+    with pytest.raises(ValidationError, match=message):
+        CoverageMetadata(**field_values)
+
+
+def test_sampled_outcome_requires_a_machine_visible_reason() -> None:
+    """A sampled result cannot masquerade as an unexplained complete result."""
+    with pytest.raises(ValidationError, match="sample_reason"):
+        ToolOutcome(status=ToolOutcomeStatus.SAMPLED)
+
+
+def test_parser_failure_is_not_serialized_as_successful_empty() -> None:
+    """A parser crash stays FAILED even when it produced no rows."""
+    response = error_response(
+        "tc_parser",
+        "parse_fixture",
+        {},
+        "malformed record at offset 42",
+        error_type="parse_error",
+        coverage=CoverageMetadata(bytes_examined=42, bytes_total=100),
+    )
+
+    assert response["status"] == "error"
+    assert response["outcome"]["status"] == "FAILED"
+    assert response["outcome"]["status"] != "SUCCESS_EMPTY"
+    assert response["outcome"]["coverage"]["bytes_examined"] == 42
+    assert response["outcome"]["coverage"]["bytes_total"] == 100
+
+
+def test_timeout_gets_a_distinct_outcome_without_breaking_legacy_status() -> None:
+    response = error_response(
+        "tc_timeout",
+        "slow_parser",
+        {},
+        "timed out",
+        error_type="timeout",
+    )
+
+    assert response["status"] == "error"
+    assert response["outcome"]["status"] == "TIMED_OUT"
+
+
+def test_success_helper_preserves_legacy_shape_and_accepts_precise_scope() -> None:
+    response = tool_response(
+        "tc_partial",
+        "bounded_parser",
+        {},
+        {"records": [1, 2]},
+        outcome=ToolOutcome(
+            status=ToolOutcomeStatus.PARTIAL,
+            coverage=CoverageMetadata(
+                rows_examined=2,
+                rows_total=9,
+                truncation_reason="parser stopped at corrupt record",
+            ),
+        ),
+    )
+
+    assert response["status"] == "success"
+    assert response["results"] == {"records": [1, 2]}
+    assert response["outcome"]["status"] == "PARTIAL"
+    assert response["outcome"]["coverage"]["rows_total"] == 9
+
+
+def test_windowed_response_distinguishes_empty_and_sampled_scope() -> None:
+    empty = windowed_response("tc_empty", [], "source", "search", {}, 0)
+    assert empty["status"] == "success"
+    assert empty["outcome"]["status"] == "SUCCESS_EMPTY"
+
+    sampled = windowed_response(
+        "tc_sampled",
+        [{"raw_text": str(index)} for index in range(3)],
+        "source",
+        "search",
+        {},
+        0,
+        cap=2,
+    )
+    assert sampled["outcome"]["status"] == "SAMPLED"
+    assert sampled["outcome"]["coverage"]["rows_examined"] == 2
+    assert sampled["outcome"]["coverage"]["rows_total"] == 3


### PR DESCRIPTION
- **BLUF:** Make every forensic tool result explicitly distinguish success, partial data, failure, and unsupported states.
- **Priority:** Critical — Treating failures as empty evidence can produce false negative conclusions.
- **Changes:** Add typed outcomes, coverage metadata, and propagation tests across tool boundaries.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 2/37; prerequisite diffs may overlap until earlier PRs land.