### PR TITLE
[critical][security] 2.2 — Add a canonical full-content audit chain

### DIFF
--- a/src/mulder/audit.py
+++ b/src/mulder/audit.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import logging
 import os
 import threading
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from mulder.models import (
     AuditSummary,
@@ -27,6 +30,389 @@ logger = logging.getLogger(__name__)
 _COST_PER_MTOK_INPUT = 3.0
 _COST_PER_MTOK_OUTPUT = 15.0
 _MIN_OUTPUT_TOKEN_ESTIMATE = 100
+
+_AUDIT_SCHEMA = "mulder.audit"
+_AUDIT_VERSION = 1
+_HASH_PREFIX = "sha256:"
+_GENESIS_HASH = _HASH_PREFIX + hashlib.sha256(b"mulder.audit:v1:genesis").hexdigest()
+_CHAIN_FIELDS = frozenset({"schema", "version", "sequence", "previous_hash", "entry_hash"})
+
+AuditIntegrityStatus = Literal[
+    "empty",
+    "verified",
+    "verified_with_legacy_anchor",
+    "legacy_unverified",
+    "invalid",
+]
+
+
+@dataclass(frozen=True)
+class AuditIntegrityResult:
+    """Result of checking one audit file's complete JSONL event chain.
+
+    ``ok`` means no structural or cryptographic error was observed.  Callers
+    that require tamper evidence must additionally require ``status`` to be
+    ``verified`` or ``verified_with_legacy_anchor``; a parseable legacy log is
+    intentionally reported as unverified rather than corrupt.  Like any
+    unsealed hash chain, this verifies the entries present in the file but
+    cannot prove that a suffix was not removed without an externally retained
+    head or the case manifest added by a later receipt layer.
+    """
+
+    ok: bool
+    status: AuditIntegrityStatus
+    entries_checked: int
+    legacy_entries: int
+    head_hash: str | None = None
+    first_error_line: int | None = None
+    first_error_sequence: int | None = None
+    error_code: str | None = None
+    message: str = ""
+    expected: object | None = None
+    actual: object | None = None
+
+    @property
+    def cryptographically_verified(self) -> bool:
+        """Whether the file has a stored chain head covering all present entries."""
+        return self.status in {"verified", "verified_with_legacy_anchor"}
+
+
+@dataclass(frozen=True)
+class _AuditScan:
+    """Internal scan output used both by verification and append recovery."""
+
+    result: AuditIntegrityResult
+    entries: tuple[dict[str, object], ...]
+    append_hash: str
+    next_sequence: int
+    parse_errors: int
+    native_entries: int
+
+
+def _canonical_json(value: object) -> bytes:
+    """Serialize a JSON value into the stable byte representation we commit."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(data: bytes) -> str:
+    return _HASH_PREFIX + hashlib.sha256(data).hexdigest()
+
+
+def _entry_hash(entry: Mapping[str, object]) -> str:
+    """Hash a native entry, excluding the self-referential ``entry_hash``."""
+    payload = {key: value for key, value in entry.items() if key != "entry_hash"}
+    return _digest(b"mulder.audit:v1:entry\0" + _canonical_json(payload))
+
+
+def _legacy_hash(previous_hash: str, entry: Mapping[str, object]) -> str:
+    """Build a deterministic anchor over a parseable legacy prefix."""
+    return _digest(
+        b"mulder.audit:v1:legacy\0"
+        + previous_hash.encode("ascii")
+        + b"\0"
+        + _canonical_json(entry)
+    )
+
+
+def _invalid_result(
+    *,
+    entries_checked: int,
+    legacy_entries: int,
+    line_number: int,
+    sequence: int | None,
+    error_code: str,
+    message: str,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> AuditIntegrityResult:
+    return AuditIntegrityResult(
+        ok=False,
+        status="invalid",
+        entries_checked=entries_checked,
+        legacy_entries=legacy_entries,
+        first_error_line=line_number,
+        first_error_sequence=sequence,
+        error_code=error_code,
+        message=message,
+        expected=expected,
+        actual=actual,
+    )
+
+
+def _scan_audit_file(log_path: Path) -> _AuditScan:
+    """Parse and verify ``log_path``, retaining the first broken-link detail."""
+    if not log_path.exists():
+        result = AuditIntegrityResult(
+            ok=True,
+            status="empty",
+            entries_checked=0,
+            legacy_entries=0,
+            message="Audit log is empty.",
+        )
+        return _AuditScan(result, (), _GENESIS_HASH, 1, 0, 0)
+
+    entries: list[dict[str, object]] = []
+    rolling_hash = _GENESIS_HASH
+    stored_head: str | None = None
+    event_count = 0
+    entries_checked = 0
+    legacy_entries = 0
+    native_entries = 0
+    parse_errors = 0
+    first_error: AuditIntegrityResult | None = None
+    saw_native = False
+
+    with open(log_path, "rb") as fh:
+        for line_number, raw_line in enumerate(fh, start=1):
+            try:
+                stripped = raw_line.decode("utf-8").strip()
+                if not stripped:
+                    continue
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                parse_errors += 1
+                if first_error is None:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count + 1,
+                        error_code="invalid_json",
+                        message=f"Line {line_number} is not valid JSON: {exc}",
+                    )
+                continue
+
+            if not isinstance(parsed, dict):
+                if first_error is None:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count + 1,
+                        error_code="entry_not_object",
+                        message=f"Line {line_number} is a JSON value, not an audit object.",
+                        expected="object",
+                        actual=type(parsed).__name__,
+                    )
+                continue
+
+            entry = cast(dict[str, object], parsed)
+            entries.append(entry)
+            event_count += 1
+            is_native = any(field in entry for field in _CHAIN_FIELDS)
+
+            if first_error is not None:
+                continue
+
+            if not is_native:
+                if saw_native:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count,
+                        error_code="legacy_after_chain",
+                        message="An unchained legacy entry appears after the native chain began.",
+                    )
+                    continue
+                try:
+                    rolling_hash = _legacy_hash(rolling_hash, entry)
+                except (TypeError, ValueError) as exc:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count,
+                        error_code="noncanonical_legacy_entry",
+                        message=f"Legacy entry cannot be canonically encoded: {exc}",
+                    )
+                    continue
+                legacy_entries += 1
+                entries_checked += 1
+                continue
+
+            saw_native = True
+            native_entries += 1
+            sequence_value = entry.get("sequence")
+            sequence = sequence_value if type(sequence_value) is int else None
+
+            required_fields = _CHAIN_FIELDS.difference(entry)
+            if required_fields:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="missing_chain_field",
+                    message=f"Native entry is missing chain fields: {sorted(required_fields)}",
+                    expected=sorted(_CHAIN_FIELDS),
+                    actual=sorted(_CHAIN_FIELDS.intersection(entry)),
+                )
+                continue
+            if entry.get("schema") != _AUDIT_SCHEMA:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unsupported_schema",
+                    message="Native entry uses an unsupported audit schema.",
+                    expected=_AUDIT_SCHEMA,
+                    actual=entry.get("schema"),
+                )
+                continue
+            if type(entry.get("version")) is not int or entry.get("version") != _AUDIT_VERSION:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unsupported_version",
+                    message="Native entry uses an unsupported audit schema version.",
+                    expected=_AUDIT_VERSION,
+                    actual=entry.get("version"),
+                )
+                continue
+            if sequence != event_count:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="sequence_mismatch",
+                    message="Audit event sequence is not contiguous.",
+                    expected=event_count,
+                    actual=sequence_value,
+                )
+                continue
+
+            legacy_marker = entry.get("legacy_prefix_entries")
+            if native_entries == 1 and legacy_entries:
+                if legacy_marker != legacy_entries:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=sequence,
+                        error_code="legacy_anchor_mismatch",
+                        message="First native entry does not declare its full legacy prefix.",
+                        expected=legacy_entries,
+                        actual=legacy_marker,
+                    )
+                    continue
+            elif legacy_marker is not None:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unexpected_legacy_anchor",
+                    message=(
+                        "Only a first native entry following legacy records may declare an anchor."
+                    ),
+                    expected=None,
+                    actual=legacy_marker,
+                )
+                continue
+
+            previous_hash = entry.get("previous_hash")
+            if previous_hash != rolling_hash:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="previous_hash_mismatch",
+                    message="Audit entry does not link to the preceding event.",
+                    expected=rolling_hash,
+                    actual=previous_hash,
+                )
+                continue
+            try:
+                expected_hash = _entry_hash(entry)
+            except (TypeError, ValueError) as exc:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="noncanonical_entry",
+                    message=f"Native entry cannot be canonically encoded: {exc}",
+                )
+                continue
+            actual_hash = entry.get("entry_hash")
+            if actual_hash != expected_hash:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="entry_hash_mismatch",
+                    message="Audit entry content does not match its committed hash.",
+                    expected=expected_hash,
+                    actual=actual_hash,
+                )
+                continue
+
+            rolling_hash = expected_hash
+            stored_head = expected_hash
+            entries_checked += 1
+
+    if first_error is not None:
+        return _AuditScan(
+            first_error,
+            tuple(entries),
+            rolling_hash,
+            event_count + 1,
+            parse_errors,
+            native_entries,
+        )
+    if event_count == 0:
+        result = AuditIntegrityResult(
+            ok=True,
+            status="empty",
+            entries_checked=0,
+            legacy_entries=0,
+            message="Audit log is empty.",
+        )
+    elif not saw_native:
+        result = AuditIntegrityResult(
+            ok=True,
+            status="legacy_unverified",
+            entries_checked=entries_checked,
+            legacy_entries=legacy_entries,
+            message="Legacy entries are readable but have no stored integrity chain.",
+        )
+    else:
+        status: AuditIntegrityStatus = (
+            "verified_with_legacy_anchor" if legacy_entries else "verified"
+        )
+        result = AuditIntegrityResult(
+            ok=True,
+            status=status,
+            entries_checked=entries_checked,
+            legacy_entries=legacy_entries,
+            head_hash=stored_head,
+            message=(
+                "The native chain commits the canonical legacy prefix and all native entries."
+                if legacy_entries
+                else "Every audit entry is covered by the native integrity chain."
+            ),
+        )
+    return _AuditScan(
+        result,
+        tuple(entries),
+        rolling_hash,
+        event_count + 1,
+        parse_errors,
+        native_entries,
+    )
 
 
 class AuditLog:
@@ -52,31 +438,71 @@ class AuditLog:
         self._estimated_input_tokens: int = 0
         self._estimated_output_tokens: int = 0
         self._timestamps: list[str] = []
+        self._append_hash = _GENESIS_HASH
+        self._next_sequence = 1
+        self._legacy_entries = 0
+        self._native_entries = 0
+        self._append_blocked_reason: str | None = None
+        self._file_fingerprint: tuple[int, int, int, int] | None = None
         self._load_existing()
+
+    def _reset_indexes(self) -> None:
+        """Reset derived state before reloading a file changed by another writer."""
+        self._tool_call_ids.clear()
+        self._tool_calls.clear()
+        self._finding_entries.clear()
+        self._total_tool_calls = 0
+        self._total_findings = 0
+        self._total_duration_ms = 0.0
+        self._tool_call_counts.clear()
+        self._tool_durations.clear()
+        self._estimated_input_tokens = 0
+        self._estimated_output_tokens = 0
+        self._timestamps.clear()
+
+    def _fingerprint(self) -> tuple[int, int, int, int] | None:
+        try:
+            stat = self._log_path.stat()
+        except FileNotFoundError:
+            return None
+        return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
     def _load_existing(self) -> None:
         """Populate in-memory indexes from an existing JSONL file."""
-        if not self._log_path.exists():
-            return
-        parse_errors = 0
-        with open(self._log_path) as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    parse_errors += 1
-                    continue
-                if isinstance(entry, dict):
-                    self._index_entry(cast(dict[str, object], entry))
-        if parse_errors > 0:
+        scan = _scan_audit_file(self._log_path)
+        self._append_hash = scan.append_hash
+        self._next_sequence = scan.next_sequence
+        self._legacy_entries = scan.result.legacy_entries
+        self._native_entries = scan.native_entries
+        self._append_blocked_reason = None if scan.result.ok else scan.result.message
+        for entry in scan.entries:
+            self._index_entry(entry)
+        if scan.parse_errors > 0:
             logger.warning(
                 "Audit log %s: %d lines failed to parse (possible corruption)",
                 self._log_path,
-                parse_errors,
+                scan.parse_errors,
             )
+        if not scan.result.ok:
+            logger.warning(
+                "Audit log %s failed integrity verification at line %s: %s",
+                self._log_path,
+                scan.result.first_error_line,
+                scan.result.message,
+            )
+        self._file_fingerprint = self._fingerprint()
+
+    def verify_integrity(self) -> AuditIntegrityResult:
+        """Verify the complete file and return the first broken-link diagnostic.
+
+        This method never mutates or repairs the log.  ``legacy_unverified`` is
+        a compatibility state, not a cryptographic success.  Once a native
+        event is appended to a legacy log, its first link canonically commits
+        the entire parseable legacy prefix as it exists at that transition.
+        Detecting removal of a complete final suffix requires an external head
+        commitment or sealed case manifest and is deliberately out of scope.
+        """
+        return _scan_audit_file(self._log_path).result
 
     def _index_entry(self, entry: dict[str, object]) -> None:
         """Index a parsed audit entry by type and update summary accumulators."""
@@ -115,11 +541,53 @@ class AuditLog:
         """Append ``entry`` to the JSONL log file and update in-memory indexes."""
         with self._lock:
             self._log_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._log_path, "a") as fh:
-                fh.write(json.dumps(entry, separators=(",", ":")) + "\n")
-                fh.flush()
-                os.fsync(fh.fileno())
-            self._index_entry(entry)
+            with open(self._log_path, "a+", encoding="utf-8") as fh:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                try:
+                    if self._fingerprint() != self._file_fingerprint:
+                        self._reset_indexes()
+                        self._load_existing()
+                    if self._append_blocked_reason is not None:
+                        raise RuntimeError(
+                            "Refusing to append to an invalid audit log: "
+                            f"{self._append_blocked_reason}"
+                        )
+                    reserved = _CHAIN_FIELDS.intersection(entry)
+                    if reserved:
+                        raise ValueError(
+                            f"Audit event may not set reserved chain fields: {sorted(reserved)}"
+                        )
+
+                    chained_entry = dict(entry)
+                    chained_entry.update(
+                        {
+                            "schema": _AUDIT_SCHEMA,
+                            "version": _AUDIT_VERSION,
+                            "sequence": self._next_sequence,
+                            "previous_hash": self._append_hash,
+                        }
+                    )
+                    if self._native_entries == 0 and self._legacy_entries:
+                        chained_entry["legacy_prefix_entries"] = self._legacy_entries
+                    chained_entry["entry_hash"] = _entry_hash(chained_entry)
+                    serialized = _canonical_json(chained_entry).decode("utf-8")
+
+                    fh.write(serialized + "\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                    self._append_hash = cast(str, chained_entry["entry_hash"])
+                    self._next_sequence += 1
+                    self._native_entries += 1
+                    self._index_entry(chained_entry)
+                    stat = os.fstat(fh.fileno())
+                    self._file_fingerprint = (
+                        stat.st_dev,
+                        stat.st_ino,
+                        stat.st_size,
+                        stat.st_mtime_ns,
+                    )
+                finally:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
     def log_tool_call(
         self,

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -175,7 +175,6 @@ _HINT_CHAR_LIMIT = 200
 _DEFAULT_SEARCH_LIMIT = 50
 _FILE_LIST_CAP = 500
 
-_HASH_SIZE_THRESHOLD = 10000
 _HASH_PREFIX = "blake2b:"
 _HASH_DIGEST_SIZE = 32
 
@@ -185,25 +184,15 @@ def _blake2b_hex(data: bytes) -> str:
 
 
 def hash_output(output: object) -> str:
-    """Return a BLAKE2b fingerprint of *output* for audit purposes.
+    """Return a BLAKE2b commitment to the complete JSON form of *output*.
 
-    For small payloads, hashes the full JSON.  For large payloads
-    (>10KB serialized), hashes a compact summary to avoid expensive
-    serialization of data that's about to be serialized again for the
-    MCP response.
+    The previous large-value heuristic committed only a length, key set, or
+    short prefix.  That was useful as a cache fingerprint but unsuitable for
+    an audit record: different tool outputs could have the same digest.  The
+    existing algorithm and serialization remain stable for small values while
+    all values now commit their complete serialized content.
     """
-    if isinstance(output, list | dict):
-        if isinstance(output, list) and len(output) > 200:
-            return _blake2b_hex(f"list:len={len(output)}".encode())
-        if isinstance(output, dict) and len(output) > 100:
-            return _blake2b_hex(f"dict:keys={sorted(output.keys())}".encode())
-        probe = json.dumps(output, sort_keys=True, default=str)
-        if len(probe) > _HASH_SIZE_THRESHOLD:
-            return _blake2b_hex(f"large:{len(probe)}:{probe[:256]}".encode())
-        return _blake2b_hex(probe.encode())
     raw = json.dumps(output, sort_keys=True, default=str)
-    if len(raw) > _HASH_SIZE_THRESHOLD:
-        return _blake2b_hex(f"large:{len(raw)}:{raw[:256]}".encode())
     return _blake2b_hex(raw.encode())
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -70,6 +71,225 @@ class TestLoadExisting:
         assert log.has_tool_call("tc_good")
         assert log.has_tool_call("tc_good2")
         assert any("2 lines failed to parse" in msg for msg in caplog.messages)
+
+
+class TestIntegrityChain:
+    @staticmethod
+    def _write_lines(path: Path, entries: list[dict[str, object]]) -> None:
+        path.write_text(
+            "".join(json.dumps(entry, separators=(",", ":")) + "\n" for entry in entries),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _read_lines(path: Path) -> list[dict[str, object]]:
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    @staticmethod
+    def _three_entry_log(path: Path) -> AuditLog:
+        audit = AuditLog(path)
+        audit.log_tool_call("tc_1", "search", {"query": "one"}, "blake2b:one")
+        audit.log_tool_call("tc_2", "search", {"query": "two"}, "blake2b:two")
+        audit.log_finding_submission("finding-1", ["tc_1", "tc_2"])
+        return audit
+
+    def test_new_events_are_canonical_and_verified(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = AuditLog(log_path)
+        audit.log_tool_call(
+            "tc_1",
+            "search",
+            {"z": {"last": 2, "first": 1}, "a": "value"},
+            "blake2b:output",
+        )
+
+        raw = log_path.read_text(encoding="utf-8").strip()
+        entry = json.loads(raw)
+        assert list(entry) == sorted(entry)
+        assert list(entry["params"]) == ["a", "z"]
+        assert list(entry["params"]["z"]) == ["first", "last"]
+        assert entry["schema"] == "mulder.audit"
+        assert entry["version"] == 1
+        assert entry["sequence"] == 1
+        assert entry["previous_hash"].startswith("sha256:")
+        assert entry["entry_hash"].startswith("sha256:")
+
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.cryptographically_verified
+        assert result.status == "verified"
+        assert result.entries_checked == 1
+        assert result.head_hash == entry["entry_hash"]
+
+    def test_key_reordering_does_not_break_canonical_hash(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = AuditLog(log_path)
+        audit.log_tool_call("tc_1", "search", {"b": 2, "a": 1}, "blake2b:output")
+        entry = self._read_lines(log_path)[0]
+        reversed_entry = dict(reversed(list(entry.items())))
+        log_path.write_text(json.dumps(reversed_entry) + "\n", encoding="utf-8")
+
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+
+    def test_edit_reports_first_broken_entry(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        entries[1]["tool_name"] = "edited"
+        self._write_lines(log_path, entries)
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.first_error_sequence == 2
+        assert result.error_code == "entry_hash_mismatch"
+
+    def test_delete_reports_sequence_gap(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[0], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "sequence_mismatch"
+        assert result.expected == 2
+        assert result.actual == 3
+
+    def test_insert_reports_duplicate_sequence(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[0], entries[0], entries[1], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "sequence_mismatch"
+
+    def test_reorder_reports_first_out_of_order_entry(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[1], entries[0], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 1
+        assert result.error_code == "sequence_mismatch"
+
+    def test_truncated_final_json_is_invalid(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        raw = log_path.read_bytes()
+        log_path.write_bytes(raw[:-12])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 3
+        assert result.error_code == "invalid_json"
+
+    def test_bit_flip_is_detected(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        raw = log_path.read_bytes()
+        original = b"blake2b:two"
+        replacement = b"blake2b:Two"
+        assert original in raw
+        log_path.write_bytes(raw.replace(original, replacement, 1))
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "entry_hash_mismatch"
+
+    def test_append_and_reload_continue_chain(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        AuditLog(log_path).log_tool_call("tc_1", "search", {}, "blake2b:one")
+        reloaded = AuditLog(log_path)
+        reloaded.log_tool_call("tc_2", "search", {}, "blake2b:two")
+
+        entries = self._read_lines(log_path)
+        assert [entry["sequence"] for entry in entries] == [1, 2]
+        assert entries[1]["previous_hash"] == entries[0]["entry_hash"]
+        result = AuditLog(log_path).verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+        assert result.entries_checked == 2
+
+    def test_concurrent_writers_serialize_under_file_lock(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        writers = [AuditLog(log_path) for _ in range(4)]
+
+        def write(index: int) -> None:
+            writers[index % len(writers)].log_tool_call(
+                f"tc_{index}", "search", {"index": index}, f"blake2b:{index}"
+            )
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(write, range(40)))
+
+        result = AuditLog(log_path).verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+        assert result.entries_checked == 40
+        assert [entry["sequence"] for entry in self._read_lines(log_path)] == list(range(1, 41))
+
+    def test_invalid_native_log_refuses_append(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        entries[0]["tool_name"] = "tampered"
+        self._write_lines(log_path, entries)
+
+        with pytest.raises(RuntimeError, match="Refusing to append"):
+            audit.log_tool_call("tc_4", "search", {}, "blake2b:four")
+
+    def test_legacy_log_is_readable_but_explicitly_unverified(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        legacy = [
+            {"type": "tool_call", "tool_call_id": "legacy-1", "tool_name": "x"},
+            {"type": "finding", "finding_id": "legacy-f", "evidence_refs": ["legacy-1"]},
+        ]
+        self._write_lines(log_path, legacy)
+
+        audit = AuditLog(log_path)
+        assert audit.has_tool_call("legacy-1")
+        result = audit.verify_integrity()
+        assert result.ok
+        assert not result.cryptographically_verified
+        assert result.status == "legacy_unverified"
+        assert result.legacy_entries == 2
+        assert result.head_hash is None
+
+    def test_first_new_entry_anchors_and_labels_legacy_prefix(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        legacy = [
+            {"type": "tool_call", "tool_call_id": "legacy-1", "tool_name": "x"},
+            {"type": "finding", "finding_id": "legacy-f", "evidence_refs": ["legacy-1"]},
+        ]
+        self._write_lines(log_path, legacy)
+        audit = AuditLog(log_path)
+        audit.log_tool_call("native-1", "search", {}, "blake2b:one")
+
+        entries = self._read_lines(log_path)
+        assert entries[2]["sequence"] == 3
+        assert entries[2]["legacy_prefix_entries"] == 2
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.cryptographically_verified
+        assert result.status == "verified_with_legacy_anchor"
+        assert result.legacy_entries == 2
+
+        entries[0]["tool_name"] = "edited-legacy"
+        self._write_lines(log_path, entries)
+        tampered = audit.verify_integrity()
+        assert not tampered.ok
+        assert tampered.first_error_line == 3
+        assert tampered.error_code == "previous_hash_mismatch"
 
 
 class TestProvenance:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -32,21 +32,19 @@ class TestHashOutput:
         expected = "blake2b:" + hashlib.blake2b(expected_json.encode(), digest_size=32).hexdigest()
         assert result == expected
 
-    def test_large_dict_summary_hash(self) -> None:
+    def test_large_dict_full_hash(self) -> None:
         data = {f"k{i}": "x" * 100 for i in range(150)}
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
-    def test_large_list_summary_hash(self) -> None:
+    def test_large_list_full_hash(self) -> None:
         data = ["x" * 50 for _ in range(250)]
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
     def test_scalar_input(self) -> None:
         result = hash_output("hello world")
@@ -124,23 +122,21 @@ class TestSlimWindow:
 
 
 class TestHashOutputHeuristic:
-    """Test the heuristic size-check that skips full JSON serialization."""
+    """Large audit commitments must distinguish complete payload content."""
 
-    def test_large_list_uses_length_hash(self) -> None:
-        """Lists with >200 items use a length summary, not full serialization."""
+    def test_large_list_commits_values(self) -> None:
         data = list(range(250))
         h1 = hash_output(data)
         data_different_content = list(range(250, 500))
         h2 = hash_output(data_different_content)
-        assert h1 == h2
+        assert h1 != h2
 
-    def test_large_dict_uses_keys_hash(self) -> None:
-        """Dicts with >100 keys use a keys summary, not full serialization."""
+    def test_large_dict_commits_values(self) -> None:
         data = {f"k{i}": "value_a" for i in range(150)}
         h1 = hash_output(data)
         data_different_values = {f"k{i}": "value_b" for i in range(150)}
         h2 = hash_output(data_different_values)
-        assert h1 == h2
+        assert h1 != h2
 
 
 class TestExtractPid:


### PR DESCRIPTION
- **BLUF:** Protect the complete audit history with deterministic chained hashes.
- **Priority:** Critical — Metadata-only receipts cannot reveal tampering with substantive outputs.
- **Changes:** Canonicalize full records and verify mutation, deletion, and reordering failures.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 9/37; prerequisite diffs may overlap until earlier PRs land.