### PR TITLE
[critical][security] 2.3 — Seal case manifests and add offline verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Each investigation produces:
 - **Per-case SQLite database** - FTS5 full-text search across all indexed evidence
 - **Append-only audit log** - JSONL recording every tool invocation with BLAKE2b output hashes
 - **Optional exports** - STIX 2.1 IOC bundle, CSV IOC list, and MITRE ATT&CK Navigator layer via `mulder export-iocs` and `mulder export-navigator`
+- **Portable case receipts** - seal evidence, logical database state, audit head, claims, tool versions, and reports with `mulder seal-case`; verify a relocated bundle offline with `mulder verify-case`
 
 ## Documentation
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -37,6 +37,8 @@ Try-it-out instructions for running Mulder, the forensic investigation platform.
     - [`mulder setup`](#mulder-setup)
     - [`mulder serve`](#mulder-serve)
     - [`mulder report`](#mulder-report)
+    - [`mulder seal-case`](#mulder-seal-case)
+    - [`mulder verify-case`](#mulder-verify-case)
     - [`mulder export-iocs`](#mulder-export-iocs)
     - [`mulder export-navigator`](#mulder-export-navigator)
   - [Understanding the Output](#understanding-the-output)
@@ -518,6 +520,46 @@ Regenerates reports (Markdown, HTML, PDF) offline from an existing case database
 |--------|---------|-------------|
 | `--db-dir` | `~/.mulder/cases` | Directory containing case databases |
 
+### `mulder seal-case`
+
+```
+mulder seal-case <case_id> [OPTIONS]
+```
+
+Creates `{case_id}.manifest.json`, a portable receipt over the case database's complete logical
+contents, the exact audit-chain head and entry count, registered original evidence, extractor and
+tool metadata, and standard report/export files found beside the database. Use `--artifact PATH`
+repeatedly to bind additional generated files. Existing manifests are preserved unless `--force`
+is explicit. Run this after the final report/export operation; any later database or audit event is
+correctly reported as a post-seal change and requires an explicit re-seal.
+
+The v1 receipt is deliberately marked **unsigned**. It detects changes relative to the retained
+manifest but does not establish an examiner identity; examiner-controlled signing is a separate
+trust layer. Sealing fails if registered evidence is missing or has already changed, or if the
+current audit chain is invalid.
+
+The `sqlite-logical-v1` database commitment includes every non-internal SQLite schema object and
+every typed value in every non-internal table, in deterministic value order. It intentionally
+excludes physical page layout, WAL/checkpoint layout, file timestamps, and SQLite-maintained
+`sqlite_*` implementation tables, so a byte-for-byte copy is not required for a logically identical
+case database. Table-level schema, row-count, and content commitments make failures diagnosable.
+
+### `mulder verify-case`
+
+```
+mulder verify-case <manifest_path> [--evidence-root PATH] [--json]
+```
+
+Verifies a copied case using only local file and SQLite reads: it does not start MCP, call a model,
+or use the network. Artifact locations are relative to the manifest, so moving the case and
+evidence directories together does not invalidate the receipt. Use `--evidence-root` when the
+evidence was moved independently. Diagnostics identify the exact missing/changed evidence,
+report, database table, or audit-chain property.
+
+Exit codes are `0` for a fully verified native case, `1` for mutation/corruption/missing material,
+`2` for intact but unchained legacy material, and `3` for an unsupported manifest schema. A legacy
+audit is reported as `LEGACY UNVERIFIED`, never as corrupt merely because it predates chaining.
+
 ### `mulder export-iocs`
 
 ```
@@ -553,6 +595,7 @@ After an investigation completes, all artifacts are written to the cases directo
 |------|-------------|
 | `{case_id}.db` | SQLite database with all indexed evidence, findings, and metadata |
 | `{case_id}.audit.jsonl` | Append-only audit log recording every tool invocation with parameters and timestamps |
+| `{case_id}.manifest.json` | Relocatable unsigned case receipt produced by `mulder seal-case` |
 
 ### Reports
 

--- a/src/mulder/audit.py
+++ b/src/mulder/audit.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import logging
 import os
 import threading
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from mulder.models import (
     AuditSummary,
@@ -27,6 +30,389 @@ logger = logging.getLogger(__name__)
 _COST_PER_MTOK_INPUT = 3.0
 _COST_PER_MTOK_OUTPUT = 15.0
 _MIN_OUTPUT_TOKEN_ESTIMATE = 100
+
+_AUDIT_SCHEMA = "mulder.audit"
+_AUDIT_VERSION = 1
+_HASH_PREFIX = "sha256:"
+_GENESIS_HASH = _HASH_PREFIX + hashlib.sha256(b"mulder.audit:v1:genesis").hexdigest()
+_CHAIN_FIELDS = frozenset({"schema", "version", "sequence", "previous_hash", "entry_hash"})
+
+AuditIntegrityStatus = Literal[
+    "empty",
+    "verified",
+    "verified_with_legacy_anchor",
+    "legacy_unverified",
+    "invalid",
+]
+
+
+@dataclass(frozen=True)
+class AuditIntegrityResult:
+    """Result of checking one audit file's complete JSONL event chain.
+
+    ``ok`` means no structural or cryptographic error was observed.  Callers
+    that require tamper evidence must additionally require ``status`` to be
+    ``verified`` or ``verified_with_legacy_anchor``; a parseable legacy log is
+    intentionally reported as unverified rather than corrupt.  Like any
+    unsealed hash chain, this verifies the entries present in the file but
+    cannot prove that a suffix was not removed without an externally retained
+    head or the case manifest added by a later receipt layer.
+    """
+
+    ok: bool
+    status: AuditIntegrityStatus
+    entries_checked: int
+    legacy_entries: int
+    head_hash: str | None = None
+    first_error_line: int | None = None
+    first_error_sequence: int | None = None
+    error_code: str | None = None
+    message: str = ""
+    expected: object | None = None
+    actual: object | None = None
+
+    @property
+    def cryptographically_verified(self) -> bool:
+        """Whether the file has a stored chain head covering all present entries."""
+        return self.status in {"verified", "verified_with_legacy_anchor"}
+
+
+@dataclass(frozen=True)
+class _AuditScan:
+    """Internal scan output used both by verification and append recovery."""
+
+    result: AuditIntegrityResult
+    entries: tuple[dict[str, object], ...]
+    append_hash: str
+    next_sequence: int
+    parse_errors: int
+    native_entries: int
+
+
+def _canonical_json(value: object) -> bytes:
+    """Serialize a JSON value into the stable byte representation we commit."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _digest(data: bytes) -> str:
+    return _HASH_PREFIX + hashlib.sha256(data).hexdigest()
+
+
+def _entry_hash(entry: Mapping[str, object]) -> str:
+    """Hash a native entry, excluding the self-referential ``entry_hash``."""
+    payload = {key: value for key, value in entry.items() if key != "entry_hash"}
+    return _digest(b"mulder.audit:v1:entry\0" + _canonical_json(payload))
+
+
+def _legacy_hash(previous_hash: str, entry: Mapping[str, object]) -> str:
+    """Build a deterministic anchor over a parseable legacy prefix."""
+    return _digest(
+        b"mulder.audit:v1:legacy\0"
+        + previous_hash.encode("ascii")
+        + b"\0"
+        + _canonical_json(entry)
+    )
+
+
+def _invalid_result(
+    *,
+    entries_checked: int,
+    legacy_entries: int,
+    line_number: int,
+    sequence: int | None,
+    error_code: str,
+    message: str,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> AuditIntegrityResult:
+    return AuditIntegrityResult(
+        ok=False,
+        status="invalid",
+        entries_checked=entries_checked,
+        legacy_entries=legacy_entries,
+        first_error_line=line_number,
+        first_error_sequence=sequence,
+        error_code=error_code,
+        message=message,
+        expected=expected,
+        actual=actual,
+    )
+
+
+def _scan_audit_file(log_path: Path) -> _AuditScan:
+    """Parse and verify ``log_path``, retaining the first broken-link detail."""
+    if not log_path.exists():
+        result = AuditIntegrityResult(
+            ok=True,
+            status="empty",
+            entries_checked=0,
+            legacy_entries=0,
+            message="Audit log is empty.",
+        )
+        return _AuditScan(result, (), _GENESIS_HASH, 1, 0, 0)
+
+    entries: list[dict[str, object]] = []
+    rolling_hash = _GENESIS_HASH
+    stored_head: str | None = None
+    event_count = 0
+    entries_checked = 0
+    legacy_entries = 0
+    native_entries = 0
+    parse_errors = 0
+    first_error: AuditIntegrityResult | None = None
+    saw_native = False
+
+    with open(log_path, "rb") as fh:
+        for line_number, raw_line in enumerate(fh, start=1):
+            try:
+                stripped = raw_line.decode("utf-8").strip()
+                if not stripped:
+                    continue
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                parse_errors += 1
+                if first_error is None:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count + 1,
+                        error_code="invalid_json",
+                        message=f"Line {line_number} is not valid JSON: {exc}",
+                    )
+                continue
+
+            if not isinstance(parsed, dict):
+                if first_error is None:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count + 1,
+                        error_code="entry_not_object",
+                        message=f"Line {line_number} is a JSON value, not an audit object.",
+                        expected="object",
+                        actual=type(parsed).__name__,
+                    )
+                continue
+
+            entry = cast(dict[str, object], parsed)
+            entries.append(entry)
+            event_count += 1
+            is_native = any(field in entry for field in _CHAIN_FIELDS)
+
+            if first_error is not None:
+                continue
+
+            if not is_native:
+                if saw_native:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count,
+                        error_code="legacy_after_chain",
+                        message="An unchained legacy entry appears after the native chain began.",
+                    )
+                    continue
+                try:
+                    rolling_hash = _legacy_hash(rolling_hash, entry)
+                except (TypeError, ValueError) as exc:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=event_count,
+                        error_code="noncanonical_legacy_entry",
+                        message=f"Legacy entry cannot be canonically encoded: {exc}",
+                    )
+                    continue
+                legacy_entries += 1
+                entries_checked += 1
+                continue
+
+            saw_native = True
+            native_entries += 1
+            sequence_value = entry.get("sequence")
+            sequence = sequence_value if type(sequence_value) is int else None
+
+            required_fields = _CHAIN_FIELDS.difference(entry)
+            if required_fields:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="missing_chain_field",
+                    message=f"Native entry is missing chain fields: {sorted(required_fields)}",
+                    expected=sorted(_CHAIN_FIELDS),
+                    actual=sorted(_CHAIN_FIELDS.intersection(entry)),
+                )
+                continue
+            if entry.get("schema") != _AUDIT_SCHEMA:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unsupported_schema",
+                    message="Native entry uses an unsupported audit schema.",
+                    expected=_AUDIT_SCHEMA,
+                    actual=entry.get("schema"),
+                )
+                continue
+            if type(entry.get("version")) is not int or entry.get("version") != _AUDIT_VERSION:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unsupported_version",
+                    message="Native entry uses an unsupported audit schema version.",
+                    expected=_AUDIT_VERSION,
+                    actual=entry.get("version"),
+                )
+                continue
+            if sequence != event_count:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="sequence_mismatch",
+                    message="Audit event sequence is not contiguous.",
+                    expected=event_count,
+                    actual=sequence_value,
+                )
+                continue
+
+            legacy_marker = entry.get("legacy_prefix_entries")
+            if native_entries == 1 and legacy_entries:
+                if legacy_marker != legacy_entries:
+                    first_error = _invalid_result(
+                        entries_checked=entries_checked,
+                        legacy_entries=legacy_entries,
+                        line_number=line_number,
+                        sequence=sequence,
+                        error_code="legacy_anchor_mismatch",
+                        message="First native entry does not declare its full legacy prefix.",
+                        expected=legacy_entries,
+                        actual=legacy_marker,
+                    )
+                    continue
+            elif legacy_marker is not None:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="unexpected_legacy_anchor",
+                    message=(
+                        "Only a first native entry following legacy records may declare an anchor."
+                    ),
+                    expected=None,
+                    actual=legacy_marker,
+                )
+                continue
+
+            previous_hash = entry.get("previous_hash")
+            if previous_hash != rolling_hash:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="previous_hash_mismatch",
+                    message="Audit entry does not link to the preceding event.",
+                    expected=rolling_hash,
+                    actual=previous_hash,
+                )
+                continue
+            try:
+                expected_hash = _entry_hash(entry)
+            except (TypeError, ValueError) as exc:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="noncanonical_entry",
+                    message=f"Native entry cannot be canonically encoded: {exc}",
+                )
+                continue
+            actual_hash = entry.get("entry_hash")
+            if actual_hash != expected_hash:
+                first_error = _invalid_result(
+                    entries_checked=entries_checked,
+                    legacy_entries=legacy_entries,
+                    line_number=line_number,
+                    sequence=sequence,
+                    error_code="entry_hash_mismatch",
+                    message="Audit entry content does not match its committed hash.",
+                    expected=expected_hash,
+                    actual=actual_hash,
+                )
+                continue
+
+            rolling_hash = expected_hash
+            stored_head = expected_hash
+            entries_checked += 1
+
+    if first_error is not None:
+        return _AuditScan(
+            first_error,
+            tuple(entries),
+            rolling_hash,
+            event_count + 1,
+            parse_errors,
+            native_entries,
+        )
+    if event_count == 0:
+        result = AuditIntegrityResult(
+            ok=True,
+            status="empty",
+            entries_checked=0,
+            legacy_entries=0,
+            message="Audit log is empty.",
+        )
+    elif not saw_native:
+        result = AuditIntegrityResult(
+            ok=True,
+            status="legacy_unverified",
+            entries_checked=entries_checked,
+            legacy_entries=legacy_entries,
+            message="Legacy entries are readable but have no stored integrity chain.",
+        )
+    else:
+        status: AuditIntegrityStatus = (
+            "verified_with_legacy_anchor" if legacy_entries else "verified"
+        )
+        result = AuditIntegrityResult(
+            ok=True,
+            status=status,
+            entries_checked=entries_checked,
+            legacy_entries=legacy_entries,
+            head_hash=stored_head,
+            message=(
+                "The native chain commits the canonical legacy prefix and all native entries."
+                if legacy_entries
+                else "Every audit entry is covered by the native integrity chain."
+            ),
+        )
+    return _AuditScan(
+        result,
+        tuple(entries),
+        rolling_hash,
+        event_count + 1,
+        parse_errors,
+        native_entries,
+    )
 
 
 class AuditLog:
@@ -52,31 +438,71 @@ class AuditLog:
         self._estimated_input_tokens: int = 0
         self._estimated_output_tokens: int = 0
         self._timestamps: list[str] = []
+        self._append_hash = _GENESIS_HASH
+        self._next_sequence = 1
+        self._legacy_entries = 0
+        self._native_entries = 0
+        self._append_blocked_reason: str | None = None
+        self._file_fingerprint: tuple[int, int, int, int] | None = None
         self._load_existing()
+
+    def _reset_indexes(self) -> None:
+        """Reset derived state before reloading a file changed by another writer."""
+        self._tool_call_ids.clear()
+        self._tool_calls.clear()
+        self._finding_entries.clear()
+        self._total_tool_calls = 0
+        self._total_findings = 0
+        self._total_duration_ms = 0.0
+        self._tool_call_counts.clear()
+        self._tool_durations.clear()
+        self._estimated_input_tokens = 0
+        self._estimated_output_tokens = 0
+        self._timestamps.clear()
+
+    def _fingerprint(self) -> tuple[int, int, int, int] | None:
+        try:
+            stat = self._log_path.stat()
+        except FileNotFoundError:
+            return None
+        return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
     def _load_existing(self) -> None:
         """Populate in-memory indexes from an existing JSONL file."""
-        if not self._log_path.exists():
-            return
-        parse_errors = 0
-        with open(self._log_path) as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    parse_errors += 1
-                    continue
-                if isinstance(entry, dict):
-                    self._index_entry(cast(dict[str, object], entry))
-        if parse_errors > 0:
+        scan = _scan_audit_file(self._log_path)
+        self._append_hash = scan.append_hash
+        self._next_sequence = scan.next_sequence
+        self._legacy_entries = scan.result.legacy_entries
+        self._native_entries = scan.native_entries
+        self._append_blocked_reason = None if scan.result.ok else scan.result.message
+        for entry in scan.entries:
+            self._index_entry(entry)
+        if scan.parse_errors > 0:
             logger.warning(
                 "Audit log %s: %d lines failed to parse (possible corruption)",
                 self._log_path,
-                parse_errors,
+                scan.parse_errors,
             )
+        if not scan.result.ok:
+            logger.warning(
+                "Audit log %s failed integrity verification at line %s: %s",
+                self._log_path,
+                scan.result.first_error_line,
+                scan.result.message,
+            )
+        self._file_fingerprint = self._fingerprint()
+
+    def verify_integrity(self) -> AuditIntegrityResult:
+        """Verify the complete file and return the first broken-link diagnostic.
+
+        This method never mutates or repairs the log.  ``legacy_unverified`` is
+        a compatibility state, not a cryptographic success.  Once a native
+        event is appended to a legacy log, its first link canonically commits
+        the entire parseable legacy prefix as it exists at that transition.
+        Detecting removal of a complete final suffix requires an external head
+        commitment or sealed case manifest and is deliberately out of scope.
+        """
+        return _scan_audit_file(self._log_path).result
 
     def _index_entry(self, entry: dict[str, object]) -> None:
         """Index a parsed audit entry by type and update summary accumulators."""
@@ -115,11 +541,53 @@ class AuditLog:
         """Append ``entry`` to the JSONL log file and update in-memory indexes."""
         with self._lock:
             self._log_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self._log_path, "a") as fh:
-                fh.write(json.dumps(entry, separators=(",", ":")) + "\n")
-                fh.flush()
-                os.fsync(fh.fileno())
-            self._index_entry(entry)
+            with open(self._log_path, "a+", encoding="utf-8") as fh:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                try:
+                    if self._fingerprint() != self._file_fingerprint:
+                        self._reset_indexes()
+                        self._load_existing()
+                    if self._append_blocked_reason is not None:
+                        raise RuntimeError(
+                            "Refusing to append to an invalid audit log: "
+                            f"{self._append_blocked_reason}"
+                        )
+                    reserved = _CHAIN_FIELDS.intersection(entry)
+                    if reserved:
+                        raise ValueError(
+                            f"Audit event may not set reserved chain fields: {sorted(reserved)}"
+                        )
+
+                    chained_entry = dict(entry)
+                    chained_entry.update(
+                        {
+                            "schema": _AUDIT_SCHEMA,
+                            "version": _AUDIT_VERSION,
+                            "sequence": self._next_sequence,
+                            "previous_hash": self._append_hash,
+                        }
+                    )
+                    if self._native_entries == 0 and self._legacy_entries:
+                        chained_entry["legacy_prefix_entries"] = self._legacy_entries
+                    chained_entry["entry_hash"] = _entry_hash(chained_entry)
+                    serialized = _canonical_json(chained_entry).decode("utf-8")
+
+                    fh.write(serialized + "\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+                    self._append_hash = cast(str, chained_entry["entry_hash"])
+                    self._next_sequence += 1
+                    self._native_entries += 1
+                    self._index_entry(chained_entry)
+                    stat = os.fstat(fh.fileno())
+                    self._file_fingerprint = (
+                        stat.st_dev,
+                        stat.st_ino,
+                        stat.st_size,
+                        stat.st_mtime_ns,
+                    )
+                finally:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
 
     def log_tool_call(
         self,

--- a/src/mulder/cli.py
+++ b/src/mulder/cli.py
@@ -215,6 +215,104 @@ def report(case_id: str, db_dir: str) -> None:
     click.echo("Done.")
 
 
+@cli.command("seal-case")
+@click.argument("case_id")
+@click.option(
+    "--db-dir",
+    default=DEFAULT_DB_DIR,
+    show_default=True,
+    help="Directory containing the case database, audit log, and standard reports.",
+)
+@click.option(
+    "--manifest",
+    "manifest_path",
+    default=None,
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Output path. Defaults to DB_DIR/CASE_ID.manifest.json.",
+)
+@click.option(
+    "--artifact",
+    "artifacts",
+    multiple=True,
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Additional generated report/export artifact to bind; repeat as needed.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Replace an existing manifest after re-verifying every current artifact.",
+)
+def seal_case_cmd(
+    case_id: str,
+    db_dir: str,
+    manifest_path: Path | None,
+    artifacts: tuple[Path, ...],
+    force: bool,
+) -> None:
+    """Seal CASE_ID into a relocatable, unsigned case manifest.
+
+    This is a local operation. It reads the case database, audit log, original
+    evidence, and generated reports without starting MCP or calling a model.
+    """
+    from mulder.receipt import SealError, seal_case
+
+    try:
+        path = seal_case(
+            case_id,
+            Path(db_dir),
+            manifest_path=manifest_path,
+            report_artifacts=artifacts,
+            overwrite=force,
+        )
+    except (OSError, SealError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"Sealed case manifest: {path}")
+    click.echo("Signature: unsigned (examiner-controlled signing is not enabled)")
+
+
+@cli.command("verify-case")
+@click.argument(
+    "manifest_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+)
+@click.option(
+    "--evidence-root",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Relocated evidence root; otherwise the manifest's relative locator is used.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit machine-readable JSON.")
+def verify_case_cmd(
+    manifest_path: Path,
+    evidence_root: Path | None,
+    json_output: bool,
+) -> None:
+    """Verify MANIFEST_PATH entirely offline.
+
+    Exit status is 0 for a fully verified native case, 2 for intact but
+    cryptographically unverified legacy material, 3 for an unsupported
+    manifest schema, and 1 for corruption, mutation, or missing artifacts.
+    """
+    import json
+
+    from mulder.receipt import format_verification_result, verify_case
+
+    result = verify_case(manifest_path, evidence_root=evidence_root)
+    if json_output:
+        click.echo(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        click.echo(format_verification_result(result))
+
+    exit_code = {
+        "verified": 0,
+        "legacy_unverified": 2,
+        "unsupported_manifest": 3,
+        "invalid": 1,
+    }[result.status]
+    if exit_code:
+        raise click.exceptions.Exit(exit_code)
+
+
 @cli.command()
 @click.argument("evidence_path")
 @click.argument("case_id")

--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -8,11 +8,13 @@ import logging
 import queue
 import re
 import threading
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypedDict, TypeVar, cast
+from uuid import uuid4
 
 from sqlalchemy import (
     Column,
@@ -35,7 +37,15 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.pool import NullPool
 
-from mulder.models import CaseMetadataRow, Finding, SourceRow, WindowRow
+from mulder.models import (
+    AtomicClaim,
+    AtomicClaimInput,
+    CaseMetadataRow,
+    EvidenceAnchor,
+    Finding,
+    SourceRow,
+    WindowRow,
+)
 
 _T = TypeVar("_T")
 
@@ -93,6 +103,55 @@ findings_t = Table(
     Column("event_time_start", Text),
     Column("event_time_end", Text),
     Column("submitted_at", Text, nullable=False),
+)
+
+claims_t = Table(
+    "claims",
+    metadata,
+    Column("claim_id", Text, primary_key=True),
+    Column(
+        "finding_id",
+        Text,
+        ForeignKey("findings.finding_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("ordinal", Integer, nullable=False),
+    Column("statement", Text, nullable=False),
+    Column("subject", Text, nullable=False),
+    Column("predicate", Text, nullable=False),
+    Column("object_value", Text, nullable=False),
+    Column("qualifiers", Text, nullable=False),
+    Column("epistemic_state", Text, nullable=False),
+)
+
+evidence_anchors_t = Table(
+    "evidence_anchors",
+    metadata,
+    Column("anchor_id", Text, primary_key=True),
+    Column(
+        "claim_id",
+        Text,
+        ForeignKey("claims.claim_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    ),
+    Column("tool_call_id", Text, nullable=False, index=True),
+    Column("source_id", Integer, ForeignKey("sources.source_id"), nullable=False, index=True),
+    Column("source_name", Text, nullable=False),
+    Column("source_hash", Text, nullable=False),
+    Column("window_id", Integer, ForeignKey("windows.window_id"), nullable=False, index=True),
+    Column("line_start", Integer, nullable=False),
+    Column("line_end", Integer, nullable=False),
+    Column("char_start", Integer, nullable=False),
+    Column("char_end", Integer, nullable=False),
+    Column("exact_text", Text, nullable=False),
+    Column("artifact_family", Text, nullable=False),
+    Column("extractor_family", Text, nullable=False),
+    Column("independence_key", Text, nullable=False, index=True),
+    Column("value_type", Text, nullable=False),
+    Column("normalized_value", Text, nullable=False),
+    Column("role", Text, nullable=False),
 )
 
 evidence_registry_t = Table(
@@ -294,6 +353,12 @@ def _migrate_add_kv_store(conn: Connection) -> None:
     )
 
 
+def _migrate_add_claim_tables(conn: Connection) -> None:
+    """Create additive atomic-claim tables for databases from older releases."""
+    claims_t.create(conn, checkfirst=True)
+    evidence_anchors_t.create(conn, checkfirst=True)
+
+
 _SENTINEL = object()
 
 
@@ -444,6 +509,7 @@ class CaseDB:
             _migrate_add_bookmarks(conn)
             _migrate_add_progress(conn)
             _migrate_add_kv_store(conn)
+            _migrate_add_claim_tables(conn)
         return db
 
     def close(self) -> None:
@@ -958,11 +1024,21 @@ class CaseDB:
 
         self._wq.submit(_do_update)
 
-    def insert_finding(self, finding: Finding) -> None:
-        """Persist a Finding to the database."""
+    def insert_finding(
+        self,
+        finding: Finding,
+        claims: list[AtomicClaimInput] | None = None,
+    ) -> list[AtomicClaim]:
+        """Persist a finding and optional atomic claims in one transaction.
 
-        def _do_insert() -> None:
-            """Persist a single finding row."""
+        Exact evidence text and provenance are resolved from the case database;
+        callers cannot inject source hashes or independence keys.  If an anchor
+        is stale, out of bounds, or does not match its expected text, the whole
+        write is rejected and no finding row is committed.
+        """
+
+        def _do_insert() -> list[AtomicClaim]:
+            """Persist a finding and its claim graph atomically."""
             with self._engine.begin() as conn:
                 conn.execute(
                     insert(findings_t).values(
@@ -981,7 +1057,194 @@ class CaseDB:
                     )
                 )
 
-        self._wq.submit(_do_insert)
+                stored: list[AtomicClaim] = []
+                resolved_source_names: set[str] = set()
+                for ordinal, claim_input in enumerate(claims or []):
+                    claim_id = f"c_{uuid4().hex[:12]}"
+                    claim = AtomicClaim(
+                        claim_id=claim_id,
+                        finding_id=finding.finding_id,
+                        ordinal=ordinal,
+                        statement=claim_input.statement,
+                        subject=claim_input.subject,
+                        predicate=claim_input.predicate,
+                        object_value=claim_input.object_value,
+                        qualifiers=claim_input.qualifiers,
+                        epistemic_state="unverified",
+                        anchors=[],
+                    )
+                    conn.execute(
+                        insert(claims_t).values(
+                            claim_id=claim.claim_id,
+                            finding_id=claim.finding_id,
+                            ordinal=claim.ordinal,
+                            statement=claim.statement,
+                            subject=claim.subject,
+                            predicate=claim.predicate,
+                            object_value=json.dumps(claim.object_value),
+                            qualifiers=json.dumps(claim.qualifiers),
+                            epistemic_state=claim.epistemic_state,
+                        )
+                    )
+
+                    resolved_anchors: list[EvidenceAnchor] = []
+                    for anchor_input in claim_input.anchors:
+                        row = conn.execute(
+                            select(
+                                windows_t.c.window_id,
+                                windows_t.c.source_id,
+                                windows_t.c.line_start,
+                                windows_t.c.line_end,
+                                windows_t.c.raw_text,
+                                sources_t.c.source_name,
+                                sources_t.c.source_hash,
+                                sources_t.c.extractor,
+                            )
+                            .select_from(
+                                windows_t.join(
+                                    sources_t,
+                                    windows_t.c.source_id == sources_t.c.source_id,
+                                )
+                            )
+                            .where(windows_t.c.window_id == anchor_input.window_id)
+                        ).fetchone()
+                        if row is None:
+                            raise ValueError(
+                                "Evidence anchor window_id "
+                                f"{anchor_input.window_id} does not exist"
+                            )
+                        raw_text = str(row.raw_text)
+                        if anchor_input.char_end > len(raw_text):
+                            raise ValueError(
+                                "Evidence anchor character range is outside window "
+                                f"{anchor_input.window_id} (length {len(raw_text)})"
+                            )
+                        exact_text = raw_text[
+                            anchor_input.char_start : anchor_input.char_end
+                        ]
+                        if exact_text != anchor_input.expected_text:
+                            raise ValueError(
+                                "Evidence anchor text does not match the immutable window at "
+                                f"{anchor_input.window_id}:{anchor_input.char_start}-"
+                                f"{anchor_input.char_end}"
+                            )
+
+                        extractor = str(row.extractor)
+                        source_hash = str(row.source_hash)
+                        anchor = EvidenceAnchor(
+                            anchor_id=f"a_{uuid4().hex[:12]}",
+                            claim_id=claim_id,
+                            tool_call_id=anchor_input.tool_call_id,
+                            source_id=int(row.source_id),
+                            source_name=str(row.source_name),
+                            source_hash=source_hash,
+                            window_id=int(row.window_id),
+                            line_start=int(row.line_start),
+                            line_end=int(row.line_end),
+                            char_start=anchor_input.char_start,
+                            char_end=anchor_input.char_end,
+                            exact_text=exact_text,
+                            artifact_family=anchor_input.artifact_family or extractor,
+                            extractor_family=extractor,
+                            independence_key=f"source:{source_hash}",
+                            value_type=anchor_input.value_type,
+                            normalized_value=anchor_input.normalized_value,
+                            role=anchor_input.role,
+                        )
+                        resolved_source_names.add(anchor.source_name)
+                        conn.execute(
+                            insert(evidence_anchors_t).values(
+                                anchor_id=anchor.anchor_id,
+                                claim_id=anchor.claim_id,
+                                tool_call_id=anchor.tool_call_id,
+                                source_id=anchor.source_id,
+                                source_name=anchor.source_name,
+                                source_hash=anchor.source_hash,
+                                window_id=anchor.window_id,
+                                line_start=anchor.line_start,
+                                line_end=anchor.line_end,
+                                char_start=anchor.char_start,
+                                char_end=anchor.char_end,
+                                exact_text=anchor.exact_text,
+                                artifact_family=anchor.artifact_family,
+                                extractor_family=anchor.extractor_family,
+                                independence_key=anchor.independence_key,
+                                value_type=anchor.value_type,
+                                normalized_value=json.dumps(anchor.normalized_value),
+                                role=anchor.role,
+                            )
+                        )
+                        resolved_anchors.append(anchor)
+                    stored.append(claim.model_copy(update={"anchors": resolved_anchors}))
+                if stored:
+                    conn.execute(
+                        update(findings_t)
+                        .where(findings_t.c.finding_id == finding.finding_id)
+                        .values(sources=json.dumps(sorted(resolved_source_names)))
+                    )
+                return stored
+
+        return self._wq.submit(_do_insert)
+
+    def get_claims(self, finding_id: str) -> list[AtomicClaim]:
+        """Return a finding's atomic claims with exact anchors, in stable order."""
+        with self._engine.connect() as conn:
+            claim_rows = conn.execute(
+                select(claims_t)
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(claims_t.c.ordinal, claims_t.c.claim_id)
+            ).fetchall()
+            anchor_rows = conn.execute(
+                select(evidence_anchors_t)
+                .select_from(
+                    evidence_anchors_t.join(
+                        claims_t, evidence_anchors_t.c.claim_id == claims_t.c.claim_id
+                    )
+                )
+                .where(claims_t.c.finding_id == finding_id)
+                .order_by(evidence_anchors_t.c.anchor_id)
+            ).fetchall()
+
+        by_claim: dict[str, list[EvidenceAnchor]] = defaultdict(list)
+        for row in anchor_rows:
+            by_claim[row.claim_id].append(
+                EvidenceAnchor(
+                    anchor_id=row.anchor_id,
+                    claim_id=row.claim_id,
+                    tool_call_id=row.tool_call_id,
+                    source_id=row.source_id,
+                    source_name=row.source_name,
+                    source_hash=row.source_hash,
+                    window_id=row.window_id,
+                    line_start=row.line_start,
+                    line_end=row.line_end,
+                    char_start=row.char_start,
+                    char_end=row.char_end,
+                    exact_text=row.exact_text,
+                    artifact_family=row.artifact_family,
+                    extractor_family=row.extractor_family,
+                    independence_key=row.independence_key,
+                    value_type=row.value_type,
+                    normalized_value=json.loads(row.normalized_value),
+                    role=row.role,
+                )
+            )
+
+        return [
+            AtomicClaim(
+                claim_id=row.claim_id,
+                finding_id=row.finding_id,
+                ordinal=row.ordinal,
+                statement=row.statement,
+                subject=row.subject,
+                predicate=row.predicate,
+                object_value=json.loads(row.object_value),
+                qualifiers=json.loads(row.qualifiers),
+                epistemic_state=row.epistemic_state,
+                anchors=by_claim[row.claim_id],
+            )
+            for row in claim_rows
+        ]
 
     def update_finding(self, finding_id: str, **kwargs: object) -> bool:
         """Update fields on an existing finding. Returns True if found.

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -2,9 +2,91 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
+
+
+class ToolOutcomeStatus(str, Enum):
+    """Machine-readable execution state for a forensic tool result.
+
+    The legacy MCP response ``status`` remains ``success`` or ``error`` for
+    backwards compatibility.  This enum carries the more precise state needed
+    to decide what conclusions the result can support.
+    """
+
+    SUCCESS_NONEMPTY = "SUCCESS_NONEMPTY"
+    SUCCESS_EMPTY = "SUCCESS_EMPTY"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    UNAVAILABLE = "UNAVAILABLE"
+    UNSUPPORTED_VERSION = "UNSUPPORTED_VERSION"
+    FAILED = "FAILED"
+    TIMED_OUT = "TIMED_OUT"
+    PARTIAL = "PARTIAL"
+    SAMPLED = "SAMPLED"
+
+
+class FallbackAttempt(BaseModel):
+    """One earlier adapter attempt retained when a fallback produced a result."""
+
+    adapter: str
+    status: ToolOutcomeStatus
+    reason: str | None = None
+    tool_version: str | None = None
+    parser_version: str | None = None
+
+
+class CoverageMetadata(BaseModel):
+    """Structured scope and implementation provenance for a tool outcome.
+
+    ``examined`` values describe content successfully examined, rather than
+    content merely discovered or attempted.  Unknown values stay ``None``;
+    callers must not turn an unknown total into an implicit complete result.
+    """
+
+    bytes_examined: int | None = Field(default=None, ge=0)
+    bytes_total: int | None = Field(default=None, ge=0)
+    rows_examined: int | None = Field(default=None, ge=0)
+    rows_total: int | None = Field(default=None, ge=0)
+    truncation_reason: str | None = None
+    sample_reason: str | None = None
+    tool_version: str | None = None
+    parser_version: str | None = None
+    fallback_lineage: list[FallbackAttempt] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _check_scope_bounds(self) -> CoverageMetadata:
+        """Reject coverage that claims to examine more than the known total."""
+        if (
+            self.bytes_examined is not None
+            and self.bytes_total is not None
+            and self.bytes_examined > self.bytes_total
+        ):
+            raise ValueError("bytes_examined cannot exceed bytes_total")
+        if (
+            self.rows_examined is not None
+            and self.rows_total is not None
+            and self.rows_examined > self.rows_total
+        ):
+            raise ValueError("rows_examined cannot exceed rows_total")
+        return self
+
+
+class ToolOutcome(BaseModel):
+    """Versioned, serializable execution semantics for an MCP tool response."""
+
+    schema_version: Literal[1] = 1
+    status: ToolOutcomeStatus
+    coverage: CoverageMetadata = Field(default_factory=CoverageMetadata)
+    reason: str | None = None
+
+    @model_validator(mode="after")
+    def _check_status_metadata(self) -> ToolOutcome:
+        """Require the scope explanation that makes sampled results auditable."""
+        if self.status is ToolOutcomeStatus.SAMPLED and not self.coverage.sample_reason:
+            raise ValueError("SAMPLED outcomes require coverage.sample_reason")
+        return self
 
 
 class WindowRow(BaseModel):

--- a/src/mulder/models.py
+++ b/src/mulder/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -88,6 +88,8 @@ class ToolOutcome(BaseModel):
             raise ValueError("SAMPLED outcomes require coverage.sample_reason")
         return self
 
+JsonScalar: TypeAlias = str | int | float | bool | None
+
 
 class WindowRow(BaseModel):
     """A single windowed slice of evidence text from an indexed source."""
@@ -145,6 +147,83 @@ class Finding(BaseModel):
         if not self.evidence_refs:
             raise ValueError("evidence_refs must contain at least one tool_call_id")
         return self
+
+
+class EvidenceAnchorInput(BaseModel):
+    """Caller-supplied locator for an exact quote in an evidence window.
+
+    The caller identifies a previously returned window and the exact character
+    range it is relying on.  Source identity, hashes, extractor family, and the
+    independence key are resolved by :class:`CaseDB`; callers cannot assert
+    those provenance fields themselves.
+    """
+
+    tool_call_id: str = Field(min_length=1)
+    window_id: int = Field(gt=0)
+    char_start: int = Field(ge=0)
+    char_end: int = Field(gt=0)
+    expected_text: str = Field(min_length=1)
+    artifact_family: str | None = None
+    value_type: str = "text"
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+    @model_validator(mode="after")
+    def _check_character_range(self) -> EvidenceAnchorInput:
+        if self.char_end <= self.char_start:
+            raise ValueError("char_end must be greater than char_start")
+        return self
+
+
+class AtomicClaimInput(BaseModel):
+    """A material statement and the exact evidence anchors offered for it."""
+
+    statement: str = Field(min_length=1)
+    subject: str = Field(min_length=1)
+    predicate: str = Field(min_length=1)
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    anchors: list[EvidenceAnchorInput] = Field(min_length=1)
+
+
+class EvidenceAnchor(BaseModel):
+    """Server-resolved immutable evidence locator for an atomic claim."""
+
+    anchor_id: str
+    claim_id: str
+    tool_call_id: str
+    source_id: int
+    source_name: str
+    source_hash: str
+    window_id: int
+    line_start: int
+    line_end: int
+    char_start: int
+    char_end: int
+    exact_text: str
+    artifact_family: str
+    extractor_family: str
+    independence_key: str
+    value_type: str
+    normalized_value: JsonScalar = None
+    role: Literal["supports", "contradicts"] = "supports"
+
+
+class AtomicClaim(BaseModel):
+    """Persisted atomic finding statement with resolved evidence anchors."""
+
+    claim_id: str
+    finding_id: str
+    ordinal: int = Field(ge=0)
+    statement: str
+    subject: str
+    predicate: str
+    object_value: JsonScalar
+    qualifiers: dict[str, JsonScalar] = Field(default_factory=dict)
+    epistemic_state: Literal[
+        "legacy_unverified", "unverified", "verified", "contradicted", "inconclusive"
+    ] = "unverified"
+    anchors: list[EvidenceAnchor] = Field(default_factory=list)
 
 
 class ToolCallEntry(BaseModel):

--- a/src/mulder/path_policy.py
+++ b/src/mulder/path_policy.py
@@ -1,0 +1,61 @@
+"""Resolved filesystem path-containment policy.
+
+The interface deliberately returns the authorized, resolved path.  Callers must
+use that path for the subsequent filesystem operation so a symlink is not
+authorized by its destination and then accessed again through its original
+name.
+
+Resolution falls back to non-strict mode only when a path does not exist, which
+preserves support for probing missing paths without treating other resolution
+errors as safe.  A missing path is allowed only when its prospective resolved
+location is inside an allowed root.  Existing symlinks (including an existing
+prefix of a non-existent path) are followed, so a symlink whose destination
+escapes every allowed root is denied.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+
+class PathPolicyError(ValueError):
+    """Raised when a path cannot be safely resolved inside an allowed root."""
+
+
+def _resolve(path: Path) -> Path:
+    """Resolve *path*, permitting absence but rejecting other resolution errors."""
+    try:
+        return path.resolve(strict=True)
+    except FileNotFoundError:
+        return path.resolve(strict=False)
+
+
+def resolve_allowed_path(target: Path, allowed_roots: Iterable[Path]) -> Path:
+    """Return *target* resolved inside one of *allowed_roots*.
+
+    Resolution makes containment path-component aware, collapses ``..``,
+    follows existing symlinks, and retains the previous behavior for
+    non-existent paths.  Symlink loops and other resolution failures are
+    denied.
+
+    Raises:
+        PathPolicyError: If resolution fails or the target is outside every
+            allowed root.
+    """
+    try:
+        resolved_target = _resolve(target)
+    except (OSError, RuntimeError) as exc:
+        raise PathPolicyError(f"Cannot resolve path: {target}") from exc
+
+    resolved_roots: list[Path] = []
+    for root in allowed_roots:
+        try:
+            resolved_roots.append(_resolve(root))
+        except (OSError, RuntimeError) as exc:
+            raise PathPolicyError(f"Cannot resolve allowed root: {root}") from exc
+
+    if any(resolved_target.is_relative_to(root) for root in resolved_roots):
+        return resolved_target
+
+    raise PathPolicyError("Access denied: path is outside allowed directories")

--- a/src/mulder/receipt.py
+++ b/src/mulder/receipt.py
@@ -1,0 +1,1350 @@
+"""Portable, offline-verifiable case manifests.
+
+The manifest is deliberately a receipt, not a signature.  It commits every
+artifact needed to review a case and carries an explicit ``unsigned`` marker;
+examiner-controlled signing is a separate layer.  Paths are stored relative to
+the manifest so a case directory can be moved without invalidating it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, cast
+
+from mulder import __version__
+from mulder.audit import AuditIntegrityResult, AuditLog
+
+MANIFEST_SCHEMA = "mulder.case-manifest"
+MANIFEST_VERSION = 1
+SQLITE_LOGICAL_PROFILE = "sqlite-logical-v1"
+
+VerificationStatus = Literal["verified", "legacy_unverified", "invalid", "unsupported_manifest"]
+DiagnosticSeverity = Literal["error", "warning"]
+SignatureStatus = Literal["unsigned", "unknown"]
+
+_STANDARD_ARTIFACT_SUFFIXES = (
+    ".report.md",
+    ".report.html",
+    ".report.pdf",
+    ".model_usage.json",
+    ".iocs.csv",
+    ".iocs.stix.json",
+    ".navigator.json",
+)
+
+
+class SealError(ValueError):
+    """Raised when current case state cannot be sealed consistently."""
+
+
+@dataclass(frozen=True)
+class VerificationDiagnostic:
+    """One precise problem or trust limitation found by ``verify_case``."""
+
+    code: str
+    severity: DiagnosticSeverity
+    subject: str
+    message: str
+    expected: object | None = None
+    actual: object | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-safe diagnostic dictionary."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class CaseVerificationResult:
+    """Complete result of an offline case-manifest verification."""
+
+    status: VerificationStatus
+    manifest_path: str
+    case_id: str | None
+    artifacts_checked: int
+    diagnostics: tuple[VerificationDiagnostic, ...]
+    signature_status: SignatureStatus = "unknown"
+
+    @property
+    def ok(self) -> bool:
+        """Whether every committed artifact and the audit chain verified."""
+        return self.status == "verified"
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a stable machine-readable representation."""
+        return {
+            "status": self.status,
+            "manifest_path": self.manifest_path,
+            "case_id": self.case_id,
+            "artifacts_checked": self.artifacts_checked,
+            "signature_status": self.signature_status,
+            "diagnostics": [diagnostic.as_dict() for diagnostic in self.diagnostics],
+        }
+
+
+@dataclass(frozen=True)
+class _DatabaseSnapshot:
+    case_id: str
+    ingested_at: str
+    evidence_root: str
+    extractor_versions: dict[str, str]
+    registry_status: Literal["present", "legacy_absent"]
+    evidence_registry: tuple[dict[str, object], ...]
+    normalized_sources: tuple[dict[str, object], ...]
+    logical_digest: str
+    schema_objects: tuple[dict[str, object], ...]
+    tables: tuple[dict[str, object], ...]
+
+
+def _canonical_json(value: object) -> bytes:
+    """Encode JSON in the stable representation used for commitments."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _reject_json_constant(value: str) -> object:
+    """Reject the non-standard NaN/Infinity tokens accepted by ``json``."""
+    raise ValueError(f"non-finite JSON number is not permitted: {value}")
+
+
+def _unique_json_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """Reject duplicate keys instead of silently choosing the final value."""
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key is not permitted: {key!r}")
+        result[key] = value
+    return result
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> tuple[str, int]:
+    """Return a full-content digest and size from one opened regular file."""
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        opened = os.fstat(handle.fileno())
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError(f"not a regular file: {path}")
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return "sha256:" + digest.hexdigest(), size
+
+
+def _stored_sha256(value: object) -> str | None:
+    """Normalize the historical bare SHA-256 registry format."""
+    if not isinstance(value, str):
+        return None
+    lowered = value.lower()
+    if lowered.startswith("sha256:"):
+        lowered = lowered[7:]
+    if len(lowered) != 64 or any(char not in "0123456789abcdef" for char in lowered):
+        return None
+    return "sha256:" + lowered
+
+
+def _sqlite_value(value: object) -> dict[str, object]:
+    """Losslessly tag one SQLite value for canonical hashing."""
+    if value is None:
+        return {"type": "null"}
+    if isinstance(value, bytes):
+        return {"type": "blob", "value": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, str):
+        return {"type": "text", "value": value}
+    if isinstance(value, int):
+        return {"type": "integer", "value": str(value)}
+    if isinstance(value, float):
+        return {"type": "real", "value": value.hex()}
+    raise TypeError(f"unsupported SQLite value type: {type(value).__name__}")
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _table_commitment(
+    connection: sqlite3.Connection,
+    name: str,
+    schema_sql: str | None,
+) -> dict[str, object]:
+    """Commit a table schema and all rows in deterministic value order."""
+    quoted = _quote_identifier(name)
+    columns_raw = connection.execute(f"PRAGMA table_xinfo({quoted})").fetchall()
+    columns = [
+        {
+            "cid": row[0],
+            "name": row[1],
+            "type": row[2],
+            "notnull": row[3],
+            "default": row[4],
+            "pk": row[5],
+            "hidden": row[6],
+        }
+        for row in columns_raw
+    ]
+    readable = [cast(str, row[1]) for row in columns_raw if row[6] in (0, 2, 3)]
+    table_header = {
+        "name": name,
+        "schema_sql": schema_sql,
+        "columns": columns,
+    }
+    schema_digest = _sha256_bytes(_canonical_json(table_header))
+    content = hashlib.sha256()
+    content.update(b"mulder.sqlite-logical:v1:table\0")
+    content.update(_canonical_json(table_header))
+    content.update(b"\n")
+
+    row_count = 0
+    if readable:
+        projection = ", ".join(_quote_identifier(column) for column in readable)
+        # Ordering by every projected value gives rowid-independent output.  Equal
+        # rows have identical encodings, so their relative order is immaterial.
+        ordering = ", ".join(_quote_identifier(column) for column in readable)
+        cursor = connection.execute(f"SELECT {projection} FROM {quoted} ORDER BY {ordering}")
+        for row in cursor:
+            encoded = [_sqlite_value(value) for value in row]
+            content.update(_canonical_json(encoded))
+            content.update(b"\n")
+            row_count += 1
+
+    return {
+        "name": name,
+        "schema_digest": schema_digest,
+        "content_digest": "sha256:" + content.hexdigest(),
+        "row_count": row_count,
+    }
+
+
+def _connect_read_only(path: Path) -> sqlite3.Connection:
+    """Open SQLite without creating or migrating a database."""
+    uri = path.resolve().as_uri() + "?mode=ro"
+    connection = sqlite3.connect(uri, uri=True, timeout=5.0)
+    connection.execute("PRAGMA query_only=ON")
+    return connection
+
+
+def _snapshot_database(path: Path) -> _DatabaseSnapshot:
+    """Capture one read transaction over metadata and every logical DB table."""
+    try:
+        connection = _connect_read_only(path)
+    except sqlite3.Error as exc:
+        raise SealError(f"Cannot open case database read-only: {path}: {exc}") from exc
+
+    try:
+        connection.execute("BEGIN")
+        schema_rows = connection.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_schema "
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name, tbl_name"
+        ).fetchall()
+        schema_objects = tuple(
+            {
+                "type": row[0],
+                "name": row[1],
+                "table": row[2],
+                "sql": row[3],
+            }
+            for row in schema_rows
+        )
+        table_rows = [(row[1], row[3]) for row in schema_rows if row[0] == "table"]
+        table_names = {cast(str, row[0]) for row in table_rows}
+        if "case_metadata" not in table_names:
+            raise SealError("Database is not a Mulder case: case_metadata table is absent")
+
+        metadata_row = connection.execute(
+            "SELECT case_id, ingested_at, evidence_root, extractor_versions "
+            "FROM case_metadata LIMIT 1"
+        ).fetchone()
+        if metadata_row is None:
+            raise SealError("Database is not a Mulder case: case metadata is empty")
+        if not all(isinstance(metadata_row[index], str) for index in range(3)):
+            raise SealError(
+                "Case metadata contains a non-text case ID, timestamp, or evidence root"
+            )
+        try:
+            extractor_versions_raw = json.loads(cast(str, metadata_row[3]))
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise SealError("Case extractor_versions is not valid JSON") from exc
+        if not isinstance(extractor_versions_raw, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in extractor_versions_raw.items()
+        ):
+            raise SealError("Case extractor_versions must be a string-to-string object")
+        extractor_versions = cast(dict[str, str], extractor_versions_raw)
+
+        registry: list[dict[str, object]] = []
+        registry_status: Literal["present", "legacy_absent"] = "legacy_absent"
+        if "evidence_registry" in table_names:
+            registry_status = "present"
+            registry_rows = connection.execute(
+                "SELECT id, file_path, sha256, size_bytes, registered_at "
+                "FROM evidence_registry ORDER BY id"
+            ).fetchall()
+            registry = [
+                {
+                    "registry_id": row[0],
+                    "original_path": row[1],
+                    "sha256": row[2],
+                    "size_bytes": row[3],
+                    "registered_at": row[4],
+                }
+                for row in registry_rows
+            ]
+
+        normalized_sources: list[dict[str, object]] = []
+        if "sources" in table_names:
+            source_columns = {
+                cast(str, row[1])
+                for row in connection.execute('PRAGMA table_xinfo("sources")').fetchall()
+            }
+            windows_expr = "windows_hash" if "windows_hash" in source_columns else "NULL"
+            source_rows = connection.execute(
+                "SELECT source_id, source_name, source_hash, extractor, line_count, "
+                f"{windows_expr} FROM sources ORDER BY source_id"
+            ).fetchall()
+            normalized_sources = [
+                {
+                    "source_id": row[0],
+                    "source_name": row[1],
+                    "source_hash": row[2],
+                    "extractor": row[3],
+                    "line_count": row[4],
+                    "windows_hash": row[5],
+                }
+                for row in source_rows
+            ]
+
+        tables = tuple(
+            _table_commitment(connection, cast(str, name), cast(str | None, schema_sql))
+            for name, schema_sql in table_rows
+        )
+        logical = hashlib.sha256()
+        logical.update(b"mulder.sqlite-logical:v1:database\0")
+        for schema_object in schema_objects:
+            logical.update(_canonical_json(schema_object))
+            logical.update(b"\n")
+        for table in tables:
+            logical.update(_canonical_json(table))
+            logical.update(b"\n")
+        connection.rollback()
+        return _DatabaseSnapshot(
+            case_id=cast(str, metadata_row[0]),
+            ingested_at=cast(str, metadata_row[1]),
+            evidence_root=cast(str, metadata_row[2]),
+            extractor_versions=extractor_versions,
+            registry_status=registry_status,
+            evidence_registry=tuple(registry),
+            normalized_sources=tuple(normalized_sources),
+            logical_digest="sha256:" + logical.hexdigest(),
+            schema_objects=schema_objects,
+            tables=tables,
+        )
+    except SealError:
+        raise
+    except (sqlite3.Error, TypeError, ValueError) as exc:
+        raise SealError(f"Cannot snapshot case database {path}: {exc}") from exc
+    finally:
+        connection.close()
+
+
+def _portable_path(path: Path, manifest_parent: Path) -> str:
+    """Return a normalized relative locator, including sibling directories."""
+    return Path(os.path.relpath(path.resolve(strict=False), manifest_parent.resolve())).as_posix()
+
+
+def _relative_to(path: Path, root: Path) -> str | None:
+    try:
+        return path.resolve(strict=False).relative_to(root.resolve(strict=False)).as_posix()
+    except ValueError:
+        return None
+
+
+def _assert_quiescent_database(path: Path) -> None:
+    """Reject a live SQLite write journal that would be easy to omit from a copy."""
+    for suffix in ("-wal", "-journal"):
+        sidecar = Path(str(path) + suffix)
+        try:
+            size = sidecar.stat().st_size
+        except FileNotFoundError:
+            continue
+        if size:
+            raise SealError(
+                f"Case database is not quiescent ({sidecar.name} is non-empty); "
+                "stop the writer/checkpoint SQLite before sealing"
+            )
+
+
+def _stable_file_commitment(path: Path) -> tuple[str, int]:
+    """Hash a stable file snapshot, rejecting concurrent changes."""
+    for _attempt in range(3):
+        before = path.stat()
+        digest, size = _sha256_file(path)
+        after = path.stat()
+        fingerprint_before = (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns)
+        fingerprint_after = (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+        if fingerprint_before == fingerprint_after and size == after.st_size:
+            return digest, size
+    raise SealError(f"Artifact changed while it was being sealed: {path}")
+
+
+def _audit_commitment(path: Path) -> tuple[AuditIntegrityResult, str, int, dict[str, int]]:
+    """Capture a stable audit file, including its externally retained head."""
+    for _attempt in range(3):
+        first = AuditLog(path)
+        first_result = first.verify_integrity()
+        digest, size = _stable_file_commitment(path)
+        second = AuditLog(path)
+        second_result = second.verify_integrity()
+        second_digest, second_size = _stable_file_commitment(path)
+        if first_result == second_result and digest == second_digest and size == second_size:
+            if not first_result.ok:
+                raise SealError(
+                    "Cannot seal an invalid audit chain: "
+                    f"{first_result.error_code or 'invalid'}: {first_result.message}"
+                )
+            return first_result, digest, size, dict(first.summary().tool_call_counts)
+    raise SealError(f"Audit log changed while it was being sealed: {path}")
+
+
+def _manifest_hash(manifest: Mapping[str, object]) -> str:
+    """Hash the manifest with the self-referential field omitted."""
+    copy = dict(manifest)
+    integrity_raw = copy.get("integrity")
+    if isinstance(integrity_raw, dict):
+        integrity = dict(cast(dict[str, object], integrity_raw))
+        integrity.pop("manifest_hash", None)
+        copy["integrity"] = integrity
+    return _sha256_bytes(b"mulder.case-manifest:v1\0" + _canonical_json(copy))
+
+
+def _discover_reports(case_id: str, db_dir: Path) -> list[Path]:
+    """Find the standard report/export artifacts produced by Mulder's CLI."""
+    reports: list[Path] = []
+    for suffix in _STANDARD_ARTIFACT_SUFFIXES:
+        candidate = db_dir / f"{case_id}{suffix}"
+        if candidate.is_file():
+            reports.append(candidate)
+    return reports
+
+
+def _write_manifest(path: Path, manifest: Mapping[str, object], overwrite: bool) -> None:
+    """Atomically persist a completed manifest."""
+    if path.exists() and not overwrite:
+        raise SealError(f"Manifest already exists (pass --force to replace it): {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(manifest, handle, indent=2, sort_keys=True, ensure_ascii=False)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise
+
+
+def seal_case(
+    case_id: str,
+    db_dir: Path,
+    *,
+    manifest_path: Path | None = None,
+    report_artifacts: Sequence[Path] = (),
+    overwrite: bool = False,
+) -> Path:
+    """Create a versioned manifest binding one complete case snapshot.
+
+    Standard Mulder report/export files are discovered next to the case DB.
+    ``report_artifacts`` adds explicitly named artifacts outside that set.  The
+    command refuses stale registry entries and invalid audit chains so a newly
+    created receipt verifies at the moment it is written.
+    """
+    db_dir = Path(db_dir).expanduser().resolve(strict=False)
+    db_path = db_dir / f"{case_id}.db"
+    audit_path = db_dir / f"{case_id}.audit.jsonl"
+    output = (
+        Path(manifest_path).expanduser().resolve(strict=False)
+        if manifest_path is not None
+        else db_dir / f"{case_id}.manifest.json"
+    )
+    if not db_path.is_file():
+        raise SealError(f"Case database not found: {db_path}")
+    if not audit_path.is_file():
+        raise SealError(f"Case audit log not found: {audit_path}")
+
+    _assert_quiescent_database(db_path)
+    database = _snapshot_database(db_path)
+    _assert_quiescent_database(db_path)
+    if database.case_id != case_id:
+        raise SealError(
+            f"Case ID mismatch: requested {case_id!r}, database contains {database.case_id!r}"
+        )
+
+    evidence_root = Path(database.evidence_root).expanduser().resolve(strict=False)
+    evidence_root_kind = "file" if evidence_root.is_file() else "directory"
+    evidence_entries: list[dict[str, object]] = []
+    evidence_digests: dict[Path, tuple[str, int]] = {}
+    for registry_entry in database.evidence_registry:
+        registered_path = registry_entry["original_path"]
+        if not isinstance(registered_path, str) or not registered_path:
+            raise SealError(
+                f"Evidence registry entry {registry_entry['registry_id']} has no valid path"
+            )
+        original_path = Path(registered_path).expanduser()
+        actual_path = (
+            original_path if original_path.is_absolute() else evidence_root / original_path
+        ).resolve(strict=False)
+        if not actual_path.is_file():
+            raise SealError(f"Registered evidence artifact is missing: {original_path}")
+        expected_hash = _stored_sha256(registry_entry["sha256"])
+        if expected_hash is None:
+            raise SealError(
+                "Registered evidence artifact has an invalid SHA-256 value: "
+                f"{original_path}: {registry_entry['sha256']!r}"
+            )
+        commitment = evidence_digests.get(actual_path)
+        if commitment is None:
+            commitment = _stable_file_commitment(actual_path)
+            evidence_digests[actual_path] = commitment
+        actual_hash, actual_size = commitment
+        expected_size = registry_entry["size_bytes"]
+        if actual_hash != expected_hash or actual_size != expected_size:
+            raise SealError(
+                "Registered evidence artifact changed before sealing: "
+                f"{original_path} (expected {expected_hash}/{expected_size}, "
+                f"actual {actual_hash}/{actual_size})"
+            )
+        root_relative = _relative_to(actual_path, evidence_root)
+        evidence_entries.append(
+            {
+                **registry_entry,
+                "sha256": expected_hash,
+                "location": {
+                    "root": "evidence" if root_relative is not None else "manifest",
+                    "path": (
+                        root_relative
+                        if root_relative is not None
+                        else _portable_path(actual_path, output.parent)
+                    ),
+                },
+            }
+        )
+
+    audit_result, audit_hash, audit_size, tool_counts = _audit_commitment(audit_path)
+
+    reports: list[dict[str, object]] = []
+    candidates = [*_discover_reports(case_id, db_dir), *(Path(p) for p in report_artifacts)]
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve(strict=False)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if not resolved.is_file():
+            raise SealError(f"Report artifact not found: {candidate}")
+        digest, size = _stable_file_commitment(resolved)
+        reports.append(
+            {
+                "name": resolved.name,
+                "path": _portable_path(resolved, output.parent),
+                "sha256": digest,
+                "size_bytes": size,
+            }
+        )
+
+    table_by_name = {cast(str, table["name"]): table for table in database.tables}
+    record_sets: dict[str, object] = {}
+    for name in ("claims", "evidence_anchors"):
+        table = table_by_name.get(name)
+        record_sets[name] = (
+            {
+                "status": "present",
+                "row_count": table["row_count"],
+                "content_digest": table["content_digest"],
+            }
+            if table is not None
+            else {"status": "absent_legacy"}
+        )
+
+    manifest: dict[str, object] = {
+        "schema": MANIFEST_SCHEMA,
+        "version": MANIFEST_VERSION,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "case": {
+            "case_id": database.case_id,
+            "ingested_at": database.ingested_at,
+        },
+        "locations": {
+            "manifest": {"path": ".", "kind": "directory"},
+            "evidence": {
+                "path": _portable_path(evidence_root, output.parent),
+                "kind": evidence_root_kind,
+                "original_path": database.evidence_root,
+            },
+        },
+        "database": {
+            "path": _portable_path(db_path, output.parent),
+            "profile": SQLITE_LOGICAL_PROFILE,
+            "logical_digest": database.logical_digest,
+            "schema_objects": list(database.schema_objects),
+            "tables": list(database.tables),
+            "record_sets": record_sets,
+            "normalized_sources": list(database.normalized_sources),
+        },
+        "evidence_registry": {
+            "status": database.registry_status,
+            "entries": evidence_entries,
+        },
+        "audit": {
+            "path": _portable_path(audit_path, output.parent),
+            "sha256": audit_hash,
+            "size_bytes": audit_size,
+            "chain_status": audit_result.status,
+            "entry_count": audit_result.entries_checked,
+            "legacy_entries": audit_result.legacy_entries,
+            "head_hash": audit_result.head_hash,
+        },
+        "methodology": {
+            "profile": "mulder-case-v1",
+            "mulder_version": __version__,
+            "extractor_versions": database.extractor_versions,
+            "audit_tool_counts": dict(sorted(tool_counts.items())),
+        },
+        "reports": reports,
+        "integrity": {
+            "algorithm": "sha256",
+            "signature": {"status": "unsigned"},
+        },
+    }
+    cast(dict[str, object], manifest["integrity"])["manifest_hash"] = _manifest_hash(manifest)
+    _write_manifest(output, manifest, overwrite)
+    return output
+
+
+def _diagnostic(
+    diagnostics: list[VerificationDiagnostic],
+    code: str,
+    subject: str,
+    message: str,
+    *,
+    severity: DiagnosticSeverity = "error",
+    expected: object | None = None,
+    actual: object | None = None,
+) -> None:
+    diagnostics.append(
+        VerificationDiagnostic(
+            code=code,
+            severity=severity,
+            subject=subject,
+            message=message,
+            expected=expected,
+            actual=actual,
+        )
+    )
+
+
+def _resolve_relative(parent: Path, value: object) -> Path:
+    if not isinstance(value, str) or not value:
+        raise ValueError("artifact path must be a non-empty string")
+    path = Path(value)
+    if path.is_absolute():
+        raise ValueError("artifact path must be relative to its declared root")
+    return (parent / path).resolve(strict=False)
+
+
+def _verify_file(
+    *,
+    path: Path,
+    expected_hash: object,
+    expected_size: object,
+    subject: str,
+    code_prefix: str,
+    diagnostics: list[VerificationDiagnostic],
+) -> bool:
+    if not path.exists():
+        _diagnostic(
+            diagnostics,
+            f"{code_prefix}.missing",
+            subject,
+            f"Committed artifact is missing: {path}",
+            expected=str(path),
+            actual=None,
+        )
+        return False
+    if not path.is_file():
+        _diagnostic(
+            diagnostics,
+            f"{code_prefix}.not_regular_file",
+            subject,
+            f"Committed artifact is not a regular file: {path}",
+        )
+        return False
+    try:
+        actual_hash, actual_size = _sha256_file(path)
+    except OSError as exc:
+        _diagnostic(
+            diagnostics,
+            f"{code_prefix}.unreadable",
+            subject,
+            f"Cannot read committed artifact {path}: {exc}",
+        )
+        return False
+    if actual_size != expected_size:
+        _diagnostic(
+            diagnostics,
+            f"{code_prefix}.size_mismatch",
+            subject,
+            f"Artifact size changed: {path}",
+            expected=expected_size,
+            actual=actual_size,
+        )
+    if actual_hash != expected_hash:
+        _diagnostic(
+            diagnostics,
+            f"{code_prefix}.content_mismatch",
+            subject,
+            f"Artifact content digest changed: {path}",
+            expected=expected_hash,
+            actual=actual_hash,
+        )
+    return True
+
+
+def _verify_database(
+    manifest_parent: Path,
+    raw: Mapping[str, object],
+    expected_case_id: str | None,
+    diagnostics: list[VerificationDiagnostic],
+) -> int:
+    try:
+        path = _resolve_relative(manifest_parent, raw.get("path"))
+    except ValueError as exc:
+        _diagnostic(diagnostics, "database.invalid_path", "database", str(exc))
+        return 0
+    if not path.is_file():
+        _diagnostic(
+            diagnostics,
+            "database.missing",
+            "database",
+            f"Case database is missing: {path}",
+        )
+        return 0
+    if raw.get("profile") != SQLITE_LOGICAL_PROFILE:
+        _diagnostic(
+            diagnostics,
+            "database.unsupported_profile",
+            "database",
+            "Database commitment profile is unsupported.",
+            expected=SQLITE_LOGICAL_PROFILE,
+            actual=raw.get("profile"),
+        )
+        return 0
+    try:
+        _assert_quiescent_database(path)
+    except SealError as exc:
+        _diagnostic(
+            diagnostics,
+            "database.active_journal",
+            "database",
+            str(exc),
+        )
+        return 0
+    try:
+        actual = _snapshot_database(path)
+    except (SealError, OSError) as exc:
+        _diagnostic(
+            diagnostics,
+            "database.unreadable",
+            "database",
+            f"Cannot verify case database {path}: {exc}",
+        )
+        return 0
+
+    if actual.case_id != expected_case_id:
+        _diagnostic(
+            diagnostics,
+            "database.case_id_mismatch",
+            "database:case_metadata",
+            "Database case ID differs from the manifest case ID.",
+            expected=expected_case_id,
+            actual=actual.case_id,
+        )
+
+    expected_schema_raw = raw.get("schema_objects")
+    if not isinstance(expected_schema_raw, list):
+        _diagnostic(
+            diagnostics,
+            "database.invalid_schema_manifest",
+            "database",
+            "Database schema-object commitments must be a list.",
+        )
+    else:
+        expected_schema: dict[tuple[str, str, str], dict[str, object]] = {}
+        for index, schema_raw in enumerate(expected_schema_raw):
+            if not isinstance(schema_raw, dict) or not all(
+                isinstance(schema_raw.get(field), str) for field in ("type", "name", "table")
+            ):
+                _diagnostic(
+                    diagnostics,
+                    "database.invalid_schema_entry",
+                    f"database:schema:{index}",
+                    "Database schema entry must name its type, object, and table.",
+                )
+                continue
+            schema = cast(dict[str, object], schema_raw)
+            key = (
+                cast(str, schema["type"]),
+                cast(str, schema["name"]),
+                cast(str, schema["table"]),
+            )
+            if key in expected_schema:
+                _diagnostic(
+                    diagnostics,
+                    "database.duplicate_schema_entry",
+                    f"database:schema:{key[1]}",
+                    f"Database schema entry is duplicated: {key[1]}",
+                )
+            expected_schema[key] = schema
+        actual_schema = {
+            (
+                cast(str, schema["type"]),
+                cast(str, schema["name"]),
+                cast(str, schema["table"]),
+            ): schema
+            for schema in actual.schema_objects
+        }
+        for key in sorted(set(expected_schema) - set(actual_schema)):
+            _diagnostic(
+                diagnostics,
+                "database.schema_object_missing",
+                f"database:schema:{key[1]}",
+                f"Committed database {key[0]} is missing: {key[1]}",
+            )
+        for key in sorted(set(actual_schema) - set(expected_schema)):
+            _diagnostic(
+                diagnostics,
+                "database.schema_object_added",
+                f"database:schema:{key[1]}",
+                f"Uncommitted database {key[0]} was added: {key[1]}",
+            )
+        for key in sorted(set(expected_schema) & set(actual_schema)):
+            expected_object = expected_schema[key]
+            actual_object = actual_schema[key]
+            if expected_object != actual_object:
+                _diagnostic(
+                    diagnostics,
+                    "database.schema_object_mismatch",
+                    f"database:schema:{key[1]}",
+                    f"Database {key[0]} definition changed: {key[1]}",
+                    expected=_sha256_bytes(_canonical_json(expected_object)),
+                    actual=_sha256_bytes(_canonical_json(actual_object)),
+                )
+
+    expected_tables_raw = raw.get("tables")
+    if not isinstance(expected_tables_raw, list):
+        _diagnostic(
+            diagnostics,
+            "database.invalid_table_manifest",
+            "database",
+            "Database table commitments must be a list.",
+        )
+        return 1
+    expected_tables: dict[str, dict[str, object]] = {}
+    for index, row_raw in enumerate(expected_tables_raw):
+        if not isinstance(row_raw, dict) or not isinstance(row_raw.get("name"), str):
+            _diagnostic(
+                diagnostics,
+                "database.invalid_table_entry",
+                f"database:table:{index}",
+                "Database table commitment must be an object with a string name.",
+            )
+            continue
+        row = cast(dict[str, object], row_raw)
+        name = cast(str, row["name"])
+        if name in expected_tables:
+            _diagnostic(
+                diagnostics,
+                "database.duplicate_table_entry",
+                f"database:table:{name}",
+                f"Database table commitment is duplicated: {name}",
+            )
+        expected_tables[name] = row
+    actual_tables: dict[str, dict[str, object]] = {
+        cast(str, row["name"]): row for row in actual.tables
+    }
+    for name in sorted(set(expected_tables) - set(actual_tables), key=str):
+        _diagnostic(
+            diagnostics,
+            "database.table_missing",
+            f"database:{name}",
+            f"Committed database table is missing: {name}",
+        )
+    for name in sorted(set(actual_tables) - set(expected_tables), key=str):
+        _diagnostic(
+            diagnostics,
+            "database.table_added",
+            f"database:{name}",
+            f"Uncommitted database table was added: {name}",
+        )
+    for name in sorted(set(expected_tables) & set(actual_tables), key=str):
+        expected = expected_tables[name]
+        observed = actual_tables[name]
+        if expected.get("schema_digest") != observed.get("schema_digest"):
+            _diagnostic(
+                diagnostics,
+                "database.schema_mismatch",
+                f"database:{name}",
+                f"Database table schema changed: {name}",
+                expected=expected.get("schema_digest"),
+                actual=observed.get("schema_digest"),
+            )
+        if expected.get("row_count") != observed.get("row_count"):
+            _diagnostic(
+                diagnostics,
+                "database.row_count_mismatch",
+                f"database:{name}",
+                f"Database table row count changed: {name}",
+                expected=expected.get("row_count"),
+                actual=observed.get("row_count"),
+            )
+        if expected.get("content_digest") != observed.get("content_digest"):
+            _diagnostic(
+                diagnostics,
+                "database.content_mismatch",
+                f"database:{name}",
+                f"Database table content changed: {name}",
+                expected=expected.get("content_digest"),
+                actual=observed.get("content_digest"),
+            )
+    if raw.get("logical_digest") != actual.logical_digest:
+        _diagnostic(
+            diagnostics,
+            "database.logical_digest_mismatch",
+            "database",
+            "Case database logical digest changed.",
+            expected=raw.get("logical_digest"),
+            actual=actual.logical_digest,
+        )
+    return 1
+
+
+def _verify_audit(
+    manifest_parent: Path,
+    raw: Mapping[str, object],
+    diagnostics: list[VerificationDiagnostic],
+) -> tuple[int, bool]:
+    try:
+        path = _resolve_relative(manifest_parent, raw.get("path"))
+    except ValueError as exc:
+        _diagnostic(diagnostics, "audit.invalid_path", "audit", str(exc))
+        return 0, False
+    if not _verify_file(
+        path=path,
+        expected_hash=raw.get("sha256"),
+        expected_size=raw.get("size_bytes"),
+        subject="audit",
+        code_prefix="audit",
+        diagnostics=diagnostics,
+    ):
+        return 0, False
+
+    result = AuditLog(path).verify_integrity()
+    if not result.ok:
+        _diagnostic(
+            diagnostics,
+            "audit.chain_invalid",
+            "audit",
+            result.message,
+            expected="valid chained or explicit legacy audit",
+            actual={
+                "error_code": result.error_code,
+                "line": result.first_error_line,
+                "sequence": result.first_error_sequence,
+            },
+        )
+    expected_count = raw.get("entry_count")
+    if result.entries_checked != expected_count:
+        _diagnostic(
+            diagnostics,
+            "audit.entry_count_mismatch",
+            "audit",
+            "Audit entry count differs from the sealed count; a suffix may have been removed.",
+            expected=expected_count,
+            actual=result.entries_checked,
+        )
+    if result.head_hash != raw.get("head_hash"):
+        _diagnostic(
+            diagnostics,
+            "audit.head_mismatch",
+            "audit",
+            "Audit chain head differs from the externally sealed head.",
+            expected=raw.get("head_hash"),
+            actual=result.head_hash,
+        )
+    if result.status != raw.get("chain_status"):
+        _diagnostic(
+            diagnostics,
+            "audit.status_mismatch",
+            "audit",
+            "Audit integrity status changed since sealing.",
+            expected=raw.get("chain_status"),
+            actual=result.status,
+        )
+
+    legacy = result.status in {"legacy_unverified", "empty"}
+    if result.status == "legacy_unverified":
+        _diagnostic(
+            diagnostics,
+            "audit.legacy_unverified",
+            "audit",
+            "Legacy audit entries are readable and content-bound but were never hash-chained.",
+            severity="warning",
+        )
+    elif result.status == "empty":
+        _diagnostic(
+            diagnostics,
+            "audit.empty_unverified",
+            "audit",
+            "The sealed audit is empty and provides no event-chain assurance.",
+            severity="warning",
+        )
+    return 1, legacy
+
+
+def _verify_evidence(
+    manifest_parent: Path,
+    raw: Mapping[str, object],
+    locations: Mapping[str, object],
+    evidence_root_override: Path | None,
+    diagnostics: list[VerificationDiagnostic],
+) -> tuple[int, bool]:
+    legacy = raw.get("status") == "legacy_absent"
+    if legacy:
+        _diagnostic(
+            diagnostics,
+            "evidence.registry_legacy_absent",
+            "evidence_registry",
+            "This legacy database has no evidence registry; original evidence is unverified.",
+            severity="warning",
+        )
+    entries = raw.get("entries")
+    if not isinstance(entries, list):
+        _diagnostic(
+            diagnostics,
+            "evidence.invalid_registry",
+            "evidence_registry",
+            "Evidence registry entries must be a list.",
+        )
+        return 0, legacy
+
+    evidence_location = locations.get("evidence")
+    evidence_kind = None
+    try:
+        if evidence_root_override is not None:
+            evidence_base = evidence_root_override.expanduser().resolve(strict=False)
+        elif isinstance(evidence_location, dict):
+            evidence_base = _resolve_relative(
+                manifest_parent, cast(dict[str, object], evidence_location).get("path")
+            )
+        else:
+            raise ValueError("manifest has no evidence root location")
+        if isinstance(evidence_location, dict):
+            evidence_kind = evidence_location.get("kind")
+    except ValueError as exc:
+        _diagnostic(diagnostics, "evidence.invalid_root", "evidence_registry", str(exc))
+        return 0, legacy
+
+    checked = 0
+    for index, entry_raw in enumerate(entries):
+        if not isinstance(entry_raw, dict):
+            _diagnostic(
+                diagnostics,
+                "evidence.invalid_entry",
+                f"evidence:{index}",
+                "Evidence registry entry must be an object.",
+            )
+            continue
+        entry = cast(dict[str, object], entry_raw)
+        location = entry.get("location")
+        if not isinstance(location, dict):
+            _diagnostic(
+                diagnostics,
+                "evidence.invalid_location",
+                f"evidence:{index}",
+                "Evidence registry entry has no valid location.",
+            )
+            continue
+        root_name = location.get("root")
+        try:
+            if root_name == "evidence":
+                relative = location.get("path")
+                if evidence_kind == "file" or evidence_base.is_file():
+                    if relative not in (".", ""):
+                        raise ValueError("file evidence root can only resolve the '.' entry")
+                    artifact_path = evidence_base
+                else:
+                    artifact_path = _resolve_relative(evidence_base, relative)
+            elif root_name == "manifest":
+                artifact_path = _resolve_relative(manifest_parent, location.get("path"))
+            else:
+                raise ValueError(f"unsupported evidence location root: {root_name!r}")
+        except ValueError as exc:
+            _diagnostic(
+                diagnostics,
+                "evidence.invalid_location",
+                f"evidence:{index}",
+                str(exc),
+            )
+            continue
+        _verify_file(
+            path=artifact_path,
+            expected_hash=entry.get("sha256"),
+            expected_size=entry.get("size_bytes"),
+            subject=f"evidence:{entry.get('registry_id', index)}:{entry.get('original_path')}",
+            code_prefix="evidence",
+            diagnostics=diagnostics,
+        )
+        checked += 1
+    return checked, legacy
+
+
+def _verify_reports(
+    manifest_parent: Path,
+    raw: object,
+    diagnostics: list[VerificationDiagnostic],
+) -> int:
+    if not isinstance(raw, list):
+        _diagnostic(
+            diagnostics,
+            "report.invalid_manifest",
+            "reports",
+            "Report commitments must be a list.",
+        )
+        return 0
+    checked = 0
+    for index, report_raw in enumerate(raw):
+        if not isinstance(report_raw, dict):
+            _diagnostic(
+                diagnostics,
+                "report.invalid_entry",
+                f"report:{index}",
+                "Report commitment must be an object.",
+            )
+            continue
+        report = cast(dict[str, object], report_raw)
+        try:
+            path = _resolve_relative(manifest_parent, report.get("path"))
+        except ValueError as exc:
+            _diagnostic(diagnostics, "report.invalid_path", f"report:{index}", str(exc))
+            continue
+        _verify_file(
+            path=path,
+            expected_hash=report.get("sha256"),
+            expected_size=report.get("size_bytes"),
+            subject=f"report:{report.get('name', index)}",
+            code_prefix="report",
+            diagnostics=diagnostics,
+        )
+        checked += 1
+    return checked
+
+
+def verify_case(
+    manifest_path: Path,
+    *,
+    evidence_root: Path | None = None,
+) -> CaseVerificationResult:
+    """Verify a sealed case without MCP, an inference provider, or network I/O."""
+    path = Path(manifest_path).expanduser().resolve(strict=False)
+    diagnostics: list[VerificationDiagnostic] = []
+    try:
+        raw = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_unique_json_object,
+        )
+    except FileNotFoundError:
+        _diagnostic(
+            diagnostics,
+            "manifest.missing",
+            "manifest",
+            f"Case manifest is missing: {path}",
+        )
+        return CaseVerificationResult("invalid", str(path), None, 0, tuple(diagnostics))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        _diagnostic(
+            diagnostics,
+            "manifest.unreadable",
+            "manifest",
+            f"Cannot read case manifest {path}: {exc}",
+        )
+        return CaseVerificationResult("invalid", str(path), None, 0, tuple(diagnostics))
+    if not isinstance(raw, dict):
+        _diagnostic(
+            diagnostics,
+            "manifest.invalid_structure",
+            "manifest",
+            "Case manifest must be a JSON object.",
+        )
+        return CaseVerificationResult("invalid", str(path), None, 0, tuple(diagnostics))
+    manifest = cast(dict[str, object], raw)
+    case_raw = manifest.get("case")
+    case_id = case_raw.get("case_id") if isinstance(case_raw, dict) else None
+    case_id = case_id if isinstance(case_id, str) else None
+
+    if manifest.get("schema") != MANIFEST_SCHEMA or manifest.get("version") != MANIFEST_VERSION:
+        _diagnostic(
+            diagnostics,
+            "manifest.unsupported_schema",
+            "manifest",
+            "Case manifest schema or version is unsupported.",
+            expected={"schema": MANIFEST_SCHEMA, "version": MANIFEST_VERSION},
+            actual={"schema": manifest.get("schema"), "version": manifest.get("version")},
+        )
+        return CaseVerificationResult(
+            "unsupported_manifest", str(path), case_id, 0, tuple(diagnostics)
+        )
+
+    integrity = manifest.get("integrity")
+    signature_status: SignatureStatus = "unknown"
+    if not isinstance(integrity, dict) or integrity.get("algorithm") != "sha256":
+        _diagnostic(
+            diagnostics,
+            "manifest.invalid_integrity",
+            "manifest",
+            "Manifest has no supported integrity block.",
+        )
+    else:
+        try:
+            observed_hash = _manifest_hash(manifest)
+        except (TypeError, ValueError) as exc:
+            _diagnostic(
+                diagnostics,
+                "manifest.noncanonical_content",
+                "manifest",
+                f"Manifest contains a value that cannot be canonically encoded: {exc}",
+            )
+        else:
+            if integrity.get("manifest_hash") != observed_hash:
+                _diagnostic(
+                    diagnostics,
+                    "manifest.content_mismatch",
+                    "manifest",
+                    "Manifest content does not match its embedded commitment.",
+                    expected=integrity.get("manifest_hash"),
+                    actual=observed_hash,
+                )
+        signature = integrity.get("signature")
+        if not isinstance(signature, dict) or signature.get("status") != "unsigned":
+            _diagnostic(
+                diagnostics,
+                "manifest.unsupported_signature",
+                "manifest",
+                "This verifier supports only the explicit unsigned v1 receipt.",
+            )
+        else:
+            signature_status = "unsigned"
+
+    locations = manifest.get("locations")
+    database = manifest.get("database")
+    evidence = manifest.get("evidence_registry")
+    audit = manifest.get("audit")
+    if not all(isinstance(section, dict) for section in (locations, database, evidence, audit)):
+        _diagnostic(
+            diagnostics,
+            "manifest.invalid_structure",
+            "manifest",
+            "Manifest is missing a locations, database, evidence_registry, or audit object.",
+        )
+        return CaseVerificationResult(
+            "invalid", str(path), case_id, 0, tuple(diagnostics), signature_status
+        )
+
+    checked = _verify_database(
+        path.parent, cast(dict[str, object], database), case_id, diagnostics
+    )
+    audit_checked, legacy_audit = _verify_audit(
+        path.parent, cast(dict[str, object], audit), diagnostics
+    )
+    checked += audit_checked
+    evidence_checked, legacy_registry = _verify_evidence(
+        path.parent,
+        cast(dict[str, object], evidence),
+        cast(dict[str, object], locations),
+        evidence_root,
+        diagnostics,
+    )
+    checked += evidence_checked
+    checked += _verify_reports(path.parent, manifest.get("reports"), diagnostics)
+
+    has_errors = any(diagnostic.severity == "error" for diagnostic in diagnostics)
+    if has_errors:
+        status: VerificationStatus = "invalid"
+    elif legacy_audit or legacy_registry:
+        status = "legacy_unverified"
+    else:
+        status = "verified"
+    return CaseVerificationResult(
+        status,
+        str(path),
+        case_id,
+        checked,
+        tuple(diagnostics),
+        signature_status,
+    )
+
+
+def format_verification_result(result: CaseVerificationResult) -> str:
+    """Render a concise human-readable verification report."""
+    label = result.status.upper().replace("_", " ")
+    case = result.case_id or "unknown"
+    trust = " — unsigned manifest" if result.signature_status == "unsigned" else ""
+    lines = [f"Case {case}: {label}{trust} ({result.artifacts_checked} artifacts checked)"]
+    for diagnostic in result.diagnostics:
+        lines.append(
+            f"[{diagnostic.severity.upper()}] {diagnostic.code} "
+            f"({diagnostic.subject}): {diagnostic.message}"
+        )
+        if diagnostic.expected is not None or diagnostic.actual is not None:
+            lines.append(f"  expected: {diagnostic.expected!r}")
+            lines.append(f"  actual:   {diagnostic.actual!r}")
+    return "\n".join(lines)
+
+
+def manifest_report_paths(manifest: Mapping[str, object]) -> Iterable[str]:
+    """Expose report locators for future bundle/export integrations."""
+    reports = manifest.get("reports")
+    if not isinstance(reports, list):
+        return ()
+    return tuple(
+        cast(str, report["path"])
+        for report in reports
+        if isinstance(report, dict) and isinstance(report.get("path"), str)
+    )

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -176,7 +176,6 @@ _HINT_CHAR_LIMIT = 200
 _DEFAULT_SEARCH_LIMIT = 50
 _FILE_LIST_CAP = 500
 
-_HASH_SIZE_THRESHOLD = 10000
 _HASH_PREFIX = "blake2b:"
 _HASH_DIGEST_SIZE = 32
 
@@ -186,25 +185,15 @@ def _blake2b_hex(data: bytes) -> str:
 
 
 def hash_output(output: object) -> str:
-    """Return a BLAKE2b fingerprint of *output* for audit purposes.
+    """Return a BLAKE2b commitment to the complete JSON form of *output*.
 
-    For small payloads, hashes the full JSON.  For large payloads
-    (>10KB serialized), hashes a compact summary to avoid expensive
-    serialization of data that's about to be serialized again for the
-    MCP response.
+    The previous large-value heuristic committed only a length, key set, or
+    short prefix.  That was useful as a cache fingerprint but unsuitable for
+    an audit record: different tool outputs could have the same digest.  The
+    existing algorithm and serialization remain stable for small values while
+    all values now commit their complete serialized content.
     """
-    if isinstance(output, list | dict):
-        if isinstance(output, list) and len(output) > 200:
-            return _blake2b_hex(f"list:len={len(output)}".encode())
-        if isinstance(output, dict) and len(output) > 100:
-            return _blake2b_hex(f"dict:keys={sorted(output.keys())}".encode())
-        probe = json.dumps(output, sort_keys=True, default=str)
-        if len(probe) > _HASH_SIZE_THRESHOLD:
-            return _blake2b_hex(f"large:{len(probe)}:{probe[:256]}".encode())
-        return _blake2b_hex(probe.encode())
     raw = json.dumps(output, sort_keys=True, default=str)
-    if len(raw) > _HASH_SIZE_THRESHOLD:
-        return _blake2b_hex(f"large:{len(raw)}:{raw[:256]}".encode())
     return _blake2b_hex(raw.encode())
 
 

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, ParamSpec
 from uuid import uuid4
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, has_ctx
 
 current_batch_id: ContextVar[str | None] = ContextVar("current_batch_id", default=None)
@@ -269,9 +270,24 @@ def windowed_response(
             duration_ms=elapsed_ms,
             batch_id=current_batch_id.get(),
         )
+    if total > cap:
+        outcome_status = ToolOutcomeStatus.SAMPLED
+    elif total == 0:
+        outcome_status = ToolOutcomeStatus.SUCCESS_EMPTY
+    else:
+        outcome_status = ToolOutcomeStatus.SUCCESS_NONEMPTY
+    outcome = ToolOutcome(
+        status=outcome_status,
+        coverage=CoverageMetadata(
+            rows_examined=len(results),
+            rows_total=total,
+            sample_reason=(f"response capped at {cap} windows" if total > cap else None),
+        ),
+    )
     resp: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "success",
+        "outcome": outcome.model_dump(mode="json"),
         "results": results,
         "source": source,
         "result_count": len(results),
@@ -303,8 +319,14 @@ def tool_response(
     results: dict[str, object] | list[object],
     source: str | None = None,
     elapsed_ms: float = 0,
+    outcome: ToolOutcome | None = None,
 ) -> dict[str, object]:
     """Build an audited success response and log the tool call.
+
+    ``outcome`` is the precise, versioned execution contract.  When omitted,
+    it defaults to ``SUCCESS_NONEMPTY`` so adoption can proceed tool by tool;
+    callers returning empty, sampled, or partial data must pass it explicitly.
+    The legacy top-level ``status`` is retained for existing clients.
 
     When *source* is provided (indicating data has been indexed into the
     case DB), returns a compact response with only a preview of the output.
@@ -314,6 +336,8 @@ def tool_response(
     When *source* is None, returns the full results (for read/reference
     tools whose output is not indexed elsewhere).
     """
+    precise_outcome = outcome or ToolOutcome(status=ToolOutcomeStatus.SUCCESS_NONEMPTY)
+
     if has_ctx():
         ctx = get_ctx()
         ctx.audit.log_tool_call(
@@ -329,6 +353,7 @@ def tool_response(
         return {
             "tool_call_id": tc_id,
             "status": "success",
+            "outcome": precise_outcome.model_dump(mode="json"),
             "results": results,
             "source": source,
         }
@@ -352,6 +377,7 @@ def tool_response(
     resp: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "success",
+        "outcome": precise_outcome.model_dump(mode="json"),
         "source": source,
         "preview": preview + ("..." if len(preview) >= _PREVIEW_CHAR_LIMIT else ""),
         "hint": (
@@ -375,8 +401,31 @@ def error_response(
     elapsed_ms: float = 0,
     error_type: str = "unknown",
     suggestion: str | None = None,
+    outcome_status: ToolOutcomeStatus | None = None,
+    coverage: CoverageMetadata | None = None,
 ) -> dict[str, object]:
-    """Build an audited error response and log the tool call."""
+    """Build an audited error response and log the tool call.
+
+    Common legacy error types are mapped to precise outcome states.  A caller
+    can supply ``outcome_status`` and ``coverage`` when it knows more.
+    """
+    if outcome_status is None:
+        if error_type == "timeout":
+            outcome_status = ToolOutcomeStatus.TIMED_OUT
+        elif error_type in {
+            "binary_missing",
+            "file_not_found",
+            "hive_not_found",
+            "no_filelist",
+        }:
+            outcome_status = ToolOutcomeStatus.UNAVAILABLE
+        else:
+            outcome_status = ToolOutcomeStatus.FAILED
+    outcome = ToolOutcome(
+        status=outcome_status,
+        coverage=coverage or CoverageMetadata(),
+        reason=error,
+    )
     if has_ctx():
         ctx = get_ctx()
         ctx.audit.log_tool_call(
@@ -390,6 +439,7 @@ def error_response(
     result: dict[str, object] = {
         "tool_call_id": tc_id,
         "status": "error",
+        "outcome": outcome.model_dump(mode="json"),
         "error_type": error_type,
         "error_message": error,
     }

--- a/src/mulder/server/tools/artifacts.py
+++ b/src/mulder/server/tools/artifacts.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from mulder.path_policy import PathPolicyError, resolve_allowed_path
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import hash_output, make_tool_call_id
@@ -48,21 +49,15 @@ def _readonly_authorizer(
     return sqlite3.SQLITE_DENY
 
 
-def _validate_path_access(target: Path) -> str | None:
-    """Return an error message if the path is not under an allowed root, else None."""
-    try:
-        resolved = target.resolve()
-    except OSError:
-        return f"Cannot resolve path: {target}"
+def _resolve_artifact_path(target: Path) -> Path:
+    """Resolve *target* within the active evidence or case-storage root."""
     cfg = get_cfg()
-    allowed_roots = [Path(cfg.db_dir).resolve()]
+    allowed_roots = [Path(cfg.db_dir)]
     ctx = get_ctx()
     meta = ctx.db.get_case_metadata()
     if meta and meta.evidence_root:
-        allowed_roots.append(Path(meta.evidence_root).resolve())
-    if not any(str(resolved).startswith(str(root)) for root in allowed_roots):
-        return "Access denied: path is outside allowed directories"
-    return None
+        allowed_roots.append(Path(meta.evidence_root))
+    return resolve_allowed_path(target, allowed_roots)
 
 
 _TOOL_TIMEOUT = 120
@@ -454,13 +449,13 @@ def list_directory(
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
 
-    target = Path(path)
-    path_err = _validate_path_access(target)
-    if path_err:
+    try:
+        target = _resolve_artifact_path(Path(path))
+    except PathPolicyError as exc:
         return {
             "tool_call_id": tc_id,
             "status": "error",
-            "error_message": path_err,
+            "error_message": str(exc),
             "results": [],
             "result_count": 0,
         }
@@ -550,13 +545,13 @@ def read_evidence_file(
     t0 = time.monotonic()
     params = {"file_path": file_path, "max_bytes": max_bytes}
 
-    target = Path(file_path)
-    path_err = _validate_path_access(target)
-    if path_err:
+    try:
+        target = _resolve_artifact_path(Path(file_path))
+    except PathPolicyError as exc:
         return {
             "tool_call_id": tc_id,
             "status": "error",
-            "error_message": path_err,
+            "error_message": str(exc),
         }
     if not target.exists():
         elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/extract/app_files.py
+++ b/src/mulder/server/tools/extract/app_files.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 from typing import Any
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -289,6 +290,9 @@ def index_app_files(
 
     if not all_matches:
         elapsed = (time.monotonic() - t0) * 1000
+        rows_examined = sum(
+            len(chunk.splitlines()) for chunks, _offset in chunk_groups for chunk in chunks
+        )
         return tool_response(
             tc_id,
             "index_app_files",
@@ -303,6 +307,14 @@ def index_app_files(
             },
             source=None,
             elapsed_ms=elapsed,
+            outcome=ToolOutcome(
+                status=ToolOutcomeStatus.SUCCESS_EMPTY,
+                coverage=CoverageMetadata(
+                    rows_examined=rows_examined,
+                    rows_total=rows_examined,
+                    parser_version="fls-text-v1",
+                ),
+            ),
         )
 
     capped = all_matches[:max_files]
@@ -351,6 +363,31 @@ def index_app_files(
         "extensions_used": sorted(ext_set),
     }
 
+    if files_indexed < len(capped):
+        outcome_status = ToolOutcomeStatus.PARTIAL
+    elif len(all_matches) > len(capped):
+        outcome_status = ToolOutcomeStatus.SAMPLED
+    elif files_indexed == 0:
+        outcome_status = ToolOutcomeStatus.SUCCESS_EMPTY
+    else:
+        outcome_status = ToolOutcomeStatus.SUCCESS_NONEMPTY
+
+    coverage = CoverageMetadata(
+        rows_examined=files_indexed,
+        rows_total=len(all_matches),
+        truncation_reason=(
+            f"{len(capped) - files_indexed} selected files were not indexed"
+            if files_indexed < len(capped)
+            else None
+        ),
+        sample_reason=(
+            f"max_files={max_files} limited {len(all_matches)} matching files"
+            if len(all_matches) > len(capped)
+            else None
+        ),
+        parser_version="fls-text-v1",
+    )
+
     return tool_response(
         tc_id,
         "index_app_files",
@@ -358,4 +395,5 @@ def index_app_files(
         results,
         source=None,
         elapsed_ms=elapsed,
+        outcome=ToolOutcome(status=outcome_status, coverage=coverage),
     )

--- a/src/mulder/server/tools/extract/disk_pcap.py
+++ b/src/mulder/server/tools/extract/disk_pcap.py
@@ -15,6 +15,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from mulder.models import CoverageMetadata, ToolOutcome, ToolOutcomeStatus
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -390,6 +391,9 @@ def analyze_disk_pcaps(
 
     if not all_pcaps:
         elapsed = (time.monotonic() - t0) * 1000
+        rows_examined = sum(
+            len(chunk.splitlines()) for chunks, _offset in chunk_groups for chunk in chunks
+        )
         return tool_response(
             tc_id,
             "analyze_disk_pcaps",
@@ -401,6 +405,14 @@ def analyze_disk_pcaps(
             },
             source=None,
             elapsed_ms=elapsed,
+            outcome=ToolOutcome(
+                status=ToolOutcomeStatus.SUCCESS_EMPTY,
+                coverage=CoverageMetadata(
+                    rows_examined=rows_examined,
+                    rows_total=rows_examined,
+                    parser_version="fls-text-v1",
+                ),
+            ),
         )
 
     max_size_bytes = max_pcap_size_mb * 1024 * 1024
@@ -478,6 +490,25 @@ def analyze_disk_pcaps(
         "credentials": all_credentials[:100],
     }
 
+    incomplete_count = len(pcaps_failed) + len(pcaps_skipped_size)
+    outcome = ToolOutcome(
+        status=(
+            ToolOutcomeStatus.PARTIAL
+            if incomplete_count
+            else ToolOutcomeStatus.SUCCESS_NONEMPTY
+        ),
+        coverage=CoverageMetadata(
+            rows_examined=len(pcaps_analyzed),
+            rows_total=len(all_pcaps),
+            truncation_reason=(
+                f"{incomplete_count} discovered captures were not analyzed"
+                if incomplete_count
+                else None
+            ),
+            parser_version="fls-text-v1",
+        ),
+    )
+
     return tool_response(
         tc_id,
         "analyze_disk_pcaps",
@@ -485,4 +516,5 @@ def analyze_disk_pcaps(
         results,
         source=None,
         elapsed_ms=elapsed,
+        outcome=outcome,
     )

--- a/src/mulder/server/tools/findings.py
+++ b/src/mulder/server/tools/findings.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 from uuid import uuid4
 
-from mulder.models import AuditSummary, CaseMetadataRow, Finding, SourceRow
+from mulder.models import AtomicClaimInput, AuditSummary, CaseMetadataRow, Finding, SourceRow
 from mulder.patterns import SEVERITY_ORDER, source_is_cited
 from mulder.report.renderer import ReportRenderer
 from mulder.server.app import get_ctx, get_job_store, mcp
@@ -186,6 +186,7 @@ def submit_finding(
     mitre_attack_ids: list[str] | None = None,
     event_time_start: str | None = None,
     event_time_end: str | None = None,
+    claims: list[dict[str, Any]] | None = None,
 ) -> dict[str, object]:
     """Record a forensic finding with validated evidence references and metadata.
 
@@ -200,6 +201,13 @@ def submit_finding(
     pass null rather than fabricating. Day-precision placeholders are
     auto-nullified.
 
+    New callers should also submit atomic ``claims``. Each claim points to an
+    exact character range in an indexed evidence window and repeats the text
+    expected at that immutable location. The server resolves source identity,
+    hashes, extractor family, and independence key rather than trusting those
+    values from the caller. Omitting ``claims`` remains supported for legacy
+    clients; such prose is not promoted to a verified atomic claim.
+
     Returns finding_id on acceptance. Severity must be
     critical/high/medium/low/info. Confidence must be "confirmed"
     (corroborated by 2+ sources) or "inference".
@@ -208,7 +216,26 @@ def submit_finding(
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
 
-    invalid_refs = [ref for ref in evidence_refs if not ctx.audit.has_tool_call(ref)]
+    try:
+        claim_inputs = [AtomicClaimInput.model_validate(raw) for raw in claims or []]
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Atomic claim validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
+
+    claim_refs = {
+        anchor.tool_call_id for claim in claim_inputs for anchor in claim.anchors
+    }
+    invalid_refs = [
+        ref
+        for ref in sorted(set(evidence_refs) | claim_refs)
+        if not ctx.audit.has_tool_call(ref)
+    ]
     if invalid_refs:
         recent_ids = sorted(ctx.audit.tool_call_ids)[-10:]
         resp = error_response(
@@ -220,6 +247,17 @@ def submit_finding(
         )
         resp["valid_refs"] = recent_ids
         return resp
+
+    if claim_inputs and claim_refs != set(evidence_refs):
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            "Atomic claim tool_call_ids must exactly match evidence_refs; "
+            "uncited or unanchored references are not accepted",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
 
     case_metadata = ctx.db.get_case_metadata()
     finding_id = f"f_{uuid4().hex[:8]}"
@@ -267,7 +305,17 @@ def submit_finding(
             "Consider whether 'inference' is more appropriate."
         )
 
-    ctx.db.insert_finding(finding)
+    try:
+        stored_claims = ctx.db.insert_finding(finding, claim_inputs)
+    except Exception as exc:
+        return error_response(
+            tc_id,
+            "submit_finding",
+            {"title": title, "evidence_refs": evidence_refs},
+            f"Evidence anchor validation error: {exc}",
+            (time.monotonic() - t0) * 1000,
+            error_type="validation",
+        )
     ctx.audit.log_finding_submission(finding_id, evidence_refs)
 
     result: dict[str, object] = {
@@ -275,6 +323,8 @@ def submit_finding(
         "finding_id": finding_id,
         "status": "accepted",
         "confidence": finding.confidence,
+        "atomic_claims": [claim.model_dump() for claim in stored_claims],
+        "claim_mode": "atomic_unverified" if stored_claims else "legacy_unverified",
     }
     if thin_evidence_warning:
         result["hint"] = thin_evidence_warning
@@ -292,6 +342,7 @@ def submit_finding(
             "evidence_refs": evidence_refs,
             "sources": sources,
             "mitre_attack_ids": mitre_attack_ids or [],
+            "claim_count": len(stored_claims),
         },
         output_hash=hash_output(result),
         duration_ms=elapsed,

--- a/tests/test_app_files.py
+++ b/tests/test_app_files.py
@@ -268,6 +268,9 @@ class TestIndexAppFilesTool:
         assert result["status"] == "success"
         assert result["results"]["files_discovered"] == 0
         assert "NonExistent/Path" in result["results"]["pattern"]
+        assert result["outcome"]["status"] == "SUCCESS_EMPTY"
+        assert result["outcome"]["coverage"]["rows_examined"] == 8
+        assert result["outcome"]["coverage"]["rows_total"] == 8
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")
@@ -301,6 +304,10 @@ class TestIndexAppFilesTool:
         assert result["results"]["files_discovered"] == 300
         assert result["results"]["files_capped_at"] == 50
         assert mock_extract.call_count == 50
+        assert result["outcome"]["status"] == "SAMPLED"
+        assert result["outcome"]["coverage"]["rows_examined"] == 50
+        assert result["outcome"]["coverage"]["rows_total"] == 300
+        assert "max_files=50" in result["outcome"]["coverage"]["sample_reason"]
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")
@@ -330,6 +337,9 @@ class TestIndexAppFilesTool:
         assert result["status"] == "success"
         assert result["results"]["files_extracted"] == 0
         assert result["results"]["files_skipped_binary"] > 0
+        assert result["outcome"]["status"] == "PARTIAL"
+        assert result["outcome"]["coverage"]["rows_examined"] == 0
+        assert result["outcome"]["coverage"]["rows_total"] > 0
 
     @patch("mulder.server.tools.extract.app_files.extract_and_index")
     @patch("mulder.server.tools.extract.app_files._extract_and_read_file")

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -70,6 +71,225 @@ class TestLoadExisting:
         assert log.has_tool_call("tc_good")
         assert log.has_tool_call("tc_good2")
         assert any("2 lines failed to parse" in msg for msg in caplog.messages)
+
+
+class TestIntegrityChain:
+    @staticmethod
+    def _write_lines(path: Path, entries: list[dict[str, object]]) -> None:
+        path.write_text(
+            "".join(json.dumps(entry, separators=(",", ":")) + "\n" for entry in entries),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _read_lines(path: Path) -> list[dict[str, object]]:
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    @staticmethod
+    def _three_entry_log(path: Path) -> AuditLog:
+        audit = AuditLog(path)
+        audit.log_tool_call("tc_1", "search", {"query": "one"}, "blake2b:one")
+        audit.log_tool_call("tc_2", "search", {"query": "two"}, "blake2b:two")
+        audit.log_finding_submission("finding-1", ["tc_1", "tc_2"])
+        return audit
+
+    def test_new_events_are_canonical_and_verified(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = AuditLog(log_path)
+        audit.log_tool_call(
+            "tc_1",
+            "search",
+            {"z": {"last": 2, "first": 1}, "a": "value"},
+            "blake2b:output",
+        )
+
+        raw = log_path.read_text(encoding="utf-8").strip()
+        entry = json.loads(raw)
+        assert list(entry) == sorted(entry)
+        assert list(entry["params"]) == ["a", "z"]
+        assert list(entry["params"]["z"]) == ["first", "last"]
+        assert entry["schema"] == "mulder.audit"
+        assert entry["version"] == 1
+        assert entry["sequence"] == 1
+        assert entry["previous_hash"].startswith("sha256:")
+        assert entry["entry_hash"].startswith("sha256:")
+
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.cryptographically_verified
+        assert result.status == "verified"
+        assert result.entries_checked == 1
+        assert result.head_hash == entry["entry_hash"]
+
+    def test_key_reordering_does_not_break_canonical_hash(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = AuditLog(log_path)
+        audit.log_tool_call("tc_1", "search", {"b": 2, "a": 1}, "blake2b:output")
+        entry = self._read_lines(log_path)[0]
+        reversed_entry = dict(reversed(list(entry.items())))
+        log_path.write_text(json.dumps(reversed_entry) + "\n", encoding="utf-8")
+
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+
+    def test_edit_reports_first_broken_entry(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        entries[1]["tool_name"] = "edited"
+        self._write_lines(log_path, entries)
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.first_error_sequence == 2
+        assert result.error_code == "entry_hash_mismatch"
+
+    def test_delete_reports_sequence_gap(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[0], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "sequence_mismatch"
+        assert result.expected == 2
+        assert result.actual == 3
+
+    def test_insert_reports_duplicate_sequence(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[0], entries[0], entries[1], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "sequence_mismatch"
+
+    def test_reorder_reports_first_out_of_order_entry(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        self._write_lines(log_path, [entries[1], entries[0], entries[2]])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 1
+        assert result.error_code == "sequence_mismatch"
+
+    def test_truncated_final_json_is_invalid(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        raw = log_path.read_bytes()
+        log_path.write_bytes(raw[:-12])
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 3
+        assert result.error_code == "invalid_json"
+
+    def test_bit_flip_is_detected(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        raw = log_path.read_bytes()
+        original = b"blake2b:two"
+        replacement = b"blake2b:Two"
+        assert original in raw
+        log_path.write_bytes(raw.replace(original, replacement, 1))
+
+        result = audit.verify_integrity()
+        assert not result.ok
+        assert result.first_error_line == 2
+        assert result.error_code == "entry_hash_mismatch"
+
+    def test_append_and_reload_continue_chain(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        AuditLog(log_path).log_tool_call("tc_1", "search", {}, "blake2b:one")
+        reloaded = AuditLog(log_path)
+        reloaded.log_tool_call("tc_2", "search", {}, "blake2b:two")
+
+        entries = self._read_lines(log_path)
+        assert [entry["sequence"] for entry in entries] == [1, 2]
+        assert entries[1]["previous_hash"] == entries[0]["entry_hash"]
+        result = AuditLog(log_path).verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+        assert result.entries_checked == 2
+
+    def test_concurrent_writers_serialize_under_file_lock(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        writers = [AuditLog(log_path) for _ in range(4)]
+
+        def write(index: int) -> None:
+            writers[index % len(writers)].log_tool_call(
+                f"tc_{index}", "search", {"index": index}, f"blake2b:{index}"
+            )
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            list(pool.map(write, range(40)))
+
+        result = AuditLog(log_path).verify_integrity()
+        assert result.ok
+        assert result.status == "verified"
+        assert result.entries_checked == 40
+        assert [entry["sequence"] for entry in self._read_lines(log_path)] == list(range(1, 41))
+
+    def test_invalid_native_log_refuses_append(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        audit = self._three_entry_log(log_path)
+        entries = self._read_lines(log_path)
+        entries[0]["tool_name"] = "tampered"
+        self._write_lines(log_path, entries)
+
+        with pytest.raises(RuntimeError, match="Refusing to append"):
+            audit.log_tool_call("tc_4", "search", {}, "blake2b:four")
+
+    def test_legacy_log_is_readable_but_explicitly_unverified(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        legacy = [
+            {"type": "tool_call", "tool_call_id": "legacy-1", "tool_name": "x"},
+            {"type": "finding", "finding_id": "legacy-f", "evidence_refs": ["legacy-1"]},
+        ]
+        self._write_lines(log_path, legacy)
+
+        audit = AuditLog(log_path)
+        assert audit.has_tool_call("legacy-1")
+        result = audit.verify_integrity()
+        assert result.ok
+        assert not result.cryptographically_verified
+        assert result.status == "legacy_unverified"
+        assert result.legacy_entries == 2
+        assert result.head_hash is None
+
+    def test_first_new_entry_anchors_and_labels_legacy_prefix(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "audit.jsonl"
+        legacy = [
+            {"type": "tool_call", "tool_call_id": "legacy-1", "tool_name": "x"},
+            {"type": "finding", "finding_id": "legacy-f", "evidence_refs": ["legacy-1"]},
+        ]
+        self._write_lines(log_path, legacy)
+        audit = AuditLog(log_path)
+        audit.log_tool_call("native-1", "search", {}, "blake2b:one")
+
+        entries = self._read_lines(log_path)
+        assert entries[2]["sequence"] == 3
+        assert entries[2]["legacy_prefix_entries"] == 2
+        result = audit.verify_integrity()
+        assert result.ok
+        assert result.cryptographically_verified
+        assert result.status == "verified_with_legacy_anchor"
+        assert result.legacy_entries == 2
+
+        entries[0]["tool_name"] = "edited-legacy"
+        self._write_lines(log_path, entries)
+        tampered = audit.verify_integrity()
+        assert not tampered.ok
+        assert tampered.first_error_line == 3
+        assert tampered.error_code == "previous_hash_mismatch"
 
 
 class TestProvenance:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -11,7 +11,7 @@ from mulder.db import (
     CaseDB,
     _sanitize_fts5_query,
 )
-from mulder.models import Finding, WindowRow
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding, WindowRow
 
 
 class TestCaseLifecycle:
@@ -155,6 +155,105 @@ class TestFindings:
         assert f.finding_id == "f-001"
         assert f.evidence_refs == ["tc_aabbccdd"]
         assert f.mitre_attack_ids == ["T1059.001"]
+
+    def test_atomic_claim_resolves_exact_immutable_anchor(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "sha256-memory", "volatility", 1
+        )
+        tmp_case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=20,
+                    line_end=20,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe parent 500",
+                )
+            ],
+        )
+        window = tmp_case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+        claim_input = AtomicClaimInput(
+            statement="Process 1234 is cmd.exe",
+            subject="process:1234",
+            predicate="image_name",
+            object_value="cmd.exe",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=9,
+                    char_end=16,
+                    expected_text="cmd.exe",
+                    artifact_family="memory_process_list",
+                )
+            ],
+        )
+
+        stored = tmp_case_db.insert_finding(sample_finding, [claim_input])
+
+        assert len(stored) == 1
+        claims = tmp_case_db.get_claims(sample_finding.finding_id)
+        assert claims == stored
+        anchor = claims[0].anchors[0]
+        assert anchor.exact_text == "cmd.exe"
+        assert anchor.source_hash == "sha256-memory"
+        assert anchor.extractor_family == "volatility"
+        assert anchor.independence_key == "source:sha256-memory"
+        assert tmp_case_db.get_finding(sample_finding.finding_id).sources == [
+            "volatility.pslist"
+        ]
+
+    def test_stale_anchor_rejects_entire_finding(
+        self, tmp_case_db: CaseDB, sample_finding: Finding
+    ) -> None:
+        sid = tmp_case_db.register_source("src", "/p", "hash", "text", 1)
+        tmp_case_db.insert_windows(
+            sid,
+            [WindowRow(source_id=sid, line_start=1, line_end=1, event_time=None, raw_text="abc")],
+        )
+        window = tmp_case_db.get_windows_by_source("src")[0]
+        assert window.window_id is not None
+        claim = AtomicClaimInput(
+            statement="Value is xyz",
+            subject="value",
+            predicate="equals",
+            object_value="xyz",
+            anchors=[
+                EvidenceAnchorInput(
+                    tool_call_id="tc_aabbccdd",
+                    window_id=window.window_id,
+                    char_start=0,
+                    char_end=3,
+                    expected_text="xyz",
+                )
+            ],
+        )
+
+        with pytest.raises(ValueError, match="does not match"):
+            tmp_case_db.insert_finding(sample_finding, [claim])
+        assert tmp_case_db.get_finding(sample_finding.finding_id) is None
+
+    def test_open_migrates_missing_claim_tables(self, tmp_path: Path) -> None:
+        db = CaseDB.create(case_id="legacy-claims", evidence_root="/ev", db_dir=tmp_path)
+        with db._engine.begin() as conn:
+            conn.execute(text("DROP TABLE evidence_anchors"))
+            conn.execute(text("DROP TABLE claims"))
+        db.close()
+
+        reopened = CaseDB.open("legacy-claims", tmp_path)
+        with reopened._engine.connect() as conn:
+            names = {
+                row[0]
+                for row in conn.execute(
+                    text("SELECT name FROM sqlite_master WHERE type = 'table'")
+                )
+            }
+        reopened.close()
+        assert {"claims", "evidence_anchors"} <= names
 
 
 class TestExtractorVersions:

--- a/tests/test_disk_pcap.py
+++ b/tests/test_disk_pcap.py
@@ -245,6 +245,7 @@ class TestAnalyzeDiskPcapsTool:
         )
         assert result["status"] == "error"
         assert result["error_type"] == "no_filelist"
+        assert result["outcome"]["status"] == "UNAVAILABLE"
 
     @patch("mulder.server.tools.extract.disk_pcap.require_binary")
     @patch("mulder.server.tools.extract.disk_pcap._collect_fls_chunks")
@@ -270,6 +271,7 @@ class TestAnalyzeDiskPcapsTool:
         assert result["status"] == "success"
         assert result["results"]["pcaps_discovered"] == 0
         assert result["results"]["pcaps_analyzed"] == 0
+        assert result["outcome"]["status"] == "SUCCESS_EMPTY"
 
     @patch("mulder.server.tools.extract.disk_pcap.extract_and_index")
     @patch("mulder.server.tools.extract.disk_pcap._extract_pcap_via_icat")
@@ -312,6 +314,9 @@ class TestAnalyzeDiskPcapsTool:
         assert result["status"] == "success"
         assert "Captures/huge.pcap" in result["results"]["pcaps_skipped_oversize"]
         assert result["results"]["pcaps_analyzed"] == 0
+        assert result["outcome"]["status"] == "PARTIAL"
+        assert result["outcome"]["coverage"]["rows_examined"] == 0
+        assert result["outcome"]["coverage"]["rows_total"] == 1
 
     @patch("mulder.server.tools.extract.disk_pcap.extract_and_index")
     @patch("mulder.server.tools.extract.disk_pcap._extract_pcap_via_icat")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -32,21 +32,19 @@ class TestHashOutput:
         expected = "blake2b:" + hashlib.blake2b(expected_json.encode(), digest_size=32).hexdigest()
         assert result == expected
 
-    def test_large_dict_summary_hash(self) -> None:
+    def test_large_dict_full_hash(self) -> None:
         data = {f"k{i}": "x" * 100 for i in range(150)}
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
-    def test_large_list_summary_hash(self) -> None:
+    def test_large_list_full_hash(self) -> None:
         data = ["x" * 50 for _ in range(250)]
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
     def test_scalar_input(self) -> None:
         result = hash_output("hello world")
@@ -124,23 +122,21 @@ class TestSlimWindow:
 
 
 class TestHashOutputHeuristic:
-    """Test the heuristic size-check that skips full JSON serialization."""
+    """Large audit commitments must distinguish complete payload content."""
 
-    def test_large_list_uses_length_hash(self) -> None:
-        """Lists with >200 items use a length summary, not full serialization."""
+    def test_large_list_commits_values(self) -> None:
         data = list(range(250))
         h1 = hash_output(data)
         data_different_content = list(range(250, 500))
         h2 = hash_output(data_different_content)
-        assert h1 == h2
+        assert h1 != h2
 
-    def test_large_dict_uses_keys_hash(self) -> None:
-        """Dicts with >100 keys use a keys summary, not full serialization."""
+    def test_large_dict_commits_values(self) -> None:
         data = {f"k{i}": "value_a" for i in range(150)}
         h1 = hash_output(data)
         data_different_values = {f"k{i}": "value_b" for i in range(150)}
         h2 = hash_output(data_different_values)
-        assert h1 == h2
+        assert h1 != h2
 
 
 class TestExtractPid:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from mulder.models import Finding
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding
 
 
 class TestFinding:
@@ -85,3 +85,25 @@ class TestFinding:
         assert f.mitre_attack_ids == []
         assert f.event_time_start is None
         assert f.event_time_end is None
+
+
+class TestAtomicClaimInput:
+    def test_rejects_empty_anchor_list(self) -> None:
+        with pytest.raises(ValidationError, match="anchors"):
+            AtomicClaimInput(
+                statement="cmd.exe executed",
+                subject="cmd.exe",
+                predicate="executed",
+                object_value=True,
+                anchors=[],
+            )
+
+    def test_rejects_reversed_character_range(self) -> None:
+        with pytest.raises(ValidationError, match="char_end"):
+            EvidenceAnchorInput(
+                tool_call_id="tc_1",
+                window_id=1,
+                char_start=8,
+                char_end=4,
+                expected_text="cmd",
+            )

--- a/tests/test_path_policy.py
+++ b/tests/test_path_policy.py
@@ -1,0 +1,151 @@
+"""Adversarial tests for resolved filesystem path containment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mulder.path_policy import PathPolicyError, resolve_allowed_path
+
+
+def test_allows_root_and_nested_file(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    nested = evidence_root / "host" / "logs" / "security.evtx"
+    nested.parent.mkdir(parents=True)
+    nested.touch()
+
+    assert resolve_allowed_path(evidence_root, [evidence_root]) == evidence_root.resolve()
+    assert resolve_allowed_path(nested, [evidence_root]) == nested.resolve()
+
+
+def test_rejects_sibling_with_same_string_prefix(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    sibling = tmp_path / "evidence-other" / "secrets.txt"
+    evidence_root.mkdir()
+    sibling.parent.mkdir()
+    sibling.touch()
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(sibling, [evidence_root])
+
+
+def test_dotdot_is_checked_after_resolution(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+
+    inside = evidence_root / "host" / ".." / "timeline.csv"
+    outside = evidence_root / ".." / "outside.txt"
+
+    assert resolve_allowed_path(inside, [evidence_root]) == (evidence_root / "timeline.csv")
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(outside, [evidence_root])
+
+
+def test_rejects_existing_symlink_escape(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    outside_root = tmp_path / "outside"
+    evidence_root.mkdir()
+    outside_root.mkdir()
+    secret = outside_root / "secret.txt"
+    secret.touch()
+    escape = evidence_root / "escape"
+    escape.symlink_to(outside_root, target_is_directory=True)
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(escape / "secret.txt", [evidence_root])
+
+
+def test_allows_symlink_whose_destination_is_inside_root(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    real_dir = evidence_root / "real"
+    real_dir.mkdir(parents=True)
+    artifact = real_dir / "artifact.txt"
+    artifact.touch()
+    link = evidence_root / "link"
+    link.symlink_to(real_dir, target_is_directory=True)
+
+    assert resolve_allowed_path(link / "artifact.txt", [evidence_root]) == artifact.resolve()
+
+
+def test_nonexistent_descendant_is_provisionally_allowed(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    missing = evidence_root / "not-created" / "artifact.txt"
+
+    assert not missing.exists()
+    assert resolve_allowed_path(missing, [evidence_root]) == missing.resolve(strict=False)
+
+
+def test_dangling_symlink_is_checked_by_destination(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    dangling_escape = evidence_root / "dangling"
+    dangling_escape.symlink_to(tmp_path / "outside" / "missing.txt")
+
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(dangling_escape, [evidence_root])
+
+
+def test_accepts_evidence_and_case_roots_but_not_common_parent(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    case_root = tmp_path / "cases"
+    evidence_file = evidence_root / "image.E01"
+    case_file = case_root / "case.sqlite3"
+    unrelated = tmp_path / "other.txt"
+    evidence_root.mkdir()
+    case_root.mkdir()
+    evidence_file.touch()
+    case_file.touch()
+    unrelated.touch()
+    roots = [evidence_root, case_root]
+
+    assert resolve_allowed_path(evidence_file, roots) == evidence_file.resolve()
+    assert resolve_allowed_path(case_file, roots) == case_file.resolve()
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(unrelated, roots)
+
+
+def test_artifact_adapter_uses_configured_evidence_and_case_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from mulder.server.tools import artifacts
+
+    evidence_root = tmp_path / "evidence"
+    case_root = tmp_path / "cases"
+    evidence_root.mkdir()
+    case_root.mkdir()
+    evidence_file = evidence_root / "artifact.txt"
+    case_file = case_root / "case.sqlite3"
+    evidence_file.touch()
+    case_file.touch()
+
+    metadata = SimpleNamespace(evidence_root=str(evidence_root))
+    db = SimpleNamespace(get_case_metadata=lambda: metadata)
+    monkeypatch.setattr(artifacts, "get_cfg", lambda: SimpleNamespace(db_dir=case_root))
+    monkeypatch.setattr(artifacts, "get_ctx", lambda: SimpleNamespace(db=db))
+
+    assert artifacts._resolve_artifact_path(evidence_file) == evidence_file.resolve()
+    assert artifacts._resolve_artifact_path(case_file) == case_file.resolve()
+
+
+def test_file_root_does_not_authorize_sibling_prefix(tmp_path: Path) -> None:
+    evidence_image = tmp_path / "image.E01"
+    sibling = tmp_path / "image.E01.backup"
+    evidence_image.touch()
+    sibling.touch()
+
+    assert resolve_allowed_path(evidence_image, [evidence_image]) == evidence_image.resolve()
+    with pytest.raises(PathPolicyError, match="outside allowed directories"):
+        resolve_allowed_path(sibling, [evidence_image])
+
+
+def test_symlink_loop_fails_closed(tmp_path: Path) -> None:
+    evidence_root = tmp_path / "evidence"
+    evidence_root.mkdir()
+    loop = evidence_root / "loop"
+    loop.symlink_to(loop)
+
+    with pytest.raises(PathPolicyError, match="Cannot resolve path"):
+        resolve_allowed_path(loop, [evidence_root])

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,403 @@
+"""Tests for relocatable sealed case manifests and offline verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from mulder.audit import AuditLog
+from mulder.cli import cli
+from mulder.db import CaseDB
+from mulder.models import AtomicClaimInput, EvidenceAnchorInput, Finding, WindowRow
+from mulder.receipt import CaseVerificationResult, SealError, seal_case, verify_case
+
+
+@dataclass(frozen=True)
+class SealedFixture:
+    """Paths belonging to one realistic sealed test case."""
+
+    bundle: Path
+    case_dir: Path
+    evidence: Path
+    database: Path
+    audit: Path
+    report: Path
+    manifest: Path
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _build_sealed_case(tmp_path: Path, *, legacy_audit: bool = False) -> SealedFixture:
+    bundle = tmp_path / "portable-case"
+    case_dir = bundle / "case"
+    evidence_root = bundle / "evidence"
+    case_dir.mkdir(parents=True)
+    evidence_root.mkdir()
+    evidence = evidence_root / "host.log"
+    evidence_bytes = b"PID 1234 cmd.exe parent 500\n"
+    evidence.write_bytes(evidence_bytes)
+
+    db = CaseDB.create("fixture", str(evidence_root), case_dir)
+    db.register_evidence_file(str(evidence), _sha256(evidence_bytes), len(evidence_bytes))
+    source_id = db.register_source(
+        "host.processes",
+        str(evidence),
+        "sha256:" + _sha256(evidence_bytes),
+        "fixture-extractor",
+        1,
+    )
+    db.insert_windows(
+        source_id,
+        [
+            WindowRow(
+                source_id=source_id,
+                line_start=1,
+                line_end=1,
+                event_time=None,
+                raw_text=evidence_bytes.decode().strip(),
+            )
+        ],
+    )
+    window = db.get_windows_by_source("host.processes")[0]
+    assert window.window_id is not None
+    finding = Finding(
+        finding_id="finding-1",
+        case_id="fixture",
+        title="Process observed",
+        description="Process 1234 is cmd.exe",
+        severity="high",
+        confidence="inference",
+        evidence_refs=["tc-1"],
+        sources=["host.processes"],
+        submitted_at="2026-01-01T00:00:00+00:00",
+    )
+    db.insert_finding(
+        finding,
+        [
+            AtomicClaimInput(
+                statement="Process 1234 is cmd.exe",
+                subject="process:1234",
+                predicate="image_name",
+                object_value="cmd.exe",
+                anchors=[
+                    EvidenceAnchorInput(
+                        tool_call_id="tc-1",
+                        window_id=window.window_id,
+                        char_start=9,
+                        char_end=16,
+                        expected_text="cmd.exe",
+                    )
+                ],
+            )
+        ],
+    )
+    db.update_extractor_versions({"fixture-extractor": "2.1.0"})
+    db.close()
+
+    audit = case_dir / "fixture.audit.jsonl"
+    if legacy_audit:
+        audit.write_text(
+            json.dumps(
+                {
+                    "type": "tool_call",
+                    "tool_call_id": "legacy-1",
+                    "tool_name": "search",
+                    "params": {},
+                    "output_hash": "sha256:legacy",
+                    "duration_ms": 1,
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    else:
+        log = AuditLog(audit)
+        log.log_tool_call("tc-1", "search", {"query": "cmd.exe"}, "sha256:one")
+        log.log_finding_submission("finding-1", ["tc-1"])
+
+    report = case_dir / "fixture.report.md"
+    report.write_text("# Fixture report\n\nProcess 1234 is cmd.exe.\n", encoding="utf-8")
+    manifest = seal_case("fixture", case_dir)
+    return SealedFixture(
+        bundle=bundle,
+        case_dir=case_dir,
+        evidence=evidence,
+        database=case_dir / "fixture.db",
+        audit=audit,
+        report=report,
+        manifest=manifest,
+    )
+
+
+def _codes(result: CaseVerificationResult) -> set[str]:
+    return {diagnostic.code for diagnostic in result.diagnostics}
+
+
+def test_clean_case_verifies_and_binds_claims_tools_and_reports(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+
+    result = verify_case(sealed.manifest)
+    manifest = json.loads(sealed.manifest.read_text(encoding="utf-8"))
+
+    assert result.ok
+    assert result.status == "verified"
+    assert result.diagnostics == ()
+    assert result.artifacts_checked == 4  # database, audit, evidence, report
+    assert manifest["schema"] == "mulder.case-manifest"
+    assert manifest["version"] == 1
+    assert manifest["integrity"]["signature"] == {"status": "unsigned"}
+    assert manifest["audit"]["entry_count"] == 2
+    assert manifest["audit"]["head_hash"].startswith("sha256:")
+    assert manifest["database"]["record_sets"]["claims"]["row_count"] == 1
+    assert manifest["database"]["record_sets"]["evidence_anchors"]["row_count"] == 1
+    assert manifest["methodology"]["extractor_versions"] == {"fixture-extractor": "2.1.0"}
+    assert manifest["methodology"]["audit_tool_counts"] == {"search": 1}
+    assert [report["name"] for report in manifest["reports"]] == ["fixture.report.md"]
+
+
+@pytest.mark.parametrize(
+    ("replacement", "expected_codes"),
+    [
+        (b"PID 9876 cmd.exe parent 500\n", {"evidence.content_mismatch"}),
+        (
+            b"PID 1234 cmd.exe parent 500\nappended\n",
+            {"evidence.content_mismatch", "evidence.size_mismatch"},
+        ),
+    ],
+)
+def test_evidence_mutation_is_detected_even_at_same_size(
+    tmp_path: Path, replacement: bytes, expected_codes: set[str]
+) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    sealed.evidence.write_bytes(replacement)
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert expected_codes <= _codes(result)
+
+
+def test_missing_evidence_is_named_precisely(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    sealed.evidence.unlink()
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert "evidence.missing" in _codes(result)
+    diagnostic = next(item for item in result.diagnostics if item.code == "evidence.missing")
+    assert "host.log" in diagnostic.message
+
+
+@pytest.mark.parametrize(
+    ("attribute", "expected_code"),
+    [("database", "database.missing"), ("audit", "audit.missing")],
+)
+def test_missing_core_case_artifact_is_named(
+    tmp_path: Path, attribute: str, expected_code: str
+) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    getattr(sealed, attribute).unlink()
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert expected_code in _codes(result)
+
+
+def test_evidence_path_substitution_is_detected(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    original_size = sealed.evidence.stat().st_size
+    substitute = tmp_path / "substitute.log"
+    substitute.write_bytes(b"Z" * original_size)
+    sealed.evidence.unlink()
+    sealed.evidence.symlink_to(substitute)
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert "evidence.content_mismatch" in _codes(result)
+    assert "evidence.size_mismatch" not in _codes(result)
+
+
+def test_report_same_size_mutation_and_missing_report_are_detected(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    original = sealed.report.read_bytes()
+    sealed.report.write_bytes(b"X" * len(original))
+
+    changed = verify_case(sealed.manifest)
+    assert changed.status == "invalid"
+    assert "report.content_mismatch" in _codes(changed)
+    assert "report.size_mismatch" not in _codes(changed)
+
+    sealed.report.unlink()
+    missing = verify_case(sealed.manifest)
+    assert missing.status == "invalid"
+    assert "report.missing" in _codes(missing)
+
+
+def test_database_mutation_names_the_changed_table(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    connection = sqlite3.connect(sealed.database)
+    try:
+        connection.execute("UPDATE case_metadata SET narrative = 'changed after sealing'")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert "database.content_mismatch" in _codes(result)
+    assert any(item.subject == "database:case_metadata" for item in result.diagnostics)
+    assert "database.logical_digest_mismatch" in _codes(result)
+
+
+def test_database_schema_change_is_reported_separately(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    connection = sqlite3.connect(sealed.database)
+    try:
+        connection.execute("ALTER TABLE progress ADD COLUMN external_note TEXT")
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert "database.schema_mismatch" in _codes(result)
+    assert any(item.subject == "database:progress" for item in result.diagnostics)
+
+
+def test_live_database_journal_is_not_treated_as_a_portable_snapshot(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    Path(str(sealed.database) + "-wal").write_bytes(b"uncheckpointed")
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert "database.active_journal" in _codes(result)
+
+
+def test_audit_suffix_truncation_is_caught_by_sealed_count_and_head(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    lines = sealed.audit.read_text(encoding="utf-8").splitlines(keepends=True)
+    sealed.audit.write_text("".join(lines[:-1]), encoding="utf-8")
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "invalid"
+    assert {
+        "audit.content_mismatch",
+        "audit.size_mismatch",
+        "audit.entry_count_mismatch",
+        "audit.head_mismatch",
+    } <= _codes(result)
+
+
+def test_unsupported_manifest_schema_is_not_reported_as_corruption(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    manifest = json.loads(sealed.manifest.read_text(encoding="utf-8"))
+    manifest["version"] = 999
+    sealed.manifest.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "unsupported_manifest"
+    assert _codes(result) == {"manifest.unsupported_schema"}
+
+
+def test_case_bundle_remains_valid_after_relocation(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    relocated = tmp_path / "offline" / "renamed-case"
+    relocated.parent.mkdir()
+    shutil.move(str(sealed.bundle), relocated)
+
+    result = verify_case(relocated / "case" / "fixture.manifest.json")
+
+    assert result.status == "verified"
+
+
+def test_evidence_root_override_supports_independent_relocation(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    relocated_evidence = tmp_path / "detached-evidence"
+    shutil.move(str(sealed.evidence.parent), relocated_evidence)
+
+    without_override = verify_case(sealed.manifest)
+    with_override = verify_case(sealed.manifest, evidence_root=relocated_evidence)
+
+    assert "evidence.missing" in _codes(without_override)
+    assert with_override.status == "verified"
+
+
+def test_metadata_only_touch_does_not_invalidate_content_receipt(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    before = sealed.evidence.stat()
+    os.utime(sealed.evidence, ns=(before.st_atime_ns, before.st_mtime_ns + 1_000_000))
+
+    assert verify_case(sealed.manifest).status == "verified"
+
+
+def test_legacy_audit_is_explicitly_unverified_not_corrupt(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path, legacy_audit=True)
+
+    result = verify_case(sealed.manifest)
+
+    assert result.status == "legacy_unverified"
+    assert _codes(result) == {"audit.legacy_unverified"}
+    assert all(item.severity == "warning" for item in result.diagnostics)
+
+
+def test_sealing_refuses_stale_registered_evidence(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    sealed.manifest.unlink()
+    sealed.evidence.write_bytes(b"changed")
+
+    with pytest.raises(SealError, match="changed before sealing"):
+        seal_case("fixture", sealed.case_dir)
+
+
+def test_cli_seal_and_offline_verify_contract(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path)
+    sealed.manifest.unlink()
+    runner = CliRunner()
+
+    created = runner.invoke(
+        cli,
+        ["seal-case", "fixture", "--db-dir", str(sealed.case_dir)],
+    )
+    verified = runner.invoke(cli, ["verify-case", str(sealed.manifest), "--json"])
+
+    assert created.exit_code == 0, created.output
+    assert "Signature: unsigned" in created.output
+    assert verified.exit_code == 0, verified.output
+    payload = json.loads(verified.output)
+    assert payload["status"] == "verified"
+    assert payload["signature_status"] == "unsigned"
+
+
+def test_cli_legacy_and_unsupported_exit_codes(tmp_path: Path) -> None:
+    sealed = _build_sealed_case(tmp_path, legacy_audit=True)
+    runner = CliRunner()
+
+    legacy = runner.invoke(cli, ["verify-case", str(sealed.manifest)])
+    assert legacy.exit_code == 2
+    assert "LEGACY UNVERIFIED" in legacy.output
+
+    manifest = json.loads(sealed.manifest.read_text(encoding="utf-8"))
+    manifest["version"] = 2
+    sealed.manifest.write_text(json.dumps(manifest), encoding="utf-8")
+    unsupported = runner.invoke(cli, ["verify-case", str(sealed.manifest)])
+    assert unsupported.exit_code == 3
+    assert "UNSUPPORTED MANIFEST" in unsupported.output

--- a/tests/test_submit_finding.py
+++ b/tests/test_submit_finding.py
@@ -9,6 +9,7 @@ import pytest
 
 from mulder.audit import AuditLog
 from mulder.db import CaseDB
+from mulder.models import WindowRow
 from mulder.server.app import _tool_dispatch_sync
 from mulder.server.tools.findings import _sanitize_event_time
 
@@ -89,6 +90,94 @@ class TestEvidenceValidation:
         )
         assert "error" in result or result.get("status") != "accepted"
         assert "valid_refs" in result
+
+    def test_atomic_claim_is_resolved_and_persisted(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        sid = case_db.register_source(
+            "volatility.pslist", "/evidence/memory.raw", "memory-hash", "volatility", 1
+        )
+        case_db.insert_windows(
+            sid,
+            [
+                WindowRow(
+                    source_id=sid,
+                    line_start=1,
+                    line_end=1,
+                    event_time=None,
+                    raw_text="PID 1234 cmd.exe",
+                )
+            ],
+        )
+        window = case_db.get_windows_by_source("volatility.pslist")[0]
+        assert window.window_id is not None
+
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Suspicious process",
+            description="PID 1234 is cmd.exe",
+            severity="high",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd"],
+            sources=["caller-controlled-name"],
+            claims=[
+                {
+                    "statement": "PID 1234 is cmd.exe",
+                    "subject": "process:1234",
+                    "predicate": "image_name",
+                    "object_value": "cmd.exe",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": window.window_id,
+                            "char_start": 9,
+                            "char_end": 16,
+                            "expected_text": "cmd.exe",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        assert result["status"] == "accepted"
+        assert result["claim_mode"] == "atomic_unverified"
+        finding_id = str(result["finding_id"])
+        assert case_db.get_finding(finding_id).sources == ["volatility.pslist"]
+        assert case_db.get_claims(finding_id)[0].anchors[0].exact_text == "cmd.exe"
+
+    def test_claim_refs_must_exactly_match_finding_refs(
+        self, case_db: CaseDB, audit_log: AuditLog
+    ) -> None:
+        result = _call_submit_finding(
+            case_db,
+            audit_log,
+            title="Mismatched refs",
+            description="desc",
+            severity="medium",
+            confidence="inference",
+            evidence_refs=["tc_aabbccdd", "tc_11223344"],
+            sources=["src"],
+            claims=[
+                {
+                    "statement": "statement",
+                    "subject": "subject",
+                    "predicate": "equals",
+                    "object_value": "value",
+                    "anchors": [
+                        {
+                            "tool_call_id": "tc_aabbccdd",
+                            "window_id": 1,
+                            "char_start": 0,
+                            "char_end": 1,
+                            "expected_text": "x",
+                        }
+                    ],
+                }
+            ],
+        )
+        assert result.get("error_type") == "validation"
+        assert "exactly match" in str(result.get("error_message"))
 
 
 class TestTimestampSanitization:

--- a/tests/test_tool_outcomes.py
+++ b/tests/test_tool_outcomes.py
@@ -1,0 +1,182 @@
+"""Tests for precise, backwards-compatible forensic tool outcomes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from mulder.models import (
+    CoverageMetadata,
+    FallbackAttempt,
+    ToolOutcome,
+    ToolOutcomeStatus,
+)
+from mulder.server.helpers import error_response, tool_response, windowed_response
+
+
+def test_all_outcome_states_serialize_as_stable_strings() -> None:
+    """Every universal status is JSON-safe and round-trips through the schema."""
+    expected = {
+        "SUCCESS_NONEMPTY",
+        "SUCCESS_EMPTY",
+        "NOT_APPLICABLE",
+        "UNAVAILABLE",
+        "UNSUPPORTED_VERSION",
+        "FAILED",
+        "TIMED_OUT",
+        "PARTIAL",
+        "SAMPLED",
+    }
+    assert {status.value for status in ToolOutcomeStatus} == expected
+
+    for status in ToolOutcomeStatus:
+        coverage = CoverageMetadata(
+            sample_reason="bounded fixture" if status is ToolOutcomeStatus.SAMPLED else None
+        )
+        original = ToolOutcome(status=status, coverage=coverage)
+        encoded = json.dumps(original.model_dump(mode="json"))
+        assert ToolOutcome.model_validate_json(encoded) == original
+
+
+def test_json_schema_exposes_status_and_coverage_contract() -> None:
+    """Generated schemas let MCP clients validate the additive envelope."""
+    schema = ToolOutcome.model_json_schema()
+
+    assert set(schema["$defs"]["ToolOutcomeStatus"]["enum"]) == {
+        status.value for status in ToolOutcomeStatus
+    }
+    coverage_properties = schema["$defs"]["CoverageMetadata"]["properties"]
+    assert {
+        "bytes_examined",
+        "bytes_total",
+        "rows_examined",
+        "rows_total",
+        "truncation_reason",
+        "sample_reason",
+        "tool_version",
+        "parser_version",
+        "fallback_lineage",
+    } <= coverage_properties.keys()
+
+
+def test_coverage_serializes_fallback_lineage_and_versions() -> None:
+    """Fallback provenance remains structured instead of becoming prose."""
+    outcome = ToolOutcome(
+        status=ToolOutcomeStatus.SUCCESS_NONEMPTY,
+        coverage=CoverageMetadata(
+            bytes_examined=512,
+            bytes_total=512,
+            rows_examined=8,
+            rows_total=8,
+            tool_version="2.4.1",
+            parser_version="evtx-0.8.1",
+            fallback_lineage=[
+                FallbackAttempt(
+                    adapter="primary-evtx-parser",
+                    status=ToolOutcomeStatus.UNSUPPORTED_VERSION,
+                    reason="unknown chunk format",
+                    parser_version="evtx-0.7.4",
+                )
+            ],
+        ),
+    )
+
+    wire = outcome.model_dump(mode="json")
+    assert wire["schema_version"] == 1
+    assert wire["coverage"]["fallback_lineage"][0]["status"] == "UNSUPPORTED_VERSION"
+    assert wire["coverage"]["parser_version"] == "evtx-0.8.1"
+
+
+@pytest.mark.parametrize(
+    ("field_values", "message"),
+    [
+        ({"bytes_examined": 2, "bytes_total": 1}, "bytes_examined"),
+        ({"rows_examined": 2, "rows_total": 1}, "rows_examined"),
+    ],
+)
+def test_coverage_rejects_impossible_scope(
+    field_values: dict[str, int], message: str
+) -> None:
+    """An adapter cannot claim to examine more than its known input scope."""
+    with pytest.raises(ValidationError, match=message):
+        CoverageMetadata(**field_values)
+
+
+def test_sampled_outcome_requires_a_machine_visible_reason() -> None:
+    """A sampled result cannot masquerade as an unexplained complete result."""
+    with pytest.raises(ValidationError, match="sample_reason"):
+        ToolOutcome(status=ToolOutcomeStatus.SAMPLED)
+
+
+def test_parser_failure_is_not_serialized_as_successful_empty() -> None:
+    """A parser crash stays FAILED even when it produced no rows."""
+    response = error_response(
+        "tc_parser",
+        "parse_fixture",
+        {},
+        "malformed record at offset 42",
+        error_type="parse_error",
+        coverage=CoverageMetadata(bytes_examined=42, bytes_total=100),
+    )
+
+    assert response["status"] == "error"
+    assert response["outcome"]["status"] == "FAILED"
+    assert response["outcome"]["status"] != "SUCCESS_EMPTY"
+    assert response["outcome"]["coverage"]["bytes_examined"] == 42
+    assert response["outcome"]["coverage"]["bytes_total"] == 100
+
+
+def test_timeout_gets_a_distinct_outcome_without_breaking_legacy_status() -> None:
+    response = error_response(
+        "tc_timeout",
+        "slow_parser",
+        {},
+        "timed out",
+        error_type="timeout",
+    )
+
+    assert response["status"] == "error"
+    assert response["outcome"]["status"] == "TIMED_OUT"
+
+
+def test_success_helper_preserves_legacy_shape_and_accepts_precise_scope() -> None:
+    response = tool_response(
+        "tc_partial",
+        "bounded_parser",
+        {},
+        {"records": [1, 2]},
+        outcome=ToolOutcome(
+            status=ToolOutcomeStatus.PARTIAL,
+            coverage=CoverageMetadata(
+                rows_examined=2,
+                rows_total=9,
+                truncation_reason="parser stopped at corrupt record",
+            ),
+        ),
+    )
+
+    assert response["status"] == "success"
+    assert response["results"] == {"records": [1, 2]}
+    assert response["outcome"]["status"] == "PARTIAL"
+    assert response["outcome"]["coverage"]["rows_total"] == 9
+
+
+def test_windowed_response_distinguishes_empty_and_sampled_scope() -> None:
+    empty = windowed_response("tc_empty", [], "source", "search", {}, 0)
+    assert empty["status"] == "success"
+    assert empty["outcome"]["status"] == "SUCCESS_EMPTY"
+
+    sampled = windowed_response(
+        "tc_sampled",
+        [{"raw_text": str(index)} for index in range(3)],
+        "source",
+        "search",
+        {},
+        0,
+        cap=2,
+    )
+    assert sampled["outcome"]["status"] == "SAMPLED"
+    assert sampled["outcome"]["coverage"]["rows_examined"] == 2
+    assert sampled["outcome"]["coverage"]["rows_total"] == 3


### PR DESCRIPTION
- **BLUF:** Produce portable content-addressed case manifests that can be verified offline.
- **Priority:** Critical — Evidence integrity must remain checkable after export or transfer.
- **Changes:** Seal snapshots, verify digests and inode safety, and reject tampered manifests.
- **Validation:** Combined stack: 1,621 tests passed; Ruff and MyPy clean.
- **Series:** Mulder roadmap PR 10/37; prerequisite diffs may overlap until earlier PRs land.