### PR TITLE
[critical] fix(tools): correct the CLI contract of every wrapped forensic tool

### DIFF
--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -877,7 +877,7 @@ def run_capa(
             error_type="file_not_found",
         )
 
-    cmd = [capa_bin, "--format", "json", "--quiet"]
+    cmd = [capa_bin, "--json", "--quiet"]
     if rules_path:
         if not Path(rules_path).exists():
             return error_response(
@@ -1018,13 +1018,12 @@ def run_floss(
 
     cmd = [
         floss_bin,
-        "--format",
-        "json",
+        "--json",
         "--minimum-length",
         str(minimum_length),
     ]
     if not include_static:
-        cmd.append("--only")
+        cmd.extend(["--no", "static"])
     cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -1021,10 +1021,13 @@ def run_floss(
         "--json",
         "--minimum-length",
         str(minimum_length),
+        # The sample must precede --no/--only: both are nargs="+" with
+        # `choices`, so argparse consumes the following path as a string
+        # type and exits 2.
+        str(target),
     ]
     if not include_static:
         cmd.extend(["--no", "static"])
-    cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)
     try:

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -57,6 +57,16 @@ def _default_sigma_rules() -> Path:
     return asset_display_path("sigma-rules", "rules", "windows")
 
 
+def _default_chainsaw_mapping() -> Path:
+    """The Sigma-to-EVTX field mapping chainsaw requires for ``hunt -s``.
+
+    ``chainsaw hunt`` treats ``--mapping`` as *required* whenever Sigma rules
+    are supplied; the file ships in chainsaw's own ``mappings/`` directory,
+    which ``mulder setup`` fetches alongside the binary.
+    """
+    return asset_display_path("chainsaw", "mappings", "sigma-event-logs-all.yml")
+
+
 def _resolve_evtx_evidence(evidence_path: str) -> str:
     """Resolve a disk image path to its EVTX extraction directory.
 
@@ -108,6 +118,7 @@ def _run_chainsaw_hunt(
     binary: str,
     evidence_path: Path,
     sigma_rules_path: Path,
+    mapping_path: Path,
     output_dir: Path,
     time_start: str | None = None,
     time_end: str | None = None,
@@ -119,6 +130,7 @@ def _run_chainsaw_hunt(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         sigma_rules_path: Path to Sigma rules directory.
+        mapping_path: Path to the chainsaw Sigma field-mapping file.
         output_dir: Output directory for results.
         time_start: Optional time range start (ISO 8601).
         time_end: Optional time range end (ISO 8601).
@@ -137,6 +149,8 @@ def _run_chainsaw_hunt(
         str(evidence_path),
         "-s",
         str(sigma_rules_path),
+        "--mapping",
+        str(mapping_path),
         "--json",
         "--output",
         str(output_file),
@@ -208,13 +222,18 @@ def _run_chainsaw_search(
 
 
 def _run_chainsaw_srum(
-    binary: str, srum_path: Path, output_dir: Path, timeout: int = _CHAINSAW_TIMEOUT
+    binary: str,
+    srum_path: Path,
+    software_hive: Path,
+    output_dir: Path,
+    timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw SRUM parsing mode.
 
     Args:
         binary: Resolved Chainsaw executable.
         srum_path: Path to the SRUDB.dat file.
+        software_hive: Path to the SOFTWARE registry hive (required by chainsaw).
         output_dir: Output directory for results.
         timeout: Subprocess timeout in seconds.
 
@@ -230,7 +249,8 @@ def _run_chainsaw_srum(
         "analyse",
         "srum",
         str(srum_path),
-        "--json",
+        "--software",
+        str(software_hive),
         "--output",
         str(output_file),
     ]
@@ -248,8 +268,6 @@ def _run_chainsaw_timeline(
     binary: str,
     evidence_path: Path,
     output_dir: Path,
-    time_start: str | None = None,
-    time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw in dump/timeline mode against EVTX files.
@@ -258,8 +276,6 @@ def _run_chainsaw_timeline(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         output_dir: Output directory for results.
-        time_start: Optional time range start.
-        time_end: Optional time range end.
         timeout: Subprocess timeout in seconds.
 
     Returns:
@@ -277,10 +293,6 @@ def _run_chainsaw_timeline(
         "--output",
         str(output_file),
     ]
-    if time_start:
-        cmd.extend(["--from", time_start])
-    if time_end:
-        cmd.extend(["--to", time_end])
 
     subprocess.run(
         cmd,
@@ -420,6 +432,7 @@ def run_chainsaw(
     mode: Literal["hunt", "search", "srum", "timeline"] = "hunt",
     sigma_rules_path: str = "",
     search_term: str | None = None,
+    software_hive: str = "",
     time_range_start: str | None = None,
     time_range_end: str | None = None,
     force: bool = False,
@@ -442,10 +455,13 @@ def run_chainsaw(
             resolves to the rules installed by 'mulder setup'.
         search_term: Required when mode="search". The keyword or
             regex pattern to search for in EVTX records.
+        software_hive: Required when mode="srum". Path to the SOFTWARE
+            registry hive extracted from the same host as the SRUM
+            database; chainsaw needs it to resolve application IDs.
         time_range_start: Optional ISO 8601 timestamp to filter results
-            (inclusive start).
+            (inclusive start). Not supported in "timeline" mode.
         time_range_end: Optional ISO 8601 timestamp to filter results
-            (inclusive end).
+            (inclusive end). Not supported in "timeline" mode.
         force: Re-run extraction even if sources already exist.
     """
     tc_id = make_tool_call_id()
@@ -455,6 +471,7 @@ def run_chainsaw(
         "mode": mode,
         "sigma_rules_path": sigma_rules_path,
         "search_term": search_term,
+        "software_hive": software_hive,
         "time_range_start": time_range_start,
         "time_range_end": time_range_end,
         "force": force,
@@ -511,7 +528,37 @@ def run_chainsaw(
             error_type="invalid_argument",
         )
 
+    if mode == "srum" and not software_hive:
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "software_hive is required when mode='srum': chainsaw needs the "
+            "SOFTWARE registry hive to resolve SRUM application IDs",
+            error_type="invalid_argument",
+        )
+
+    if mode == "timeline" and (time_range_start or time_range_end):
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "chainsaw dump has no time-range filter; use mode='search' or "
+            "filter the returned timeline instead",
+            error_type="invalid_argument",
+        )
+
     rules = Path(sigma_rules_path) if sigma_rules_path else _default_sigma_rules()
+    mapping = _default_chainsaw_mapping()
+    if mode == "hunt" and not mapping.exists():
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            f"chainsaw Sigma mapping not found at {mapping}. Run 'mulder setup' "
+            "to provision chainsaw's mappings/ directory.",
+            error_type="asset_missing",
+        )
 
     timeout = adaptive_timeout(evidence_path, base=_CHAINSAW_TIMEOUT)
     with tempfile.TemporaryDirectory(prefix="mulder_chainsaw_") as tmpdir:
@@ -522,6 +569,7 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     rules,
+                    mapping,
                     output_dir,
                     time_range_start,
                     time_range_end,
@@ -544,7 +592,11 @@ def run_chainsaw(
                 source_name = "chainsaw.search"
             elif mode == "srum":
                 results_path = _run_chainsaw_srum(
-                    binary, Path(evidence_path), output_dir, timeout=timeout
+                    binary,
+                    Path(evidence_path),
+                    Path(software_hive),
+                    output_dir,
+                    timeout=timeout,
                 )
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"
@@ -553,8 +605,6 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     output_dir,
-                    time_range_start,
-                    time_range_end,
                     timeout=timeout,
                 )
                 result = _parse_chainsaw_timeline_results(results_path)

--- a/src/mulder/server/tools/hayabusa.py
+++ b/src/mulder/server/tools/hayabusa.py
@@ -257,8 +257,8 @@ def run_hayabusa(
     if severity not in _VALID_SEVERITIES:
         severity = "medium"
 
-    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-        out_path = tmp.name
+    tmp_dir = tempfile.mkdtemp(prefix="mulder_hayabusa_")
+    out_path = str(Path(tmp_dir) / "timeline.csv")
 
     cmd = [
         hayabusa_bin,
@@ -267,6 +267,7 @@ def run_hayabusa(
         resolved_dir,
         "-o",
         out_path,
+        "--clobber",
         "-p",
         "super-verbose",
         "--no-wizard",
@@ -293,7 +294,7 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
-        if proc.returncode != 0 and not Path(out_path).exists():
+        if proc.returncode != 0:
             stderr_preview = (proc.stderr or "")[:_PREVIEW_CHAR_LIMIT]
             return error_response(
                 tc_id,
@@ -303,12 +304,24 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
+        if not Path(out_path).exists():
+            # Hayabusa reports several fatal conditions on stdout and still
+            # exits 0; a missing output file is the only reliable signal.
+            preview = ((proc.stderr or "") + (proc.stdout or ""))[-_PREVIEW_CHAR_LIMIT:]
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                f"Hayabusa produced no output file: {preview}",
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+            )
+
         try:
             csv_text = Path(out_path).read_text(errors="replace")
         except OSError:
             csv_text = ""
     finally:
-        Path(out_path).unlink(missing_ok=True)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
     if not csv_text.strip():
         elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -100,7 +100,6 @@ def _run_zircolite_process(
         str(events_path),
         "--ruleset",
         str(ruleset_path),
-        "--json",
         "--outfile",
         str(output_file),
         *format_flags,

--- a/tests/test_binary_resolution.py
+++ b/tests/test_binary_resolution.py
@@ -34,6 +34,14 @@ def _completed(**kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
+def _fake_mapping(root: Path) -> Path:
+    """chainsaw hunt refuses to start without --mapping; give it a real file."""
+    mapping = root / "chainsaw_mappings" / "sigma-event-logs-all.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("")
+    return mapping
+
+
 class TestChainsaw:
     def test_execs_the_binary_the_gate_found(self, tmp_path: Path) -> None:
         from mulder.server.tools.chainsaw import run_chainsaw
@@ -41,10 +49,15 @@ class TestChainsaw:
         chainsaw = _fake_binary(tmp_path, "chainsaw")
         evidence = tmp_path / "evtx"
         evidence.mkdir()
+        mapping = _fake_mapping(tmp_path)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=str(chainsaw)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -76,10 +89,15 @@ class TestChainsaw:
         binary = installed / "chainsaw"
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
+        mapping = _fake_mapping(asset_root)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=None),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -104,6 +122,9 @@ class TestChainsaw:
         chainsaw.mkdir()
         (chainsaw / "chainsaw").write_text("")
         (chainsaw / "chainsaw").chmod(0o755)
+        mappings = chainsaw / "mappings"
+        mappings.mkdir()
+        (mappings / "sigma-event-logs-all.yml").write_text("")
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
@@ -115,7 +136,11 @@ class TestChainsaw:
         ):
             run_chainsaw.__wrapped__(str(asset_root))  # type: ignore[attr-defined]
 
-        assert str(rules) in mock_run.call_args[0][0]
+        argv = mock_run.call_args[0][0]
+        assert str(rules) in argv
+        # chainsaw treats --mapping as required whenever Sigma rules are given.
+        assert "--mapping" in argv
+        assert str(mappings / "sigma-event-logs-all.yml") in argv
 
 
 def _eve_stub() -> dict[str, Any]:

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -1,0 +1,205 @@
+"""Regression tests for the argv mulder hands to each wrapped forensic tool.
+
+Every assertion below was checked against the pinned release of the tool
+(``src/mulder/assets/manifest.py``) by running the real binary:
+
+* ``chainsaw 2.16.0`` -- ``hunt -s <rules>`` without ``--mapping`` exits 2
+  ("the following required arguments were not provided: --mapping");
+  ``analyse srum`` requires ``--software`` and has no ``--json``;
+  ``dump`` has no ``--from`` / ``--to``.
+* ``hayabusa 3.8.1`` -- ``csv-timeline -o <existing file>`` refuses to run
+  **and exits 0**, so only ``--clobber`` (or an absent path) makes it work.
+* ``capa 9.4.0`` / ``floss 3.1.0`` -- ``--format`` selects the *sample*
+  format; ``--format json`` is an invalid choice and both exit 2.
+* ``Zircolite 2.20.0`` -- has no ``--json`` flag at all; JSON is the default.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestZircoliteArgv:
+    def test_no_json_flag(self, tmp_path: Path) -> None:
+        from mulder.server.tools.zircolite import _run_zircolite_process
+
+        with patch(
+            "mulder.server.tools.zircolite.subprocess.run", return_value=_completed()
+        ) as run:
+            _run_zircolite_process(
+                "zircolite.py", tmp_path, "evtx", tmp_path / "rules.json", tmp_path
+            )
+
+        argv = run.call_args[0][0]
+        assert "--json" not in argv, "Zircolite 2.20.0 has no --json flag; argparse exits 2"
+        assert "--events" in argv
+        assert "--ruleset" in argv
+        assert "--outfile" in argv
+
+
+class TestCapaFlossArgv:
+    def test_capa_uses_json_not_format_json(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        assert '[capa_bin, "--json", "--quiet"]' in source
+        assert '"--format",\n        "json"' not in source
+
+    def test_floss_excludes_static_with_no_static(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        # A bare `--only` is nargs="+" and swallowed the sample path.
+        assert 'cmd.extend(["--no", "static"])' in source
+        assert 'cmd.append("--only")' not in source
+
+
+class TestChainsawArgv:
+    @staticmethod
+    def _run(tmp_path: Path, **kwargs: Any) -> tuple[dict[str, object], list[str] | None]:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "mappings" / "sigma-event-logs-all.yml"
+        mapping.parent.mkdir(parents=True, exist_ok=True)
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir(exist_ok=True)
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch("mulder.server.tools.chainsaw._default_chainsaw_mapping", return_value=mapping),
+            patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+            patch("mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()) as run,
+        ):
+            result = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+                str(evidence), **kwargs
+            )
+        argv = list(run.call_args[0][0]) if run.call_args else None
+        return result, argv
+
+    def test_hunt_passes_mapping(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="hunt")
+        assert argv is not None
+        assert "--mapping" in argv
+
+    def test_hunt_errors_when_mapping_asset_is_absent(self, tmp_path: Path) -> None:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=tmp_path / "nope.yml",
+            ),
+        ):
+            result = run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+
+        assert result["error_type"] == "asset_missing"
+
+    def test_srum_requires_software_hive(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="srum")
+        assert result["error_type"] == "invalid_argument"
+        assert "software_hive" in str(result["error_message"])
+        assert argv is None, "chainsaw must not be executed without --software"
+
+    def test_srum_passes_software_and_no_json(self, tmp_path: Path) -> None:
+        hive = tmp_path / "SOFTWARE"
+        hive.write_bytes(b"regf")
+        _, argv = self._run(tmp_path, mode="srum", software_hive=str(hive))
+        assert argv is not None
+        assert "--software" in argv
+        assert str(hive) in argv
+        assert "--json" not in argv, "chainsaw analyse srum has no --json flag"
+
+    def test_timeline_rejects_a_time_range(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="timeline", time_range_start="2024-01-01T00:00:00")
+        assert result["error_type"] == "invalid_argument"
+        assert argv is None
+
+    def test_timeline_without_a_range_passes_no_from_to(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="timeline")
+        assert argv is not None
+        assert "--from" not in argv
+        assert "--to" not in argv
+
+
+class TestHayabusaArgv:
+    def test_clobber_is_passed_and_output_path_is_fresh(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        seen: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen["argv"] = cmd
+            out = Path(cmd[cmd.index("-o") + 1])
+            seen["existed_before"] = out.exists()
+            out.write_text("Timestamp,RuleTitle\n")
+            return _completed()
+
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(hb.subprocess, "run", side_effect=fake_run),
+        ):
+            hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert "--clobber" in seen["argv"]
+        assert seen["existed_before"] is False, (
+            "hayabusa refuses to overwrite an existing -o path and exits 0 while doing so"
+        )
+
+    def test_missing_output_file_is_an_error_not_zero_alerts(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        # The real refusal: exit 0, nothing written.
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(
+                hb.subprocess,
+                "run",
+                return_value=_completed(stdout="[ERROR] The file already exists."),
+            ),
+        ):
+            result = hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert result["status"] == "error"
+        assert result.get("total_alerts") != 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -16,6 +16,7 @@ Every assertion below was checked against the pinned release of the tool
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -46,17 +47,104 @@ class TestZircoliteArgv:
         assert "--outfile" in argv
 
 
-class TestCapaFlossArgv:
-    def test_capa_uses_json_not_format_json(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        assert '[capa_bin, "--json", "--quiet"]' in source
-        assert '"--format",\n        "json"' not in source
+def _floss_parser() -> argparse.ArgumentParser:
+    """floss 3.1.0's parser, for the options mulder passes.
 
-    def test_floss_excludes_static_with_no_static(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        # A bare `--only` is nargs="+" and swallowed the sample path.
-        assert 'cmd.extend(["--no", "static"])' in source
-        assert 'cmd.append("--only")' not in source
+    Mirrors floss/main.py v3.1.0: `-n/--minimum-length`, a positional
+    `sample`, `--no`/`--only` as ``action="extend", nargs="+"`` over
+    ``{static,stack,tight,decoded}``, `-f/--format` over
+    ``{auto,pe,sc32,sc64}`` and `-j/--json`. Parsing mulder's argv with it
+    is what catches a flag rename that argparse would still reject.
+    """
+
+    class _Extend(argparse.Action):
+        def __call__(  # type: ignore[override]
+            self,
+            parser: argparse.ArgumentParser,
+            namespace: argparse.Namespace,
+            values: Any,
+            option_string: str | None = None,
+        ) -> None:
+            items = list(getattr(namespace, self.dest, None) or [])
+            items.extend(values)
+            setattr(namespace, self.dest, items)
+
+    types = ["static", "stack", "tight", "decoded"]
+    parser = argparse.ArgumentParser(prog="floss", add_help=False)
+    parser.register("action", "extend", _Extend)
+    parser.add_argument("-n", "--minimum-length", dest="min_length", type=int, default=4)
+    parser.add_argument("sample")
+    parser.add_argument(
+        "--no", action="extend", dest="disabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument(
+        "--only", action="extend", dest="enabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument("-f", "--format", choices=["auto", "pe", "sc32", "sc64"], default="auto")
+    parser.add_argument("-j", "--json", action="store_true")
+    return parser
+
+
+def _capa_parser() -> argparse.ArgumentParser:
+    """capa 9.4.0's parser, for the options mulder passes."""
+    parser = argparse.ArgumentParser(prog="capa", add_help=False)
+    parser.add_argument("-q", "--quiet", action="store_true")
+    parser.add_argument("-j", "--json", action="store_true")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["auto", "pe", "dotnet", "elf", "sc32", "sc64", "cape", "freeze"],
+        default="auto",
+    )
+    parser.add_argument("-r", "--rules", action="append", default=[])
+    parser.add_argument("sample")
+    return parser
+
+
+class TestCapaFlossArgv:
+    """Parse mulder's argv with each tool's own parser, not with a substring."""
+
+    @staticmethod
+    def _argv(tool: str, tmp_path: Path, **kwargs: Any) -> list[str]:
+        from mulder.server.tools import binary as b
+
+        sample = tmp_path / "sample.bin"
+        sample.write_bytes(b"MZ\x90\x00")
+        fake = tmp_path / tool
+        fake.write_text("#!/bin/sh\n")
+        fake.chmod(0o755)
+
+        with (
+            patch.object(b, "require_binary", return_value=str(fake)),
+            patch.object(b, "extract_and_index", return_value={}),
+            patch.object(b.subprocess, "run", return_value=_completed(stdout="{}")) as run,
+        ):
+            fn = b.run_capa if tool == "capa" else b.run_floss
+            fn.__wrapped__("case", str(sample), **kwargs)  # type: ignore[attr-defined]
+        return list(run.call_args[0][0])
+
+    def test_capa_argv_parses(self, tmp_path: Path) -> None:
+        argv = self._argv("capa", tmp_path)
+        # capa's --format takes a *sample* format; "--format json" exits 2.
+        assert "--format" not in argv
+        _capa_parser().parse_args(argv[1:])
+
+    def test_floss_argv_parses_with_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=True)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.json is True
+        assert ns.disabled_types == []
+
+    def test_floss_argv_parses_without_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=False)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.disabled_types == ["static"]
+        assert ns.sample.endswith("sample.bin")
+
+    def test_floss_sample_precedes_the_type_flags(self, tmp_path: Path) -> None:
+        """`--no static <sample>` still exits 2: nargs="+" eats the path."""
+        argv = self._argv("floss", tmp_path, include_static=False)
+        assert argv.index("--no") > argv.index(next(a for a in argv if a.endswith("sample.bin")))
 
 
 class TestChainsawArgv:


### PR DESCRIPTION
## BLUF

- **What breaks:** Five wrapped forensic tools are invoked with flags their pinned release does not accept. Each aborts on argument parsing before doing any work.
- **Impact:** Because the callers discard the `CompletedProcess`, a tool that never ran is reported to the analyst as a **completed scan with zero detections**. This is the worst failure mode a DFIR tool can have — a false negative that looks like a clean result.
- **Scope:** `run_zircolite`, `run_chainsaw` (hunt / srum / timeline), `run_hayabusa`, `run_capa`, `run_floss`. On the pinned versions, **none of these five ever executed successfully.**
- **Verification:** Every flag below was checked by downloading and running the exact pinned binary, not by reading docs.
- **Risk:** Low for capa/floss/zircolite (flag rename only). `run_chainsaw(mode="srum")` gains a required `software_hive` argument, and `mode="timeline"` now rejects a time range instead of silently exiting 2 — both are API changes, flagged below.

## Priority

**critical** — silent false negatives across five detection engines.

## What was verified, and how

| Tool (pinned) | Old argv | Observed | Fix |
|---|---|---|---|
| Zircolite 2.20.0 | `--json` | flag does not exist; argparse exits 2. JSON is the **default**, `--csv` switches away | drop `--json` |
| chainsaw 2.16.0 `hunt` | `-s <rules>` | `error: the following required arguments were not provided: --mapping` — **exit 2** | pass `--mapping` |
| chainsaw 2.16.0 `analyse srum` | `--json --output` | `Usage: chainsaw analyse srum [OPTIONS] --software <SOFTWARE_HIVE_PATH>`; no `--json` option exists | pass `--software`, drop `--json` |
| chainsaw 2.16.0 `dump` | `--from` / `--to` | neither flag exists on `dump` | reject a time range up front |
| hayabusa 3.8.1 | `-o <pre-created temp file>` | `[ERROR] The file ... already exists. Please specify a different filename or add the -C, --clobber option` — **and exits 0** | fresh path in a temp dir + `--clobber` |
| capa 9.4.0 | `--format json` | `--format` choices are `{auto,pe,dotnet,elf,sc32,sc64,...}`; **exit 2** | `--json` |
| floss 3.1.0 | `--format json`, bare `--only` | `--format` choices are `{auto,pe,sc32,sc64}`; `--only` is `nargs="+"` and swallowed the sample path | `--json`, sample **before** `--no static` |

The hayabusa case is the nastiest: it refuses to overwrite **and exits 0**, so the existing guard

```python
if proc.returncode != 0 and not Path(out_path).exists():
```

could never fire — `out_path` was created by `NamedTemporaryFile(delete=False)` and the return code was 0. The empty CSV then rendered as `total_alerts: 0`. The guard is now split: non-zero exit is an error, and a **missing output file is also an error** rather than "zero alerts".

## API changes

- `run_chainsaw` gains `software_hive: str = ""`. It is **required** when `mode="srum"` (chainsaw needs the SOFTWARE hive to resolve SRUM application IDs) and returns `invalid_argument` when absent, instead of shelling out to a command that cannot parse.
- `run_chainsaw(mode="timeline", time_range_start=...)` now returns `invalid_argument` pointing at `mode="search"`, rather than passing unsupported flags to `chainsaw dump`.
- `run_chainsaw(mode="hunt")` returns `asset_missing` if chainsaw's `mappings/` directory was not provisioned by `mulder setup`.

## A second-order bug in the floss fix

`--no` is `action="extend", nargs="+"` with `choices`, so `--no static <sample>` is *also* rejected — argparse matches both `static` and the sample path against the string-type choices and exits 2. The sample therefore has to precede the type flags. Both orderings were run through floss 3.1.0's own parser; only `--json -n 6 <sample> --no static` parses.

## Fixes verified to run, not just to differ

| Check | Result |
|---|---|
| `chainsaw hunt … --mapping …` | clears clap; fails later on rule content only |
| `capa --json --quiet <sample>` | exit 10 (missing embedded rules in a library install) — a runtime error, not usage |
| `chainsaw analyse srum -o` writes JSON | confirmed in `src/main.rs` v2.16.0 (`cs_print_json!`), so the existing `json.loads` parser is right |
| hayabusa `--clobber` on a real 2 MB `security.evtx` | **288 detection rows written** |
| hayabusa with zero detections | creates a 0-byte file — so the new "missing output file" guard does not misfire on a genuinely clean run |

## Tests

New `tests/test_cli_contracts.py` (13 tests) pins the corrected argv for each tool and records, in the module docstring, exactly which real binary produced each observation. The hayabusa test asserts the output path **does not exist** when the process is spawned — the condition that actually distinguishes working from broken, which a `"--clobber" in argv` assertion alone would not catch.

`tests/test_binary_resolution.py` fixtures gained the chainsaw `mappings/` file the new asset gate requires.

The capa and floss tests build each tool's *own* argparse parser and parse mulder's argv with it, rather than asserting on source text — a substring assertion passes for the broken `--no static <sample>` ordering, a parse does not.

`make lint format typecheck test` — 755 passed (742 baseline, +13), mypy clean, ruff clean.

## Related

The discarded `CompletedProcess` that turned these into silent successes is a separate root cause and is fixed in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
