### PR TITLE
[high] fix(tsk): correct mmls partition-row regex and share one parser

### DIFF
--- a/src/mulder/extractors/disk.py
+++ b/src/mulder/extractors/disk.py
@@ -15,14 +15,12 @@ import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+from mulder.patterns import parse_mmls_rows
+
 logger = logging.getLogger(__name__)
 _EVTX_EXTS = frozenset({".evtx"})
 
 _SECTOR_SIZE = 512
-_MMLS_ROW_RE = re.compile(
-    r"^\d+:\d+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$",
-    re.MULTILINE,
-)
 _NTFS_INDICATORS = ("ntfs", "exfat", "0x07", "win95 fat", "0x0b", "0x0c")
 _LINUX_INDICATORS = ("linux", "0x83", "ext", "0x8e")
 
@@ -120,17 +118,10 @@ def _detect_mount_offset(image_path: str) -> int:
         logger.debug("mmls found no partition table in %s", image_path)
         return 0
 
-    rows: list[tuple[int, int, str]] = []
-    for m in _MMLS_ROW_RE.finditer(proc.stdout):
-        start_sector = int(m.group(1))
-        length = int(m.group(2))
-        desc = m.group(3).strip()
-        rows.append((start_sector, length, desc))
+    annotated = parse_mmls_rows(proc.stdout)
 
-    if not rows:
+    if not annotated:
         return 0
-
-    annotated = [(s, sz, d.lower()) for s, sz, d in rows]
 
     for start, length, dl in annotated:
         if any(ind in dl for ind in _NTFS_INDICATORS) and length > 0:

--- a/src/mulder/patterns.py
+++ b/src/mulder/patterns.py
@@ -180,3 +180,29 @@ def extract_iocs_from_text(text: str) -> IOCSet:
         processes=PROCESS_RE.findall(text),
         emails=EMAIL_RE.findall(text),
     )
+
+
+MMLS_ROW_RE: re.Pattern[str] = re.compile(
+    r"^\s*\d+:\s*\S+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$",
+    re.MULTILINE,
+)
+"""Matches an ``mmls`` partition row across TSK output variations.
+
+``mmls`` prints the slot column as ``000:000`` for DOS partition tables and
+as a bare ``000`` for GPT, and indents every row by a few spaces.  A pattern
+anchored on ``^\\d+:\\d+`` therefore matches nothing at all on real output.
+
+Captures ``(start_sector, length_sectors, description)``.
+"""
+
+
+def parse_mmls_rows(mmls_text: str) -> list[tuple[int, int, str]]:
+    """Parse ``mmls`` output into ``(start_sector, length_sectors, description)``.
+
+    The description is stripped and lower-cased so callers can match it
+    against the filesystem indicator tuples directly.
+    """
+    return [
+        (int(m.group(1)), int(m.group(2)), m.group(3).strip().lower())
+        for m in MMLS_ROW_RE.finditer(mmls_text)
+    ]

--- a/src/mulder/server/tools/artifacts.py
+++ b/src/mulder/server/tools/artifacts.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from mulder.path_policy import PathPolicyError, resolve_allowed_path
+from mulder.patterns import parse_mmls_rows
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import hash_output, make_tool_call_id
@@ -99,9 +100,7 @@ def _resolve_image_and_offset() -> tuple[str, int]:
         windows = ctx.db.get_windows_by_source("tsk.partitions")
 
         mmls_text = "\n".join(w.raw_text for w in windows)
-        row_re = re.compile(r"^\d+:\d+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$", re.MULTILINE)
-        for m in row_re.finditer(mmls_text):
-            start, length, desc = int(m.group(1)), int(m.group(2)), m.group(3).strip().lower()
+        for start, length, desc in parse_mmls_rows(mmls_text):
             if any(ind in desc for ind in ("ntfs", "0x07", "hfs", "apfs")) and length > 0:
                 offset = start
                 break

--- a/src/mulder/server/tools/extract/tsk.py
+++ b/src/mulder/server/tools/extract/tsk.py
@@ -12,6 +12,7 @@ import threading
 import time
 from pathlib import Path
 
+from mulder.patterns import parse_mmls_rows
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -44,17 +45,6 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-
-_MMLS_ROW_RE = re.compile(
-    r"^\s*\d+:\s*\S+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$",
-    re.MULTILINE,
-)
-"""Regex matching mmls partition rows across TSK output variations.
-
-Handles formats with or without leading whitespace, with or without
-spaces in the slot field (e.g. ``002:000`` vs ``002:  000:000``).
-Captures: (start_sector, length, description).
-"""
 
 _NTFS_INDICATORS = ("ntfs", "0x07", "win95 fat", "0x0b", "0x0c", "basic data")
 _LINUX_INDICATORS = ("linux", "0x83", "ext", "0x8e")
@@ -89,10 +79,7 @@ def _parse_partition_offset(mmls_text: str) -> int:
     Searches for NTFS/Windows partitions first, then Linux, then falls
     back to the largest partition by sector count.
     """
-    rows: list[tuple[int, int, str]] = [
-        (int(m.group(1)), int(m.group(2)), m.group(3).strip().lower())
-        for m in _MMLS_ROW_RE.finditer(mmls_text)
-    ]
+    rows = parse_mmls_rows(mmls_text)
     if not rows:
         return 0
 
@@ -132,10 +119,7 @@ def _parse_all_partitions(mmls_text: str) -> list[tuple[int, int, str]]:
     Returns:
         List of ``(start_sector, length, description)`` tuples.
     """
-    rows: list[tuple[int, int, str]] = [
-        (int(m.group(1)), int(m.group(2)), m.group(3).strip().lower())
-        for m in _MMLS_ROW_RE.finditer(mmls_text)
-    ]
+    rows = parse_mmls_rows(mmls_text)
     if not rows:
         return []
 

--- a/src/mulder/server/tools/tsk.py
+++ b/src/mulder/server/tools/tsk.py
@@ -16,6 +16,7 @@ import threading
 import time
 
 from mulder.models import WindowRow
+from mulder.patterns import parse_mmls_rows
 from mulder.server import source_names as _sn
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
@@ -39,11 +40,6 @@ _ICAT_TIMEOUT = 30
 _ISTAT_TIMEOUT = 15
 _MAX_TEXT_BYTES = 1024 * 1024  # 1 MB cap for text file extraction
 
-# Matches mmls partition rows to extract the offset used during ingest.
-_MMLS_ROW_RE = re.compile(
-    r"^\d+:\d+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$",
-    re.MULTILINE,
-)
 _NTFS_INDICATORS = ("ntfs", "exfat", "0x07", "win95 fat", "0x0b", "0x0c")
 _LINUX_INDICATORS = ("linux", "0x83", "ext", "0x8e")
 
@@ -84,10 +80,7 @@ def _find_tsk_source_path() -> str:
 
 def _parse_offset_from_windows(mmls_text: str) -> int:
     """Parse partition offset from mmls text, preferring NTFS then Linux."""
-    rows: list[tuple[int, int, str]] = [
-        (int(m.group(1)), int(m.group(2)), m.group(3).strip().lower())
-        for m in _MMLS_ROW_RE.finditer(mmls_text)
-    ]
+    rows = parse_mmls_rows(mmls_text)
     if not rows:
         return 0
 

--- a/tests/test_mmls_parsing.py
+++ b/tests/test_mmls_parsing.py
@@ -1,0 +1,76 @@
+"""Regression tests for shared ``mmls`` partition-row parsing.
+
+Three copies of the partition-row regex were anchored on ``^\\d+:\\d+``, which
+never matches real ``mmls`` output: every row is indented and the slot column
+is ``000:000`` (DOS) or a bare ``000`` (GPT).  All of them now go through
+``mulder.patterns.parse_mmls_rows``.
+"""
+
+from __future__ import annotations
+
+from mulder.patterns import parse_mmls_rows
+
+DOS_MMLS = """DOS Partition Table
+Offset Sector: 0
+Units are in 512-byte sectors
+
+      Slot      Start        End          Length       Description
+000:  Meta      0000000000   0000000000   0000000001   Primary Table (#0)
+001:  -------   0000000000   0000002047   0000002048   Unallocated
+002:  000:000   0000002048   0000206847   0000204800   NTFS / exFAT (0x07)
+003:  000:001   0000206848   0000411647   0000204800   Linux (0x83)
+"""
+
+GPT_MMLS = """GUID Partition Table (EFI)
+Offset Sector: 0
+Units are in 512-byte sectors
+
+      Slot      Start        End          Length       Description
+000:  Meta      0000000000   0000000000   0000000001   Safety Table
+001:  -------   0000000000   0000002047   0000002048   Unallocated
+002:  000       0000002048   0001050623   0001048576   EFI system partition
+003:  001       0001050624   0488396799   0487346176   Basic data partition
+"""
+
+
+class TestParseMmlsRows:
+    def test_dos_table_rows_are_parsed(self) -> None:
+        rows = parse_mmls_rows(DOS_MMLS)
+        assert (2048, 204800, "ntfs / exfat (0x07)") in rows
+        assert (206848, 204800, "linux (0x83)") in rows
+
+    def test_gpt_table_rows_are_parsed(self) -> None:
+        rows = parse_mmls_rows(GPT_MMLS)
+        assert (2048, 1048576, "efi system partition") in rows
+        assert (1050624, 487346176, "basic data partition") in rows
+
+    def test_description_is_lowercased_and_stripped(self) -> None:
+        assert all(d == d.strip().lower() for _, _, d in parse_mmls_rows(DOS_MMLS))
+
+    def test_empty_output_yields_no_rows(self) -> None:
+        assert parse_mmls_rows("") == []
+        assert parse_mmls_rows("Cannot determine partition type\n") == []
+
+
+class TestTskToolOffset:
+    """``server.tools.tsk`` previously returned 0 for every real image."""
+
+    def test_ntfs_partition_offset_is_found(self) -> None:
+        from mulder.server.tools.tsk import _parse_offset_from_windows
+
+        assert _parse_offset_from_windows(DOS_MMLS) == 2048
+
+    def test_gpt_falls_through_to_basic_data(self) -> None:
+        from mulder.server.tools.tsk import _parse_offset_from_windows
+
+        # No NTFS/Linux indicator in GPT descriptions; must not crash.
+        assert isinstance(_parse_offset_from_windows(GPT_MMLS), int)
+
+
+class TestExtractTskOffset:
+    """The already-correct copy must keep behaving identically."""
+
+    def test_offset_matches_shared_parser(self) -> None:
+        from mulder.server.tools.extract.tsk import _parse_partition_offset
+
+        assert _parse_partition_offset(DOS_MMLS) == 2048


### PR DESCRIPTION
## BLUF

- **What breaks:** Three copies of the `mmls` partition-row regex are anchored on `^\d+:\d+`, which matches **nothing** in real `mmls` output — rows are indented and the slot column prints as `000:000` (DOS) or a bare `000` (GPT).
- **Impact:** The partition offset silently falls back to `0`, so every downstream `fls` / `icat` call reads the disk container instead of the filesystem. Partitioned images yield an empty or wrong file listing with no error.
- **Root cause:** A corrected pattern already exists at `src/mulder/server/tools/extract/tsk.py:48`; the fix was simply never propagated to the other three copies.
- **Fix:** Promote the working pattern to a single shared definition `mulder.patterns.MMLS_ROW_RE` + `parse_mmls_rows()`, and route all four call sites through it.
- **Risk:** Low. No behaviour change for the already-correct site; the other three go from "never matches" to "matches".

## Priority

**high** — silent evidence loss on any partitioned disk image; the tool reports success while listing nothing.

## Affected sites

| File | Line | State before |
|---|---|---|
| `src/mulder/server/tools/tsk.py` | 43 | broken anchor |
| `src/mulder/server/tools/artifacts.py` | 106 | broken anchor (inline copy) |
| `src/mulder/extractors/disk.py` | 22 | broken anchor |
| `src/mulder/server/tools/extract/tsk.py` | 48 | correct — now the shared source |

## Why the old pattern cannot match

Real `mmls` output:

```
      Slot      Start        End          Length       Description
000:  Meta      0000000000   0000000000   0000000001   Primary Table (#0)
002:  000:000   0000002048   0000206847   0000204800   NTFS / exFAT (0x07)
```

`^\d+:\d+\s+` requires `000:000` at column 0 with no intervening space. Every real row is `NNN:` + whitespace + slot. The shared pattern `^\s*\d+:\s*\S+\s+(\d+)\s+\d+\s+(\d+)\s+(.+)$` handles both the DOS `000:000` and GPT `000` slot forms.

## Tests

New `tests/test_mmls_parsing.py` feeds real DOS and GPT `mmls` output (not a synthetic shape) and asserts the correct start sectors come back, including through `server.tools.tsk._parse_offset_from_windows`, which previously returned `0` for every image.

`make lint format typecheck test` — 749 passed (742 before, +7 new), mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
