### PR TITLE
[critical][fix] 1.3 — Enforce evidence independence and materiality

### DIFF
--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -8,11 +8,13 @@ import logging
 import queue
 import re
 import threading
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict, TypeVar, cast
+from uuid import uuid4
 
 from sqlalchemy import (
     Column,
@@ -35,7 +37,15 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.pool import NullPool
 
-from mulder.models import CaseMetadataRow, Finding, SourceRow, WindowRow
+from mulder.models import (
+    AtomicClaim,
+    AtomicClaimInput,
+    CaseMetadataRow,
+    EvidenceAnchor,
+    Finding,
+    SourceRow,
+    WindowRow,
+)
 
 _T = TypeVar("_T")
 
@@ -93,6 +103,55 @@ findings_t = Table(
     Column("event_time_start", Text),
     Column("event_time_end", Text),
     Column("submitted_at", Text, nullable=False),
+)
+
+claims_t = Table(
+    "claims",
+    metadata,
+    Column("claim_id", Text, primary_key=True),
+    Column(
+        "finding_id",
+        Text,
+        ForeignKey("findings.finding_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("ordinal", Integer, nullable=False),
+    Column("statement", Text, nullable=False),
+    Column("subject", Text, nullable=False),
+    Column("predicate", Text, nullable=False),
+    Column("object_value", Text, nullable=False),
+    Column("qualifiers", Text, nullable=False),
+    Column("epistemic_state", Text, nullable=False),
+)
+
+evidence_anchors_t = Table(
+    "evidence_anchors",
+    metadata,
+    Column("anchor_id", Text, primary_key=True),
+    Column(
+        "claim_id",
+        Text,
+        ForeignKey("claims.claim_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("tool_call_id", Text, nullable=False, index=True),
+    Column("source_id", Integer, ForeignKey("sources.source_id"), nullable=False, index=True),
+    Column("source_name", Text, nullable=False),
+    Column("source_hash", Text, nullable=False),
+    Column("window_id", Integer, ForeignKey("windows.window_id"), nullable=False, index=True),
+    Column("line_start", Integer, nullable=False),
+    Column("line_end", Integer, nullable=False),
+    Column("char_start", Integer, nullable=False),
+    Column("char_end", Integer, nullable=False),
+    Column("exact_text", Text, nullable=False),
+    Column("artifact_family", Text, nullable=False),
+    Column("extractor_family", Text, nullable=False),
+    Column("independence_key", Text, nullable=False, index=True),
+    Column("value_type", Text, nullable=False),
+    Column("normalized_value", Text, nullable=False),
+    Column("role", Text, nullable=False),
 )
 
 evidence_registry_t = Table(
@@ -294,6 +353,12 @@ def _migrate_add_kv_store(conn: Connection) -> None:
     )
 
 
+def _migrate_add_claim_tables(conn: Connection) -> None:
+    """Create additive atomic-claim tables for databases from older releases."""
+    claims_t.create(conn, checkfirst=True)
+    evidence_anchors_t.create(conn, checkfirst=True)
+
+
 _SENTINEL = object()
 
 
@@ -444,6 +509,7 @@ class CaseDB:
             _migrate_add_bookmarks(conn)
             _migrate_add_progress(conn)
             _migrate_add_kv_store(conn)
+            _migrate_add_claim_tables(conn)
         return db
 
     def close(self) -> None:
@@ -958,11 +1024,21 @@ class CaseDB:
 
         self._wq.submit(_do_update)
 
-    def insert_finding(self, finding: Finding) -> None:
-        """Persist a Finding to the database."""
+    def insert_finding(
+        self,
+        finding: Finding,
+        claims: list[AtomicClaimInput] | None = None,
+    ) -> list[AtomicClaim]:
+        """Persist a finding and optional atomic claims in one transaction.
 
-        def _do_insert() -> None:
-            """Persist a single finding row."""
+        Exact evidence text and provenance are resolved from the case database;
+        callers cannot inject source hashes or independence keys.  If an anchor
+        is stale, out of bounds, or does not match its expected text, the whole
+        write is rejected and no finding row is committed.
+        """
+
+        def _do_insert() -> list[AtomicClaim]:
+            """Persist a finding and its claim graph atomically."""
             with self._engine.begin() as conn:
                 conn.execute(
                     insert(findings_t).values(
@@ -981,7 +1057,194 @@ class CaseDB:
                     )
                 )
 
-        self._wq.submit(_do_insert)
+                stored: list[AtomicClaim] = []
+                resolved_source_names: set[str] = set()
+                for ordinal, claim_input in enumerate(claims or []):
+                    claim_id = f"c_{uuid4().hex[:12]}"
+                    claim = AtomicClaim(
+                        claim_id=claim_id,
+                        finding_id=finding.finding_id,
+                        ordinal=ordinal,
+                        statement=claim_input.statement,
+                        subject=claim_input.subject,
+                        predicate=claim_input.predicate,
+                        object_value=claim_input.object_value,
+                        qualifiers=claim_input.qualifiers,
+                        epistemic_state="unverified",
+                        anchors=[],
+                    )
+                    conn.execute(
+                        insert(claims_t).values(
+                            claim_id=claim.claim_id,
+                            finding_id=claim.finding_id,
+                            ordinal=claim.ordinal,
+                            statement=claim.statement,
+                            subject=claim.subject,
+                            predicate=claim.predicate,
+                            object_value=json.dumps(claim.object_value),
+                            qualifiers=json.dumps(claim.qualifiers),
+                            epistemic_state=claim.epistemic_state,
+                        )
+                    )
+
+                    resolved_anchors: list[EvidenceAnchor] = []
+                    for anchor_input in claim_input.anchors:
+                        row = conn.execute(
+                            select(
+                                windows_t.c.window_id,
+                                windows_t.c.source_id,
+                                windows_t.c.line_start,
+                                windows_t.c.line_end,
+                                windows_t.c.raw_text,
+                                sources_t.c.source_name,
+                                sources_t.c.source_hash,
+                                sources_t.c.extractor,
+                            )
+                            .select_from(
+                                windows_t.join(
+                                    sources_t,
+                                    windows_t.c.source_id == sources_t.c.source_id,
+                                )
+                            )
+                            .where(windows_t.c.window_id == anchor_input.window_id)
+                        ).fetchone()
+                        if row is None:
+                            raise ValueError(
+                                "Evidence anchor window_id "
+                                f"{anchor_input.window_id} does not exist"
+                            )
+                        raw_text = str(row.raw_text)
+                        if anchor_input.char_end > len(raw_text):
+                            raise ValueError(
+                                "Evidence anchor character range is outside window "
+                                f"{anchor_input.window_id} (length {len(raw_text)})"
+                            )
+                        exact_text = raw_text[
+                            anchor_input.char_start : anchor_input.char_end
+                        ]
+                        if exact_text != anchor_input.expected_text:
+                            raise ValueError(
+                                "Evidence anchor text does not match the immutable window at "
+                                f"{anchor_input.window_id}:{anchor_input.char_start}-"
+                                f"{anchor_input.char_end}"
+                            )
+
+                        extractor = str(row.extractor)
+                        source_hash = str(row.source_hash)
+                        anchor = EvidenceAnchor(
+                            anchor_id=f"a_{uuid4().hex[:12]}",
+                            claim_id=claim_id,
+                            tool_call_id=anchor_input.tool_call_id,
+                            source_id=int(row.source_id),
+                            source_name=str(row.source_name),
+                            source_hash=source_hash,
+                            window_id=int(row.window_id),
+                            line_start=int(row.line_start),
+                            line_end=int(row.line_end),
+                            char_start=anchor_input.char_start,
+                            char_end=anchor_input.char_end,
+                            exact_text=exact_text,
+                            artifact_family=anchor_input.artifact_family or extractor,
+                            extractor_family=extractor,
+                            independence_key=f"source:{source_hash}",
+                            value_type=anchor_input.value_type,
+                            normalized_value=anchor_input.normalized_value,
+                            role=anchor_input.role,
+                        )
+                        resolved_source_names.add(anchor.source_name)
+                        conn.execute(
+                            insert(evidence_anchors_t).values(
+                                anchor_id=anchor.anchor_id,
+                                claim_id=anchor.claim_id,
+                                tool_call_id=anchor.tool_call_id,
+                                source_id=anchor.source_id,
+                                source_name=anchor.source_name,
+                                source_hash=anchor.source_hash,
+                                window_id=anchor.window_id,
+                                line_start=anchor.line_start,
+                                line_end=anchor.line_end,
+                                char_start=anchor.char_start,
+                                char_end=anchor.char_end,
+                                exact_text=anchor.exact_text,
+                                artifact_family=anchor.artifact_family,
+                                extractor_family=anchor.extractor_family,
+                                independence_key=anchor.independence_key,
+                                value_type=anchor.value_type,
+                                normalized_value=json.dumps(anchor.normalized_value),
+                                role=anchor.role,
+                            )
+                        )
+                        resolved_anchors.append(anchor)
+                    stored.append(claim.model_copy(update={"anchors": resolved_anchors}))
+                if stored:
+                    conn.execute(
+                        update(findings_t)
+                        .where(findings_t.c.finding_id == finding.finding_id)
+                        .values(sources=json.dumps(sorted(resolved_source_names)))
+                    )
+                return stored
+
+        return self._wq.submit(_do_insert)
+
+    def get_claims(self, finding_id: str) -> list[AtomicClaim]:
+        """Return a finding's atomic claims with exact anchors, in stable order."""
+        with self._engine.connect() as conn:
+            claim_rows = conn.execute(
+                select(claims_t)
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(claims_t.c.ordinal, claims_t.c.claim_id)
+            ).fetchall()
+            anchor_rows = conn.execute(
+                select(evidence_anchors_t)
+                .select_from(
+                    evidence_anchors_t.join(
+                        claims_t, evidence_anchors_t.c.claim_id == claims_t.c.claim_id
+                    )
+                )
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(evidence_anchors_t.c.anchor_id)
+            ).fetchall()
+
+        by_claim: dict[str, list[EvidenceAnchor]] = defaultdict(list)
+        for row in anchor_rows:
+            by_claim[row.claim_id].append(
+                EvidenceAnchor(
+                    anchor_id=row.anchor_id,
+                    claim_id=row.claim_id,
+                    tool_call_id=row.tool_call_id,
+                    source_id=row.source_id,
+                    source_name=row.source_name,
+                    source_hash=row.source_hash,
+                    window_id=row.window_id,
+                    line_start=row.line_start,
+                    line_end=row.line_end,
+                    char_start=row.char_start,
+                    char_end=row.char_end,
+                    exact_text=row.exact_text,
+                    artifact_family=row.artifact_family,
+                    extractor_family=row.extractor_family,
+                    independence_key=row.independence_key,
+                    value_type=row.value_type,
+                    normalized_value=json.loads(row.normalized_value),
+                    role=row.role,
+                )
+            )
+
+        return [
+            AtomicClaim(
+                claim_id=row.claim_id,
+                finding_id=row.finding_id,
+                ordinal=row.ordinal,
+                statement=row.statement,
+                subject=row.subject,
+                predicate=row.predicate,
+                object_value=json.loads(row.object_value),
+                qualifiers=json.loads(row.qualifiers),
+                epistemic_state=row.epistemic_state,
+                anchors=by_claim[row.claim_id],
+            )
+            for row in claim_rows
+        ]
 
     def update_finding(self, finding_id: str, **kwargs: object) -> bool:
         """Update fields on an existing finding. Returns True if found.

--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -41,6 +41,7 @@ from mulder.models import (
     AtomicClaim,
     AtomicClaimInput,
     CaseMetadataRow,
+    ClaimVerification,
     EvidenceAnchor,
     Finding,
     SourceRow,
@@ -152,6 +153,25 @@ evidence_anchors_t = Table(
     Column("value_type", Text, nullable=False),
     Column("normalized_value", Text, nullable=False),
     Column("role", Text, nullable=False),
+)
+
+claim_verifications_t = Table(
+    "claim_verifications",
+    metadata,
+    Column("verification_id", Text, primary_key=True),
+    Column(
+        "claim_id",
+        Text,
+        ForeignKey("claims.claim_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("verifier_name", Text, nullable=False),
+    Column("verifier_version", Text, nullable=False),
+    Column("result", Text, nullable=False),
+    Column("reason_code", Text, nullable=False),
+    Column("details", Text, nullable=False),
+    Column("verified_at", Text, nullable=False),
 )
 
 evidence_registry_t = Table(
@@ -357,6 +377,7 @@ def _migrate_add_claim_tables(conn: Connection) -> None:
     """Create additive atomic-claim tables for databases from older releases."""
     claims_t.create(conn, checkfirst=True)
     evidence_anchors_t.create(conn, checkfirst=True)
+    claim_verifications_t.create(conn, checkfirst=True)
 
 
 _SENTINEL = object()
@@ -1244,6 +1265,133 @@ class CaseDB:
                 anchors=by_claim[row.claim_id],
             )
             for row in claim_rows
+        ]
+
+    def verify_finding_claims(self, finding_id: str) -> list[ClaimVerification]:
+        """Reopen evidence anchors and deterministically verify all finding claims.
+
+        The current source/window identity and exact character slice are checked
+        before semantic verification. Results are append-only; the claim row
+        stores only the latest state for efficient gates and presentation.
+        """
+        from mulder.models import VerificationDecision
+        from mulder.verification.claims import (
+            VERIFIER_NAME,
+            VERIFIER_VERSION,
+            verify_claim,
+        )
+
+        claims = self.get_claims(finding_id)
+        if not claims:
+            return []
+
+        def _do_verify() -> list[ClaimVerification]:
+            verified_at = datetime.now(timezone.utc).isoformat()
+            results: list[ClaimVerification] = []
+            with self._engine.begin() as conn:
+                for claim in claims:
+                    evidence_problem: str | None = None
+                    for anchor in claim.anchors:
+                        row = conn.execute(
+                            select(
+                                windows_t.c.source_id,
+                                windows_t.c.raw_text,
+                                sources_t.c.source_name,
+                                sources_t.c.source_hash,
+                            )
+                            .select_from(
+                                windows_t.join(
+                                    sources_t,
+                                    windows_t.c.source_id == sources_t.c.source_id,
+                                )
+                            )
+                            .where(windows_t.c.window_id == anchor.window_id)
+                        ).fetchone()
+                        if row is None:
+                            evidence_problem = "anchor_window_missing"
+                            break
+                        if (
+                            int(row.source_id) != anchor.source_id
+                            or str(row.source_name) != anchor.source_name
+                            or str(row.source_hash) != anchor.source_hash
+                        ):
+                            evidence_problem = "anchor_provenance_changed"
+                            break
+                        raw_text = str(row.raw_text)
+                        if anchor.char_end > len(raw_text):
+                            evidence_problem = "anchor_range_invalid"
+                            break
+                        if raw_text[anchor.char_start : anchor.char_end] != anchor.exact_text:
+                            evidence_problem = "anchor_text_changed"
+                            break
+
+                    decision = (
+                        VerificationDecision(
+                            result="inconclusive",
+                            reason_code=evidence_problem,
+                            details={},
+                        )
+                        if evidence_problem is not None
+                        else verify_claim(claim)
+                    )
+                    result = ClaimVerification(
+                        verification_id=f"v_{uuid4().hex[:12]}",
+                        claim_id=claim.claim_id,
+                        verifier_name=VERIFIER_NAME,
+                        verifier_version=VERIFIER_VERSION,
+                        result=decision.result,
+                        reason_code=decision.reason_code,
+                        details=decision.details,
+                        verified_at=verified_at,
+                    )
+                    conn.execute(
+                        insert(claim_verifications_t).values(
+                            verification_id=result.verification_id,
+                            claim_id=result.claim_id,
+                            verifier_name=result.verifier_name,
+                            verifier_version=result.verifier_version,
+                            result=result.result,
+                            reason_code=result.reason_code,
+                            details=json.dumps(result.details, sort_keys=True),
+                            verified_at=result.verified_at,
+                        )
+                    )
+                    conn.execute(
+                        update(claims_t)
+                        .where(claims_t.c.claim_id == claim.claim_id)
+                        .values(epistemic_state=result.result)
+                    )
+                    results.append(result)
+            return results
+
+        return self._wq.submit(_do_verify)
+
+    def get_claim_verifications(self, finding_id: str) -> list[ClaimVerification]:
+        """Return append-only verification history for a finding's claims."""
+        stmt = (
+            select(claim_verifications_t)
+            .select_from(
+                claim_verifications_t.join(
+                    claims_t, claim_verifications_t.c.claim_id == claims_t.c.claim_id
+                )
+            )
+            .where(claims_t.c.finding_id == finding_id)
+            .order_by(claim_verifications_t.c.verified_at, claim_verifications_t.c.verification_id)
+        )
+        with self._engine.connect() as conn:
+            rows = conn.execute(stmt).fetchall()
+        return [
+            ClaimVerification(
+                verification_id=row.verification_id,
+                claim_id=row.claim_id,
+                verifier_name=row.verifier_name,
+                verifier_version=row.verifier_version,
+                result=row.result,
+                reason_code=row.reason_code,
+                details=json.loads(row.details),
+                verified_at=row.verified_at,
+            )
+            for row in rows
         ]
 
     def update_finding(self, finding_id: str, **kwargs: object) -> bool:

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -144,6 +144,24 @@ class AtomicClaim(BaseModel):
     anchors: list[EvidenceAnchor] = Field(default_factory=list)
 
 
+class VerificationDecision(BaseModel):
+    """Pure deterministic decision returned by the claim verifier module."""
+
+    result: Literal["verified", "contradicted", "inconclusive"]
+    reason_code: str
+    details: dict[str, JsonScalar] = Field(default_factory=dict)
+
+
+class ClaimVerification(VerificationDecision):
+    """Append-only persisted execution of a deterministic claim verifier."""
+
+    verification_id: str
+    claim_id: str
+    verifier_name: str
+    verifier_version: str
+    verified_at: str
+
+
 class ToolCallEntry(BaseModel):
     """A single tool invocation recorded in the audit log."""
 

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -162,6 +162,23 @@ class ClaimVerification(VerificationDecision):
     verified_at: str
 
 
+class ClaimConfirmation(BaseModel):
+    """Policy decision for one claim in a confirmed finding."""
+
+    claim_id: str
+    accepted: bool
+    reason_code: str
+    independent_sources: int = Field(ge=0)
+    required_sources: int = Field(ge=1)
+
+
+class ConfirmationAssessment(BaseModel):
+    """Server-owned corroboration decision for an entire finding."""
+
+    accepted: bool
+    claims: list[ClaimConfirmation] = Field(default_factory=list)
+
+
 class ToolCallEntry(BaseModel):
     """A single tool invocation recorded in the audit log."""
 

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, TypeAlias
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+JsonScalar: TypeAlias = str | int | float | bool | None
 
 
 class WindowRow(BaseModel):
@@ -63,6 +65,83 @@ class Finding(BaseModel):
         if not self.evidence_refs:
             raise ValueError("evidence_refs must contain at least one tool_call_id")
         return self
+
+
+class EvidenceAnchorInput(BaseModel):
+    """Caller-supplied locator for an exact quote in an evidence window.
+
+    The caller identifies a previously returned window and the exact character
+    range it is relying on.  Source identity, hashes, extractor family, and the
+    independence key are resolved by :class:`CaseDB`; callers cannot assert
+    those provenance fields themselves.
+    """
+
+    tool_call_id: str = Field(min_length=1)
+    window_id: int = Field(gt=0)
+    char_start: int = Field(ge=0)
+    char_end: int = Field(gt=0)
+    expected_text: str = Field(min_length=1)
+    artifact_family: str | None = None
+    value_type: str = "text"
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+    @model_validator(mode="after")
+    def _check_character_range(self) -> EvidenceAnchorInput:
+        if self.char_end <= self.char_start:
+            raise ValueError("char_end must be greater than char_start")
+        return self
+
+
+class AtomicClaimInput(BaseModel):
+    """A material statement and the exact evidence anchors offered for it."""
+
+    statement: str = Field(min_length=1)
+    subject: str = Field(min_length=1)
+    predicate: str = Field(min_length=1)
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    anchors: list[EvidenceAnchorInput] = Field(min_length=1)
+
+
+class EvidenceAnchor(BaseModel):
+    """Server-resolved immutable evidence locator for an atomic claim."""
+
+    anchor_id: str
+    claim_id: str
+    tool_call_id: str
+    source_id: int
+    source_name: str
+    source_hash: str
+    window_id: int
+    line_start: int
+    line_end: int
+    char_start: int
+    char_end: int
+    exact_text: str
+    artifact_family: str
+    extractor_family: str
+    independence_key: str
+    value_type: str
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+
+class AtomicClaim(BaseModel):
+    """Persisted atomic finding statement with resolved evidence anchors."""
+
+    claim_id: str
+    finding_id: str
+    ordinal: int = Field(ge=0)
+    statement: str
+    subject: str
+    predicate: str
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    epistemic_state: Literal[
+        "legacy_unverified", "unverified", "verified", "contradicted", "inconclusive"
+    ] = "unverified"
+    anchors: list[EvidenceAnchor] = Field(default_factory=list)
 
 
 class ToolCallEntry(BaseModel):

--- a/src/mulder/server/tools/findings.py
+++ b/src/mulder/server/tools/findings.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from mulder.models import AuditSummary, CaseMetadataRow, Finding, SourceRow
+from mulder.models import AtomicClaimInput, AuditSummary, CaseMetadataRow, Finding, SourceRow
 from mulder.patterns import SEVERITY_ORDER, source_is_cited
 from mulder.report.renderer import ReportRenderer
 from mulder.server.app import get_ctx, get_job_store, mcp
@@ -186,6 +186,7 @@ def submit_finding(
     mitre_attack_ids: list[str] | None = None,
     event_time_start: str | None = None,
     event_time_end: str | None = None,
+    claims: list[dict[str, Any]] | None = None,
 ) -> dict[str, object]:
     """Record a forensic finding with validated evidence references and metadata.
 
@@ -200,6 +201,13 @@ def submit_finding(
     pass null rather than fabricating. Day-precision placeholders are
     auto-nullified.
 
+    New callers should also submit atomic ``claims``. Each claim points to an
+    exact character range in an indexed evidence window and repeats the text
+    expected at that immutable location. The server resolves source identity,
+    hashes, extractor family, and independence key rather than trusting those
+    values from the caller. Omitting ``claims`` remains supported for legacy
+    clients; such prose is not promoted to a verified atomic claim.
+
     Returns finding_id on acceptance. Severity must be
     critical/high/medium/low/info. Confidence must be "confirmed"
     (corroborated by 2+ sources) or "inference".
@@ -208,7 +216,26 @@ def submit_finding(
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
 
-    invalid_refs = [ref for ref in evidence_refs if not ctx.audit.has_tool_call(ref)]
+    try:
+        claim_inputs = [AtomicClaimInput.model_validate(raw) for raw in claims or []]
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Atomic claim validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
+
+    claim_refs = {
+        anchor.tool_call_id for claim in claim_inputs for anchor in claim.anchors
+    }
+    invalid_refs = [
+        ref
+        for ref in sorted(set(evidence_refs) | claim_refs)
+        if not ctx.audit.has_tool_call(ref)
+    ]
     if invalid_refs:
         recent_ids = sorted(ctx.audit.tool_call_ids)[-10:]
         resp = error_response(
@@ -220,6 +247,17 @@ def submit_finding(
         )
         resp["valid_refs"] = recent_ids
         return resp
+
+    if claim_inputs and claim_refs != set(evidence_refs):
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            "Atomic claim tool_call_ids must exactly match evidence_refs; "
+            "uncited or unanchored references are not accepted",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
 
     case_metadata = ctx.db.get_case_metadata()
     finding_id = f"f_{uuid4().hex[:8]}"
@@ -267,7 +305,17 @@ def submit_finding(
             "Consider whether 'inference' is more appropriate."
         )
 
-    ctx.db.insert_finding(finding)
+    try:
+        stored_claims = ctx.db.insert_finding(finding, claim_inputs)
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Evidence anchor validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
     ctx.audit.log_finding_submission(finding_id, evidence_refs)
 
     result: dict[str, object] = {
@@ -275,6 +323,8 @@ def submit_finding(
         "finding_id": finding_id,
         "status": "accepted",
         "confidence": finding.confidence,
+        "atomic_claims": [claim.model_dump() for claim in stored_claims],
+        "claim_mode": "atomic_unverified" if stored_claims else "legacy_unverified",
     }
     if thin_evidence_warning:
         result["hint"] = thin_evidence_warning
@@ -292,6 +342,7 @@ def submit_finding(
             "evidence_refs": evidence_refs,
             "sources": sources,
             "mitre_attack_ids": mitre_attack_ids or [],
+            "claim_count": len(stored_claims),
         },
         output_hash=hash_output(result),
         duration_ms=elapsed,

--- a/src/mulder/server/tools/findings.py
+++ b/src/mulder/server/tools/findings.py
@@ -307,7 +307,15 @@ def submit_finding(
 
     try:
         stored_claims = ctx.db.insert_finding(finding, claim_inputs)
+        verifications = (
+            ctx.db.verify_finding_claims(finding_id) if stored_claims else []
+        )
     except Exception as exc:
+        # Claim persistence and verification are separate database operations;
+        # compensate before the finding becomes visible if verification cannot
+        # complete. Exact anchor validation itself is transactional in CaseDB.
+        if ctx.db._finding_exists(finding_id):
+            ctx.db.delete_finding(finding_id)
         return error_response(
             tc_id,
             "submit_finding",
@@ -323,8 +331,11 @@ def submit_finding(
         "finding_id": finding_id,
         "status": "accepted",
         "confidence": finding.confidence,
-        "atomic_claims": [claim.model_dump() for claim in stored_claims],
-        "claim_mode": "atomic_unverified" if stored_claims else "legacy_unverified",
+        "atomic_claims": [
+            claim.model_dump() for claim in ctx.db.get_claims(finding_id)
+        ],
+        "claim_verifications": [item.model_dump() for item in verifications],
+        "claim_mode": "atomic_checked" if stored_claims else "legacy_unverified",
     }
     if thin_evidence_warning:
         result["hint"] = thin_evidence_warning
@@ -569,7 +580,17 @@ def get_findings(limit: int = 20, offset: int = 0) -> dict[str, object]:
     all_findings = ctx.db.get_findings()
     total = len(all_findings)
     page = all_findings[offset : offset + limit]
-    results = [f.model_dump() for f in page]
+    results: list[dict[str, object]] = []
+    for finding in page:
+        item = finding.model_dump()
+        item["atomic_claims"] = [
+            claim.model_dump() for claim in ctx.db.get_claims(finding.finding_id)
+        ]
+        item["claim_verifications"] = [
+            verification.model_dump()
+            for verification in ctx.db.get_claim_verifications(finding.finding_id)
+        ]
+        results.append(item)
     resp: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "success",

--- a/src/mulder/server/tools/findings.py
+++ b/src/mulder/server/tools/findings.py
@@ -21,12 +21,20 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from mulder.models import AtomicClaimInput, AuditSummary, CaseMetadataRow, Finding, SourceRow
+from mulder.models import (
+    AtomicClaimInput,
+    AuditSummary,
+    CaseMetadataRow,
+    ConfirmationAssessment,
+    Finding,
+    SourceRow,
+)
 from mulder.patterns import SEVERITY_ORDER, source_is_cited
 from mulder.report.renderer import ReportRenderer
 from mulder.server.app import get_ctx, get_job_store, mcp
 from mulder.server.helpers import error_response, hash_output, make_tool_call_id
 from mulder.server.tool_access import ANALYSTS, Role, tool_access
+from mulder.verification.policy import assess_confirmation
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +49,7 @@ def _evaluate_finalize_gates(
     case_metadata: CaseMetadataRow,
     sources: list[SourceRow],
     audit_summary: AuditSummary,
+    confirmation_assessments: dict[str, ConfirmationAssessment] | None = None,
 ) -> list[dict[str, object]]:
     """Evaluate all finalize_report hard gates and return per-gate results.
 
@@ -148,6 +157,26 @@ def _evaluate_finalize_gates(
         passed = True
         detail = "No non-empty sources to check"
     gates.append({"name": "evidence_citation_coverage", "passed": passed, "detail": detail})
+
+    # Gate 6: Atomic confirmed findings still satisfy deterministic policy.
+    # Legacy findings have no assessment and remain explicitly outside this
+    # additive gate until migrated; new atomic findings cannot bypass it.
+    assessments = confirmation_assessments or {}
+    failed_confirmations = [
+        finding_id for finding_id, item in assessments.items() if not item.accepted
+    ]
+    passed = not failed_confirmations
+    if passed:
+        detail = (
+            f"{len(assessments)} atomic confirmed finding(s) satisfy "
+            "verification and independence policy"
+        )
+    else:
+        detail = (
+            "Atomic confirmed findings no longer satisfy verification/independence "
+            f"policy: {failed_confirmations}"
+        )
+    gates.append({"name": "atomic_confirmation", "passed": passed, "detail": detail})
 
     return gates
 
@@ -310,6 +339,25 @@ def submit_finding(
         verifications = (
             ctx.db.verify_finding_claims(finding_id) if stored_claims else []
         )
+        persisted_claims = ctx.db.get_claims(finding_id)
+        confirmation = assess_confirmation(persisted_claims) if persisted_claims else None
+        if (
+            finding.confidence == "confirmed"
+            and confirmation is not None
+            and not confirmation.accepted
+        ):
+            ctx.db.delete_finding(finding_id)
+            response = error_response(
+                tc_id,
+                "submit_finding",
+                {"title": title, "evidence_refs": evidence_refs},
+                "Confirmed atomic finding failed deterministic verification or "
+                "independent-source policy",
+                (time.monotonic() - t0) * 1000,
+                error_type="confirmation_policy",
+            )
+            response["confirmation_assessment"] = confirmation.model_dump()
+            return response
     except Exception as exc:
         # Claim persistence and verification are separate database operations;
         # compensate before the finding becomes visible if verification cannot
@@ -335,6 +383,7 @@ def submit_finding(
             claim.model_dump() for claim in ctx.db.get_claims(finding_id)
         ],
         "claim_verifications": [item.model_dump() for item in verifications],
+        "confirmation_assessment": confirmation.model_dump() if confirmation else None,
         "claim_mode": "atomic_checked" if stored_claims else "legacy_unverified",
     }
     if thin_evidence_warning:
@@ -659,7 +708,24 @@ def finalize_report() -> dict[str, object]:
     audit_summary = ctx.audit.summary()
     sources_list = ctx.db.get_sources()
 
-    gate_results = _evaluate_finalize_gates(findings, case_metadata, sources_list, audit_summary)
+    confirmation_assessments: dict[str, ConfirmationAssessment] = {}
+    for finding in findings:
+        if finding.confidence != "confirmed":
+            continue
+        atomic_claims = ctx.db.get_claims(finding.finding_id)
+        if not atomic_claims:
+            continue
+        ctx.db.verify_finding_claims(finding.finding_id)
+        confirmation_assessments[finding.finding_id] = assess_confirmation(
+            ctx.db.get_claims(finding.finding_id)
+        )
+    gate_results = _evaluate_finalize_gates(
+        findings,
+        case_metadata,
+        sources_list,
+        audit_summary,
+        confirmation_assessments,
+    )
     for gate in gate_results:
         if not gate["passed"]:
             return {

--- a/src/mulder/verification/__init__.py
+++ b/src/mulder/verification/__init__.py
@@ -1,5 +1,6 @@
 """Deterministic verification modules for evidence-backed claims."""
 
 from mulder.verification.claims import VERIFIER_NAME, VERIFIER_VERSION, verify_claim
+from mulder.verification.policy import assess_confirmation
 
-__all__ = ["VERIFIER_NAME", "VERIFIER_VERSION", "verify_claim"]
+__all__ = ["VERIFIER_NAME", "VERIFIER_VERSION", "assess_confirmation", "verify_claim"]

--- a/src/mulder/verification/__init__.py
+++ b/src/mulder/verification/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic verification modules for evidence-backed claims."""
+
+from mulder.verification.claims import VERIFIER_NAME, VERIFIER_VERSION, verify_claim
+
+__all__ = ["VERIFIER_NAME", "VERIFIER_VERSION", "verify_claim"]

--- a/src/mulder/verification/claims.py
+++ b/src/mulder/verification/claims.py
@@ -1,0 +1,164 @@
+"""Deterministic semantic verification for atomic forensic claims.
+
+The public interface is intentionally one function.  It accepts a claim whose
+anchors have already been reopened and integrity-checked by the case store, and
+returns a three-valued decision.  Predicate dispatch, normalization, conflict
+handling, and reason codes remain local to this module.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import math
+from datetime import datetime
+
+from mulder.models import AtomicClaim, EvidenceAnchor, JsonScalar, VerificationDecision
+
+VERIFIER_NAME = "mulder.atomic"
+VERIFIER_VERSION = "1"
+
+_EQUALITY_PREDICATES = frozenset(
+    {
+        "equals",
+        "eq",
+        "image_name",
+        "field_equals",
+        "hash_equals",
+        "ip_equals",
+        "domain_equals",
+        "path_equals",
+        "timestamp_equals",
+    }
+)
+_CONTAINS_PREDICATES = frozenset({"contains", "text_contains"})
+_NUMERIC_PREDICATES = frozenset(
+    {"greater_than", "greater_or_equal", "less_than", "less_or_equal"}
+)
+_TEMPORAL_PREDICATES = frozenset({"before", "after", "at_or_before", "at_or_after"})
+
+
+def _normalize(value: JsonScalar, value_type: str) -> JsonScalar:
+    """Normalize a scalar according to the server-owned anchor value type."""
+    if value is None or isinstance(value, bool):
+        return value
+    kind = value_type.strip().lower()
+    text = str(value).strip()
+    if kind in {"integer", "int"}:
+        return int(text, 0)
+    if kind in {"number", "float"}:
+        number = float(text)
+        if not math.isfinite(number):
+            raise ValueError("non-finite number")
+        return number
+    if kind in {"hash", "sha256", "md5", "sha1"}:
+        return text.lower()
+    if kind == "domain":
+        return text.lower().rstrip(".")
+    if kind == "ip":
+        return str(ipaddress.ip_address(text))
+    if kind in {"path", "windows_path"}:
+        return text.replace("\\", "/").rstrip("/").casefold()
+    if kind in {"timestamp", "datetime"}:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).isoformat()
+    return text
+
+
+def _compare(predicate: str, observed: JsonScalar, expected: JsonScalar, value_type: str) -> bool:
+    """Execute one supported predicate or raise ``KeyError`` if unsupported."""
+    canonical = predicate.strip().lower()
+    observed_n = _normalize(observed, value_type)
+    expected_n = _normalize(expected, value_type)
+    if canonical in _EQUALITY_PREDICATES:
+        return observed_n == expected_n
+    if canonical in _CONTAINS_PREDICATES:
+        return str(expected_n) in str(observed_n)
+    if canonical in _NUMERIC_PREDICATES:
+        observed_f = float(str(observed_n))
+        expected_f = float(str(expected_n))
+        if canonical == "greater_than":
+            return observed_f > expected_f
+        if canonical == "greater_or_equal":
+            return observed_f >= expected_f
+        if canonical == "less_than":
+            return observed_f < expected_f
+        return observed_f <= expected_f
+    if canonical in _TEMPORAL_PREDICATES:
+        observed_dt = datetime.fromisoformat(str(observed_n))
+        expected_dt = datetime.fromisoformat(str(expected_n))
+        if canonical == "before":
+            return observed_dt < expected_dt
+        if canonical == "after":
+            return observed_dt > expected_dt
+        if canonical == "at_or_before":
+            return observed_dt <= expected_dt
+        return observed_dt >= expected_dt
+    raise KeyError(canonical)
+
+
+def _observed_value(anchor: EvidenceAnchor) -> JsonScalar:
+    """Use deterministic normalization hints only when they match raw text."""
+    # ``normalized_value`` is retained for display and later parser adapters,
+    # but it is caller-supplied in the first schema version.  Verification is
+    # deliberately based on exact source text until an adapter can attest the
+    # normalized field.
+    return anchor.exact_text
+
+
+def verify_claim(claim: AtomicClaim) -> VerificationDecision:
+    """Verify one atomic claim against its integrity-checked exact anchors.
+
+    All selected supporting observations must satisfy the predicate. A selected
+    contradictory observation satisfying it refutes the claim. Unsupported or
+    unparseable semantics produce ``inconclusive`` rather than an optimistic
+    false/true coercion.
+    """
+    supports: list[bool] = []
+    contradictions: list[bool] = []
+    try:
+        for anchor in claim.anchors:
+            matched = _compare(
+                claim.predicate,
+                _observed_value(anchor),
+                claim.object_value,
+                anchor.value_type,
+            )
+            if anchor.role == "contradicts":
+                contradictions.append(matched)
+            else:
+                supports.append(matched)
+    except KeyError:
+        return VerificationDecision(
+            result="inconclusive",
+            reason_code="unsupported_predicate",
+            details={"predicate": claim.predicate},
+        )
+    except (TypeError, ValueError, OverflowError) as exc:
+        return VerificationDecision(
+            result="inconclusive",
+            reason_code="normalization_failed",
+            details={"error": str(exc)},
+        )
+
+    if any(contradictions):
+        return VerificationDecision(
+            result="contradicted",
+            reason_code="contradicting_anchor_matched",
+            details={"support_count": len(supports), "contradiction_count": len(contradictions)},
+        )
+    if not supports:
+        return VerificationDecision(
+            result="inconclusive",
+            reason_code="no_supporting_anchor",
+            details={"contradiction_count": len(contradictions)},
+        )
+    if all(supports):
+        return VerificationDecision(
+            result="verified",
+            reason_code="all_supporting_anchors_matched",
+            details={"support_count": len(supports)},
+        )
+    return VerificationDecision(
+        result="contradicted",
+        reason_code="supporting_anchor_mismatch",
+        details={"support_count": len(supports), "mismatch_count": supports.count(False)},
+    )

--- a/src/mulder/verification/policy.py
+++ b/src/mulder/verification/policy.py
@@ -1,0 +1,57 @@
+"""Server-owned policy for promoting atomic claims to confirmed findings."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from mulder.models import (
+    AtomicClaim,
+    ClaimConfirmation,
+    ConfirmationAssessment,
+)
+
+DEFAULT_MIN_INDEPENDENT_SOURCES = 2
+
+
+def assess_confirmation(
+    claims: Sequence[AtomicClaim],
+    *,
+    min_independent_sources: int = DEFAULT_MIN_INDEPENDENT_SOURCES,
+) -> ConfirmationAssessment:
+    """Decide whether every claim is verified and independently corroborated.
+
+    Independence keys are resolved from root source hashes by the case store,
+    never accepted from the model-facing submission. Contradicting anchors do
+    not count toward corroboration.
+    """
+    if min_independent_sources < 1:
+        raise ValueError("min_independent_sources must be at least one")
+    decisions: list[ClaimConfirmation] = []
+    for claim in claims:
+        independent = {
+            anchor.independence_key
+            for anchor in claim.anchors
+            if anchor.role == "supports"
+        }
+        if claim.epistemic_state != "verified":
+            accepted = False
+            reason = f"claim_{claim.epistemic_state}"
+        elif len(independent) < min_independent_sources:
+            accepted = False
+            reason = "insufficient_independent_sources"
+        else:
+            accepted = True
+            reason = "verified_and_independently_corroborated"
+        decisions.append(
+            ClaimConfirmation(
+                claim_id=claim.claim_id,
+                accepted=accepted,
+                reason_code=reason,
+                independent_sources=len(independent),
+                required_sources=min_independent_sources,
+            )
+        )
+    return ConfirmationAssessment(
+        accepted=bool(decisions) and all(item.accepted for item in decisions),
+        claims=decisions,
+    )

--- a/tests/test_claim_verification.py
+++ b/tests/test_claim_verification.py
@@ -1,0 +1,171 @@
+"""Tests for deterministic atomic-claim verification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import text
+
+from mulder.db import CaseDB
+from mulder.models import (
+    AtomicClaim,
+    AtomicClaimInput,
+    EvidenceAnchor,
+    EvidenceAnchorInput,
+    Finding,
+    WindowRow,
+)
+from mulder.verification.claims import verify_claim
+
+
+def _claim(
+    *,
+    predicate: str = "equals",
+    expected: str = "cmd.exe",
+    observed: str = "cmd.exe",
+    value_type: str = "text",
+    role: str = "supports",
+) -> AtomicClaim:
+    anchor = EvidenceAnchor(
+        anchor_id="a_1",
+        claim_id="c_1",
+        tool_call_id="tc_1",
+        source_id=1,
+        source_name="volatility.pslist",
+        source_hash="hash",
+        window_id=1,
+        line_start=1,
+        line_end=1,
+        char_start=0,
+        char_end=len(observed),
+        exact_text=observed,
+        artifact_family="memory",
+        extractor_family="volatility",
+        independence_key="source:hash",
+        value_type=value_type,
+        role=role,  # type: ignore[arg-type]
+    )
+    return AtomicClaim(
+        claim_id="c_1",
+        finding_id="f_1",
+        ordinal=0,
+        statement="structured statement",
+        subject="process:1",
+        predicate=predicate,
+        object_value=expected,
+        anchors=[anchor],
+    )
+
+
+class TestPureClaimVerifier:
+    def test_exact_equality_verifies(self) -> None:
+        result = verify_claim(_claim())
+        assert result.result == "verified"
+        assert result.reason_code == "all_supporting_anchors_matched"
+
+    def test_wrong_value_is_contradicted(self) -> None:
+        result = verify_claim(_claim(observed="powershell.exe"))
+        assert result.result == "contradicted"
+        assert result.reason_code == "supporting_anchor_mismatch"
+
+    def test_unsupported_predicate_is_inconclusive(self) -> None:
+        result = verify_claim(_claim(predicate="caused_exfiltration"))
+        assert result.result == "inconclusive"
+        assert result.reason_code == "unsupported_predicate"
+
+    def test_path_normalization_is_deterministic(self) -> None:
+        result = verify_claim(
+            _claim(
+                predicate="path_equals",
+                expected="c:/windows/system32/cmd.exe",
+                observed=r"C:\Windows\System32\cmd.exe",
+                value_type="path",
+            )
+        )
+        assert result.result == "verified"
+
+    def test_invalid_ip_is_inconclusive(self) -> None:
+        result = verify_claim(
+            _claim(
+                predicate="ip_equals",
+                expected="999.2.3.4",
+                observed="10.0.0.1",
+                value_type="ip",
+            )
+        )
+        assert result.result == "inconclusive"
+        assert result.reason_code == "normalization_failed"
+
+    def test_matching_contradicting_anchor_refutes(self) -> None:
+        result = verify_claim(_claim(role="contradicts"))
+        assert result.result == "contradicted"
+        assert result.reason_code == "contradicting_anchor_matched"
+
+
+class TestPersistedVerification:
+    def test_reopens_anchor_and_appends_history(self, tmp_path: Path) -> None:
+        db = CaseDB.create("case", "/evidence", tmp_path)
+        try:
+            sid = db.register_source("src", "/evidence/a", "hash", "text", 1)
+            db.insert_windows(
+                sid,
+                [
+                    WindowRow(
+                        source_id=sid,
+                        line_start=1,
+                        line_end=1,
+                        event_time=None,
+                        raw_text="cmd.exe",
+                    )
+                ],
+            )
+            window = db.get_windows_by_source("src")[0]
+            assert window.window_id is not None
+            finding = Finding(
+                finding_id="f_1",
+                case_id="case",
+                title="Process",
+                description="cmd.exe",
+                severity="medium",
+                confidence="inference",
+                evidence_refs=["tc_1"],
+                sources=["src"],
+                submitted_at="2026-01-01T01:00:00Z",
+            )
+            db.insert_finding(
+                finding,
+                [
+                    AtomicClaimInput(
+                        statement="Image is cmd.exe",
+                        subject="process:1",
+                        predicate="image_name",
+                        object_value="cmd.exe",
+                        anchors=[
+                            EvidenceAnchorInput(
+                                tool_call_id="tc_1",
+                                window_id=window.window_id,
+                                char_start=0,
+                                char_end=7,
+                                expected_text="cmd.exe",
+                            )
+                        ],
+                    )
+                ],
+            )
+
+            first = db.verify_finding_claims("f_1")
+            assert first[0].result == "verified"
+            assert db.get_claims("f_1")[0].epistemic_state == "verified"
+
+            with db._engine.begin() as conn:
+                conn.execute(
+                    text("UPDATE windows SET raw_text = 'pwsh.exe' WHERE window_id = :wid"),
+                    {"wid": window.window_id},
+                )
+            second = db.verify_finding_claims("f_1")
+            assert second[0].result == "inconclusive"
+            assert second[0].reason_code == "anchor_text_changed"
+            assert len(db.get_claim_verifications("f_1")) == 2
+            assert db.get_claims("f_1")[0].epistemic_state == "inconclusive"
+        finally:
+            db.close()

--- a/tests/test_claim_verification.py
+++ b/tests/test_claim_verification.py
@@ -16,6 +16,7 @@ from mulder.models import (
     WindowRow,
 )
 from mulder.verification.claims import verify_claim
+from mulder.verification.policy import assess_confirmation
 
 
 def _claim(
@@ -100,6 +101,39 @@ class TestPureClaimVerifier:
         result = verify_claim(_claim(role="contradicts"))
         assert result.result == "contradicted"
         assert result.reason_code == "contradicting_anchor_matched"
+
+
+class TestConfirmationPolicy:
+    def test_two_distinct_root_sources_are_required(self) -> None:
+        claim = _claim().model_copy(update={"epistemic_state": "verified"})
+        first = claim.anchors[0]
+        second = first.model_copy(
+            update={
+                "anchor_id": "a_2",
+                "source_id": 2,
+                "source_hash": "hash-2",
+                "independence_key": "source:hash-2",
+            }
+        )
+        assessment = assess_confirmation(
+            [claim.model_copy(update={"anchors": [first, second]})]
+        )
+        assert assessment.accepted is True
+        assert assessment.claims[0].independent_sources == 2
+
+    def test_repeated_anchor_from_same_root_counts_once(self) -> None:
+        claim = _claim().model_copy(update={"epistemic_state": "verified"})
+        duplicate = claim.anchors[0].model_copy(update={"anchor_id": "a_2"})
+        assessment = assess_confirmation(
+            [claim.model_copy(update={"anchors": [claim.anchors[0], duplicate]})]
+        )
+        assert assessment.accepted is False
+        assert assessment.claims[0].reason_code == "insufficient_independent_sources"
+
+    def test_non_verified_claim_cannot_be_confirmed(self) -> None:
+        assessment = assess_confirmation([_claim()])
+        assert assessment.accepted is False
+        assert assessment.claims[0].reason_code == "claim_unverified"
 
 
 class TestPersistedVerification:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -253,7 +253,7 @@ class TestFindings:
                 )
             }
         reopened.close()
-        assert {"claims", "evidence_anchors"} <= names
+        assert {"claims", "evidence_anchors", "claim_verifications"} <= names
 
 
 class TestExtractorVersions:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,7 +11,7 @@ from mulder.db import (
     CaseDB,
     _sanitize_fts5_query,
 )
-from mulder.models import Finding, WindowRow
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding, WindowRow
 
 
 class TestCaseLifecycle:
@@ -155,6 +155,105 @@ class TestFindings:
         assert f.finding_id == "f-001"
         assert f.evidence_refs == ["tc_aabbccdd"]
         assert f.mitre_attack_ids == ["T1059.001"]
+
+    def test_atomic_claim_resolves_exact_immutable_anchor(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "sha256-memory", "volatility", 1
+        )
+        tmp_case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=20,
+                    line_end=20,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe parent 500",
+                )
+            ],
+        )
+        window = tmp_case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+        claim_input = AtomicClaimInput(
+            statement="Process 1234 is cmd.exe",
+            subject="process:1234",
+            predicate="image_name",
+            object_value="cmd.exe",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=9,
+                    char_end=16,
+                    expected_text="cmd.exe",
+                    artifact_family="memory_process_list",
+                )
+            ],
+        )
+
+        stored = tmp_case_db.insert_finding(sample_finding, [claim_input])
+
+        assert len(stored) == 1
+        claims = tmp_case_db.get_claims(sample_finding.finding_id)
+        assert claims == stored
+        anchor = claims[0].anchors[0]
+        assert anchor.exact_text == "cmd.exe"
+        assert anchor.source_hash == "sha256-memory"
+        assert anchor.extractor_family == "volatility"
+        assert anchor.independence_key == "source:sha256-memory"
+        assert tmp_case_db.get_finding(sample_finding.finding_id).sources == [
+            "volatility.pslist"
+        ]
+
+    def test_stale_anchor_rejects_entire_finding(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source("src", "/p", "hash", "text", 1)
+        tmp_case_db.insert_windows(
+            sid,
+            [WindowRow(source_id=sid, line_start=1, line_end=1, event_time=None, raw_text="abc")],
+        )
+        window = tmp_case_db.get_windows_by_source("src")[0]
+        assert window.window_id is not None
+        claim = AtomicClaimInput(
+            statement="Value is xyz",
+            subject="value",
+            predicate="equals",
+            object_value="xyz",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=0,
+                    char_end=3,
+                    expected_text="xyz",
+                )
+            ],
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            tmp_case_db.insert_finding(sample_finding, [claim])
+        assert tmp_case_db.get_finding(sample_finding.finding_id) is None
+
+    def test_open_migrates_missing_claim_tables(self, tmp_path: Path) -> None:
+        db = CaseDB.create(case_id="legacy-claims", evidence_root="/ev", db_dir=tmp_path)
+        with db._engine.begin() as conn:
+            conn.execute(text("DROP TABLE evidence_anchors"))
+            conn.execute(text("DROP TABLE claims"))
+        db.close()
+
+        reopened = CaseDB.open("legacy-claims", tmp_path)
+        with reopened._engine.connect() as conn:
+            names = {
+                row[0]
+                for row in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type = 'table'")
+                )
+            }
+        reopened.close()
+        assert {"claims", "evidence_anchors"} <= names
 
 
 class TestExtractorVersions:

--- a/tests/test_finalize_gates.py
+++ b/tests/test_finalize_gates.py
@@ -15,7 +15,14 @@ import mulder.server.tools.findings  # noqa: F401 ensure tools are registered
 import mulder.server.tools.review  # noqa: F401
 from mulder.audit import AuditLog
 from mulder.db import CaseDB
-from mulder.models import AuditSummary, CaseMetadataRow, Finding, SourceRow
+from mulder.models import (
+    AuditSummary,
+    CaseMetadataRow,
+    ClaimConfirmation,
+    ConfirmationAssessment,
+    Finding,
+    SourceRow,
+)
 from mulder.server.app import _tool_dispatch_sync
 from mulder.server.tools.findings import _evaluate_finalize_gates
 
@@ -99,6 +106,33 @@ def _passing_gate_inputs() -> tuple[list[Finding], CaseMetadataRow, list[SourceR
     ]
     audit = _make_audit_summary()
     return findings, metadata, sources, audit
+
+
+class TestAtomicConfirmationGate:
+    def test_fails_when_persisted_atomic_policy_no_longer_passes(self) -> None:
+        findings, metadata, sources, audit = _passing_gate_inputs()
+        assessment = ConfirmationAssessment(
+            accepted=False,
+            claims=[
+                ClaimConfirmation(
+                    claim_id="c_1",
+                    accepted=False,
+                    reason_code="insufficient_independent_sources",
+                    independent_sources=1,
+                    required_sources=2,
+                )
+            ],
+        )
+        gates = _evaluate_finalize_gates(
+            findings,
+            metadata,
+            sources,
+            audit,
+            {"f_001": assessment},
+        )
+        gate = next(item for item in gates if item["name"] == "atomic_confirmation")
+        assert gate["passed"] is False
+        assert "f_001" in str(gate["detail"])
 
 
 class TestGateMinimumFindings:
@@ -296,7 +330,7 @@ class TestAllGatesPass:
     def test_all_gates_pass(self) -> None:
         findings, metadata, sources, audit = _passing_gate_inputs()
         gates = _evaluate_finalize_gates(findings, metadata, sources, audit)
-        assert len(gates) == 5
+        assert len(gates) == 6
         for gate in gates:
             assert gate["passed"] is True, f"Gate '{gate['name']}' unexpectedly failed"
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from mulder.models import Finding
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding
 
 
 class TestFinding:
@@ -85,3 +85,25 @@ class TestFinding:
         assert f.mitre_attack_ids == []
         assert f.event_time_start is None
         assert f.event_time_end is None
+
+
+class TestAtomicClaimInput:
+    def test_rejects_empty_anchor_list(self) -> None:
+        with pytest.raises(ValidationError, match="anchors"):
+            AtomicClaimInput(
+                statement="cmd.exe executed",
+                subject="cmd.exe",
+                predicate="executed",
+                object_value=True,
+                anchors=[],
+            )
+
+    def test_rejects_reversed_character_range(self) -> None:
+        with pytest.raises(ValidationError, match="char_end"):
+            EvidenceAnchorInput(
+                tool_call_id="tc_1",
+                window_id=1,
+                char_start=8,
+                char_end=4,
+                expected_text="cmd",
+            )

--- a/tests/test_submit_finding.py
+++ b/tests/test_submit_finding.py
@@ -141,10 +141,13 @@ class TestEvidenceValidation:
         )
 
         assert result["status"] == "accepted"
-        assert result["claim_mode"] == "atomic_unverified"
+        assert result["claim_mode"] == "atomic_checked"
+        assert result["claim_verifications"][0]["result"] == "verified"
         finding_id = str(result["finding_id"])
         assert case_db.get_finding(finding_id).sources == ["volatility.pslist"]
-        assert case_db.get_claims(finding_id)[0].anchors[0].exact_text == "cmd.exe"
+        claim = case_db.get_claims(finding_id)[0]
+        assert claim.anchors[0].exact_text == "cmd.exe"
+        assert claim.epistemic_state == "verified"
 
     def test_claim_refs_must_exactly_match_finding_refs(
         self, case_db: CaseDB, audit_log: AuditLog

--- a/tests/test_submit_finding.py
+++ b/tests/test_submit_finding.py
@@ -9,6 +9,7 @@ import pytest
 
 from mulder.audit import AuditLog
 from mulder.db import CaseDB
+from mulder.models import WindowRow
 from mulder.server.app import _tool_dispatch_sync
 from mulder.server.tools.findings import _sanitize_event_time
 
@@ -89,6 +90,94 @@ class TestEvidenceValidation:
         )
         assert "error" in result or result.get("status") != "accepted"
         assert "valid_refs" in result
+
+    def test_atomic_claim_is_resolved_and_persisted(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        sid = case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "memory-hash", "volatility", 1
+        )
+        case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=1,
+                    line_end=1,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe",
+                )
+            ],
+        )
+        window = case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Suspicious process",
+            description="PID 1234 is cmd.exe",
+            severity="high",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd"],
+            sources=["caller-controlled-name"],
+            claims=[
+                {
+                    "statement": "PID 1234 is cmd.exe",
+                    "subject": "process:1234",
+                    "predicate": "image_name",
+                    "object_value": "cmd.exe",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": window.window_id,
+                            "char_start": 9,
+                            "char_end": 16,
+                            "expected_text": "cmd.exe",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        assert result["status"] == "accepted"
+        assert result["claim_mode"] == "atomic_unverified"
+        finding_id = str(result["finding_id"])
+        assert case_db.get_finding(finding_id).sources == ["volatility.pslist"]
+        assert case_db.get_claims(finding_id)[0].anchors[0].exact_text == "cmd.exe"
+
+    def test_claim_refs_must_exactly_match_finding_refs(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Mismatched refs",
+            description="desc",
+            severity="medium",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd", "tc_11223344"],
+            sources=["src"],
+            claims=[
+                {
+                    "statement": "statement",
+                    "subject": "subject",
+                    "predicate": "equals",
+                    "object_value": "value",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": 1,
+                            "char_start": 0,
+                            "char_end": 1,
+                            "expected_text": "x",
+                        }
+                    ],
+                }
+            ],
+        )
+        assert result.get("error_type") == "validation"
+        assert "exactly match" in str(result.get("error_message"))
 
 
 class TestTimestampSanitization:

--- a/tests/test_submit_finding.py
+++ b/tests/test_submit_finding.py
@@ -182,6 +182,58 @@ class TestEvidenceValidation:
         assert result.get("error_type") == "validation"
         assert "exactly match" in str(result.get("error_message"))
 
+    def test_confirmed_atomic_claim_requires_independent_root_sources(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        sid = case_db.register_source("src", "/evidence/a", "one-root", "text", 1)
+        case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=1,
+                    line_end=1,
+                    event_time=None,
+                    raw_text="cmd.exe",
+                )
+            ],
+        )
+        window = case_db.get_windows_by_source("src")[0]
+        assert window.window_id is not None
+
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Single-source execution claim",
+            description="cmd.exe executed",
+            severity="high",
+            confidence="confirmed",
+            evidence_refs=["tc_aabbccdd"],
+            sources=["src"],
+            claims=[
+                {
+                    "statement": "Image is cmd.exe",
+                    "subject": "process:1",
+                    "predicate": "image_name",
+                    "object_value": "cmd.exe",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": window.window_id,
+                            "char_start": 0,
+                            "char_end": 7,
+                            "expected_text": "cmd.exe",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        assert result["status"] == "error"
+        assert result["error_type"] == "confirmation_policy"
+        assert result["confirmation_assessment"]["claims"][0]["independent_sources"] == 1
+        assert case_db.get_findings() == []
+
 
 class TestTimestampSanitization:
     """Tests for _sanitize_event_time timestamp validation."""


### PR DESCRIPTION
- **BLUF:** Require materially independent corroboration before a claim can be confirmed.
- **Priority:** Critical — Duplicate observations from one source must not masquerade as independent support.
- **Changes:** Derive independence keys server-side and enforce corroboration and materiality gates.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 6/37; prerequisite diffs may overlap until earlier PRs land.