### PR TITLE
[critical][feature] 1.1 — Persist atomic claims and exact evidence anchors

### DIFF
--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -8,11 +8,13 @@ import logging
 import queue
 import re
 import threading
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict, TypeVar, cast
+from uuid import uuid4
 
 from sqlalchemy import (
     Column,
@@ -35,7 +37,15 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.pool import NullPool
 
-from mulder.models import CaseMetadataRow, Finding, SourceRow, WindowRow
+from mulder.models import (
+    AtomicClaim,
+    AtomicClaimInput,
+    CaseMetadataRow,
+    EvidenceAnchor,
+    Finding,
+    SourceRow,
+    WindowRow,
+)
 
 _T = TypeVar("_T")
 
@@ -93,6 +103,55 @@ findings_t = Table(
     Column("event_time_start", Text),
     Column("event_time_end", Text),
     Column("submitted_at", Text, nullable=False),
+)
+
+claims_t = Table(
+    "claims",
+    metadata,
+    Column("claim_id", Text, primary_key=True),
+    Column(
+        "finding_id",
+        Text,
+        ForeignKey("findings.finding_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("ordinal", Integer, nullable=False),
+    Column("statement", Text, nullable=False),
+    Column("subject", Text, nullable=False),
+    Column("predicate", Text, nullable=False),
+    Column("object_value", Text, nullable=False),
+    Column("qualifiers", Text, nullable=False),
+    Column("epistemic_state", Text, nullable=False),
+)
+
+evidence_anchors_t = Table(
+    "evidence_anchors",
+    metadata,
+    Column("anchor_id", Text, primary_key=True),
+    Column(
+        "claim_id",
+        Text,
+        ForeignKey("claims.claim_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("tool_call_id", Text, nullable=False, index=True),
+    Column("source_id", Integer, ForeignKey("sources.source_id"), nullable=False, index=True),
+    Column("source_name", Text, nullable=False),
+    Column("source_hash", Text, nullable=False),
+    Column("window_id", Integer, ForeignKey("windows.window_id"), nullable=False, index=True),
+    Column("line_start", Integer, nullable=False),
+    Column("line_end", Integer, nullable=False),
+    Column("char_start", Integer, nullable=False),
+    Column("char_end", Integer, nullable=False),
+    Column("exact_text", Text, nullable=False),
+    Column("artifact_family", Text, nullable=False),
+    Column("extractor_family", Text, nullable=False),
+    Column("independence_key", Text, nullable=False, index=True),
+    Column("value_type", Text, nullable=False),
+    Column("normalized_value", Text, nullable=False),
+    Column("role", Text, nullable=False),
 )
 
 evidence_registry_t = Table(
@@ -294,6 +353,12 @@ def _migrate_add_kv_store(conn: Connection) -> None:
     )
 
 
+def _migrate_add_claim_tables(conn: Connection) -> None:
+    """Create additive atomic-claim tables for databases from older releases."""
+    claims_t.create(conn, checkfirst=True)
+    evidence_anchors_t.create(conn, checkfirst=True)
+
+
 _SENTINEL = object()
 
 
@@ -444,6 +509,7 @@ class CaseDB:
             _migrate_add_bookmarks(conn)
             _migrate_add_progress(conn)
             _migrate_add_kv_store(conn)
+            _migrate_add_claim_tables(conn)
         return db
 
     def close(self) -> None:
@@ -958,11 +1024,21 @@ class CaseDB:
 
         self._wq.submit(_do_update)
 
-    def insert_finding(self, finding: Finding) -> None:
-        """Persist a Finding to the database."""
+    def insert_finding(
+        self,
+        finding: Finding,
+        claims: list[AtomicClaimInput] | None = None,
+    ) -> list[AtomicClaim]:
+        """Persist a finding and optional atomic claims in one transaction.
 
-        def _do_insert() -> None:
-            """Persist a single finding row."""
+        Exact evidence text and provenance are resolved from the case database;
+        callers cannot inject source hashes or independence keys.  If an anchor
+        is stale, out of bounds, or does not match its expected text, the whole
+        write is rejected and no finding row is committed.
+        """
+
+        def _do_insert() -> list[AtomicClaim]:
+            """Persist a finding and its claim graph atomically."""
             with self._engine.begin() as conn:
                 conn.execute(
                     insert(findings_t).values(
@@ -981,7 +1057,194 @@ class CaseDB:
                     )
                 )
 
-        self._wq.submit(_do_insert)
+                stored: list[AtomicClaim] = []
+                resolved_source_names: set[str] = set()
+                for ordinal, claim_input in enumerate(claims or []):
+                    claim_id = f"c_{uuid4().hex[:12]}"
+                    claim = AtomicClaim(
+                        claim_id=claim_id,
+                        finding_id=finding.finding_id,
+                        ordinal=ordinal,
+                        statement=claim_input.statement,
+                        subject=claim_input.subject,
+                        predicate=claim_input.predicate,
+                        object_value=claim_input.object_value,
+                        qualifiers=claim_input.qualifiers,
+                        epistemic_state="unverified",
+                        anchors=[],
+                    )
+                    conn.execute(
+                        insert(claims_t).values(
+                            claim_id=claim.claim_id,
+                            finding_id=claim.finding_id,
+                            ordinal=claim.ordinal,
+                            statement=claim.statement,
+                            subject=claim.subject,
+                            predicate=claim.predicate,
+                            object_value=json.dumps(claim.object_value),
+                            qualifiers=json.dumps(claim.qualifiers),
+                            epistemic_state=claim.epistemic_state,
+                        )
+                    )
+
+                    resolved_anchors: list[EvidenceAnchor] = []
+                    for anchor_input in claim_input.anchors:
+                        row = conn.execute(
+                            select(
+                                windows_t.c.window_id,
+                                windows_t.c.source_id,
+                                windows_t.c.line_start,
+                                windows_t.c.line_end,
+                                windows_t.c.raw_text,
+                                sources_t.c.source_name,
+                                sources_t.c.source_hash,
+                                sources_t.c.extractor,
+                            )
+                            .select_from(
+                                windows_t.join(
+                                    sources_t,
+                                    windows_t.c.source_id == sources_t.c.source_id,
+                                )
+                            )
+                            .where(windows_t.c.window_id == anchor_input.window_id)
+                        ).fetchone()
+                        if row is None:
+                            raise ValueError(
+                                "Evidence anchor window_id "
+                                f"{anchor_input.window_id} does not exist"
+                            )
+                        raw_text = str(row.raw_text)
+                        if anchor_input.char_end > len(raw_text):
+                            raise ValueError(
+                                "Evidence anchor character range is outside window "
+                                f"{anchor_input.window_id} (length {len(raw_text)})"
+                            )
+                        exact_text = raw_text[
+                            anchor_input.char_start : anchor_input.char_end
+                        ]
+                        if exact_text != anchor_input.expected_text:
+                            raise ValueError(
+                                "Evidence anchor text does not match the immutable window at "
+                                f"{anchor_input.window_id}:{anchor_input.char_start}-"
+                                f"{anchor_input.char_end}"
+                            )
+
+                        extractor = str(row.extractor)
+                        source_hash = str(row.source_hash)
+                        anchor = EvidenceAnchor(
+                            anchor_id=f"a_{uuid4().hex[:12]}",
+                            claim_id=claim_id,
+                            tool_call_id=anchor_input.tool_call_id,
+                            source_id=int(row.source_id),
+                            source_name=str(row.source_name),
+                            source_hash=source_hash,
+                            window_id=int(row.window_id),
+                            line_start=int(row.line_start),
+                            line_end=int(row.line_end),
+                            char_start=anchor_input.char_start,
+                            char_end=anchor_input.char_end,
+                            exact_text=exact_text,
+                            artifact_family=anchor_input.artifact_family or extractor,
+                            extractor_family=extractor,
+                            independence_key=f"source:{source_hash}",
+                            value_type=anchor_input.value_type,
+                            normalized_value=anchor_input.normalized_value,
+                            role=anchor_input.role,
+                        )
+                        resolved_source_names.add(anchor.source_name)
+                        conn.execute(
+                            insert(evidence_anchors_t).values(
+                                anchor_id=anchor.anchor_id,
+                                claim_id=anchor.claim_id,
+                                tool_call_id=anchor.tool_call_id,
+                                source_id=anchor.source_id,
+                                source_name=anchor.source_name,
+                                source_hash=anchor.source_hash,
+                                window_id=anchor.window_id,
+                                line_start=anchor.line_start,
+                                line_end=anchor.line_end,
+                                char_start=anchor.char_start,
+                                char_end=anchor.char_end,
+                                exact_text=anchor.exact_text,
+                                artifact_family=anchor.artifact_family,
+                                extractor_family=anchor.extractor_family,
+                                independence_key=anchor.independence_key,
+                                value_type=anchor.value_type,
+                                normalized_value=json.dumps(anchor.normalized_value),
+                                role=anchor.role,
+                            )
+                        )
+                        resolved_anchors.append(anchor)
+                    stored.append(claim.model_copy(update={"anchors": resolved_anchors}))
+                if stored:
+                    conn.execute(
+                        update(findings_t)
+                        .where(findings_t.c.finding_id == finding.finding_id)
+                        .values(sources=json.dumps(sorted(resolved_source_names)))
+                    )
+                return stored
+
+        return self._wq.submit(_do_insert)
+
+    def get_claims(self, finding_id: str) -> list[AtomicClaim]:
+        """Return a finding's atomic claims with exact anchors, in stable order."""
+        with self._engine.connect() as conn:
+            claim_rows = conn.execute(
+                select(claims_t)
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(claims_t.c.ordinal, claims_t.c.claim_id)
+            ).fetchall()
+            anchor_rows = conn.execute(
+                select(evidence_anchors_t)
+                .select_from(
+                    evidence_anchors_t.join(
+                        claims_t, evidence_anchors_t.c.claim_id == claims_t.c.claim_id
+                    )
+                )
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(evidence_anchors_t.c.anchor_id)
+            ).fetchall()
+
+        by_claim: dict[str, list[EvidenceAnchor]] = defaultdict(list)
+        for row in anchor_rows:
+            by_claim[row.claim_id].append(
+                EvidenceAnchor(
+                    anchor_id=row.anchor_id,
+                    claim_id=row.claim_id,
+                    tool_call_id=row.tool_call_id,
+                    source_id=row.source_id,
+                    source_name=row.source_name,
+                    source_hash=row.source_hash,
+                    window_id=row.window_id,
+                    line_start=row.line_start,
+                    line_end=row.line_end,
+                    char_start=row.char_start,
+                    char_end=row.char_end,
+                    exact_text=row.exact_text,
+                    artifact_family=row.artifact_family,
+                    extractor_family=row.extractor_family,
+                    independence_key=row.independence_key,
+                    value_type=row.value_type,
+                    normalized_value=json.loads(row.normalized_value),
+                    role=row.role,
+                )
+            )
+
+        return [
+            AtomicClaim(
+                claim_id=row.claim_id,
+                finding_id=row.finding_id,
+                ordinal=row.ordinal,
+                statement=row.statement,
+                subject=row.subject,
+                predicate=row.predicate,
+                object_value=json.loads(row.object_value),
+                qualifiers=json.loads(row.qualifiers),
+                epistemic_state=row.epistemic_state,
+                anchors=by_claim[row.claim_id],
+            )
+            for row in claim_rows
+        ]
 
     def update_finding(self, finding_id: str, **kwargs: object) -> bool:
         """Update fields on an existing finding. Returns True if found.

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+JsonScalar: TypeAlias = str | int | float | bool | None
 
 
 class WindowRow(BaseModel):
@@ -63,6 +65,83 @@ class Finding(BaseModel):
         if not self.evidence_refs:
             raise ValueError("evidence_refs must contain at least one tool_call_id")
         return self
+
+
+class EvidenceAnchorInput(BaseModel):
+    """Caller-supplied locator for an exact quote in an evidence window.
+
+    The caller identifies a previously returned window and the exact character
+    range it is relying on.  Source identity, hashes, extractor family, and the
+    independence key are resolved by :class:`CaseDB`; callers cannot assert
+    those provenance fields themselves.
+    """
+
+    tool_call_id: str = Field(min_length=1)
+    window_id: int = Field(gt=0)
+    char_start: int = Field(ge=0)
+    char_end: int = Field(gt=0)
+    expected_text: str = Field(min_length=1)
+    artifact_family: str | None = None
+    value_type: str = "text"
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+    @model_validator(mode="after")
+    def _check_character_range(self) -> EvidenceAnchorInput:
+        if self.char_end <= self.char_start:
+            raise ValueError("char_end must be greater than char_start")
+        return self
+
+
+class AtomicClaimInput(BaseModel):
+    """A material statement and the exact evidence anchors offered for it."""
+
+    statement: str = Field(min_length=1)
+    subject: str = Field(min_length=1)
+    predicate: str = Field(min_length=1)
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    anchors: list[EvidenceAnchorInput] = Field(min_length=1)
+
+
+class EvidenceAnchor(BaseModel):
+    """Server-resolved immutable evidence locator for an atomic claim."""
+
+    anchor_id: str
+    claim_id: str
+    tool_call_id: str
+    source_id: int
+    source_name: str
+    source_hash: str
+    window_id: int
+    line_start: int
+    line_end: int
+    char_start: int
+    char_end: int
+    exact_text: str
+    artifact_family: str
+    extractor_family: str
+    independence_key: str
+    value_type: str
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+
+class AtomicClaim(BaseModel):
+    """Persisted atomic finding statement with resolved evidence anchors."""
+
+    claim_id: str
+    finding_id: str
+    ordinal: int = Field(ge=0)
+    statement: str
+    subject: str
+    predicate: str
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    epistemic_state: Literal[
+        "legacy_unverified", "unverified", "verified", "contradicted", "inconclusive"
+    ] = "unverified"
+    anchors: list[EvidenceAnchor] = Field(default_factory=list)
 
 
 class ToolCallEntry(BaseModel):

--- a/src/mulder/server/tools/findings.py
+++ b/src/mulder/server/tools/findings.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from mulder.models import AuditSummary, CaseMetadataRow, Finding, SourceRow
+from mulder.models import AtomicClaimInput, AuditSummary, CaseMetadataRow, Finding, SourceRow
 from mulder.patterns import SEVERITY_ORDER, source_is_cited
 from mulder.report.renderer import ReportRenderer
 from mulder.server.app import get_ctx, get_job_store, mcp
@@ -186,6 +186,7 @@ def submit_finding(
     mitre_attack_ids: list[str] | None = None,
     event_time_start: str | None = None,
     event_time_end: str | None = None,
+    claims: list[dict[str, Any]] | None = None,
 ) -> dict[str, object]:
     """Record a forensic finding with validated evidence references and metadata.
 
@@ -200,6 +201,13 @@ def submit_finding(
     pass null rather than fabricating. Day-precision placeholders are
     auto-nullified.
 
+    New callers should also submit atomic ``claims``. Each claim points to an
+    exact character range in an indexed evidence window and repeats the text
+    expected at that immutable location. The server resolves source identity,
+    hashes, extractor family, and independence key rather than trusting those
+    values from the caller. Omitting ``claims`` remains supported for legacy
+    clients; such prose is not promoted to a verified atomic claim.
+
     Returns finding_id on acceptance. Severity must be
     critical/high/medium/low/info. Confidence must be "confirmed"
     (corroborated by 2+ sources) or "inference".
@@ -208,7 +216,26 @@ def submit_finding(
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
 
-    invalid_refs = [ref for ref in evidence_refs if not ctx.audit.has_tool_call(ref)]
+    try:
+        claim_inputs = [AtomicClaimInput.model_validate(raw) for raw in claims or []]
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Atomic claim validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
+
+    claim_refs = {
+        anchor.tool_call_id for claim in claim_inputs for anchor in claim.anchors
+    }
+    invalid_refs = [
+        ref
+        for ref in sorted(set(evidence_refs) | claim_refs)
+        if not ctx.audit.has_tool_call(ref)
+    ]
     if invalid_refs:
         recent_ids = sorted(ctx.audit.tool_call_ids)[-10:]
         resp = error_response(
@@ -220,6 +247,17 @@ def submit_finding(
         )
         resp["valid_refs"] = recent_ids
         return resp
+
+    if claim_inputs and claim_refs != set(evidence_refs):
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            "Atomic claim tool_call_ids must exactly match evidence_refs; "
+            "uncited or unanchored references are not accepted",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
 
     case_metadata = ctx.db.get_case_metadata()
     finding_id = f"f_{uuid4().hex[:8]}"
@@ -267,7 +305,17 @@ def submit_finding(
             "Consider whether 'inference' is more appropriate."
         )
 
-    ctx.db.insert_finding(finding)
+    try:
+        stored_claims = ctx.db.insert_finding(finding, claim_inputs)
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Evidence anchor validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
     ctx.audit.log_finding_submission(finding_id, evidence_refs)
 
     result: dict[str, object] = {
@@ -275,6 +323,8 @@ def submit_finding(
         "finding_id": finding_id,
         "status": "accepted",
         "confidence": finding.confidence,
+        "atomic_claims": [claim.model_dump() for claim in stored_claims],
+        "claim_mode": "atomic_unverified" if stored_claims else "legacy_unverified",
     }
     if thin_evidence_warning:
         result["hint"] = thin_evidence_warning
@@ -292,6 +342,7 @@ def submit_finding(
             "evidence_refs": evidence_refs,
             "sources": sources,
             "mitre_attack_ids": mitre_attack_ids or [],
+            "claim_count": len(stored_claims),
         },
         output_hash=hash_output(result),
         duration_ms=elapsed,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,7 +11,7 @@ from mulder.db import (
     CaseDB,
     _sanitize_fts5_query,
 )
-from mulder.models import Finding, WindowRow
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding, WindowRow
 
 
 class TestCaseLifecycle:
@@ -155,6 +155,105 @@ class TestFindings:
         assert f.finding_id == "f-001"
         assert f.evidence_refs == ["tc_aabbccdd"]
         assert f.mitre_attack_ids == ["T1059.001"]
+
+    def test_atomic_claim_resolves_exact_immutable_anchor(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "sha256-memory", "volatility", 1
+        )
+        tmp_case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=20,
+                    line_end=20,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe parent 500",
+                )
+            ],
+        )
+        window = tmp_case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+        claim_input = AtomicClaimInput(
+            statement="Process 1234 is cmd.exe",
+            subject="process:1234",
+            predicate="image_name",
+            object_value="cmd.exe",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=9,
+                    char_end=16,
+                    expected_text="cmd.exe",
+                    artifact_family="memory_process_list",
+                )
+            ],
+        )
+
+        stored = tmp_case_db.insert_finding(sample_finding, [claim_input])
+
+        assert len(stored) == 1
+        claims = tmp_case_db.get_claims(sample_finding.finding_id)
+        assert claims == stored
+        anchor = claims[0].anchors[0]
+        assert anchor.exact_text == "cmd.exe"
+        assert anchor.source_hash == "sha256-memory"
+        assert anchor.extractor_family == "volatility"
+        assert anchor.independence_key == "source:sha256-memory"
+        assert tmp_case_db.get_finding(sample_finding.finding_id).sources == [
+            "volatility.pslist"
+        ]
+
+    def test_stale_anchor_rejects_entire_finding(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source("src", "/p", "hash", "text", 1)
+        tmp_case_db.insert_windows(
+            sid,
+            [WindowRow(source_id=sid, line_start=1, line_end=1, event_time=None, raw_text="abc")],
+        )
+        window = tmp_case_db.get_windows_by_source("src")[0]
+        assert window.window_id is not None
+        claim = AtomicClaimInput(
+            statement="Value is xyz",
+            subject="value",
+            predicate="equals",
+            object_value="xyz",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=0,
+                    char_end=3,
+                    expected_text="xyz",
+                )
+            ],
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            tmp_case_db.insert_finding(sample_finding, [claim])
+        assert tmp_case_db.get_finding(sample_finding.finding_id) is None
+
+    def test_open_migrates_missing_claim_tables(self, tmp_path: Path) -> None:
+        db = CaseDB.create(case_id="legacy-claims", evidence_root="/ev", db_dir=tmp_path)
+        with db._engine.begin() as conn:
+            conn.execute(text("DROP TABLE evidence_anchors"))
+            conn.execute(text("DROP TABLE claims"))
+        db.close()
+
+        reopened = CaseDB.open("legacy-claims", tmp_path)
+        with reopened._engine.connect() as conn:
+            names = {
+                row[0]
+                for row in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type = 'table'")
+                )
+            }
+        reopened.close()
+        assert {"claims", "evidence_anchors"} <= names
 
 
 class TestExtractorVersions:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from mulder.models import Finding
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding
 
 
 class TestFinding:
@@ -85,3 +85,25 @@ class TestFinding:
         assert f.mitre_attack_ids == []
         assert f.event_time_start is None
         assert f.event_time_end is None
+
+
+class TestAtomicClaimInput:
+    def test_rejects_empty_anchor_list(self) -> None:
+        with pytest.raises(ValidationError, match="anchors"):
+            AtomicClaimInput(
+                statement="cmd.exe executed",
+                subject="cmd.exe",
+                predicate="executed",
+                object_value=True,
+                anchors=[],
+            )
+
+    def test_rejects_reversed_character_range(self) -> None:
+        with pytest.raises(ValidationError, match="char_end"):
+            EvidenceAnchorInput(
+                tool_call_id="tc_1",
+                window_id=1,
+                char_start=8,
+                char_end=4,
+                expected_text="cmd",
+            )

--- a/tests/test_submit_finding.py
+++ b/tests/test_submit_finding.py
@@ -9,6 +9,7 @@ import pytest
 
 from mulder.audit import AuditLog
 from mulder.db import CaseDB
+from mulder.models import WindowRow
 from mulder.server.app import _tool_dispatch_sync
 from mulder.server.tools.findings import _sanitize_event_time
 
@@ -89,6 +90,94 @@ class TestEvidenceValidation:
         )
         assert "error" in result or result.get("status") != "accepted"
         assert "valid_refs" in result
+
+    def test_atomic_claim_is_resolved_and_persisted(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        sid = case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "memory-hash", "volatility", 1
+        )
+        case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=1,
+                    line_end=1,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe",
+                )
+            ],
+        )
+        window = case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Suspicious process",
+            description="PID 1234 is cmd.exe",
+            severity="high",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd"],
+            sources=["caller-controlled-name"],
+            claims=[
+                {
+                    "statement": "PID 1234 is cmd.exe",
+                    "subject": "process:1234",
+                    "predicate": "image_name",
+                    "object_value": "cmd.exe",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": window.window_id,
+                            "char_start": 9,
+                            "char_end": 16,
+                            "expected_text": "cmd.exe",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        assert result["status"] == "accepted"
+        assert result["claim_mode"] == "atomic_unverified"
+        finding_id = str(result["finding_id"])
+        assert case_db.get_finding(finding_id).sources == ["volatility.pslist"]
+        assert case_db.get_claims(finding_id)[0].anchors[0].exact_text == "cmd.exe"
+
+    def test_claim_refs_must_exactly_match_finding_refs(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Mismatched refs",
+            description="desc",
+            severity="medium",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd", "tc_11223344"],
+            sources=["src"],
+            claims=[
+                {
+                    "statement": "statement",
+                    "subject": "subject",
+                    "predicate": "equals",
+                    "object_value": "value",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": 1,
+                            "char_start": 0,
+                            "char_end": 1,
+                            "expected_text": "x",
+                        }
+                    ],
+                }
+            ],
+        )
+        assert result.get("error_type") == "validation"
+        assert "exactly match" in str(result.get("error_message"))
 
 
 class TestTimestampSanitization:


### PR DESCRIPTION
- **BLUF:** Store findings as atomic claims bound to precise evidence locations.
- **Priority:** Critical — Reviewers need to reproduce each factual assertion without relying on narrative summaries.
- **Changes:** Add selectors, byte and character ranges, windows, and explicit legacy-unverified handling.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 4/37; prerequisite diffs may overlap until earlier PRs land.