### PR TITLE
[critical] fix(index): align evidence windows to line boundaries

### DIFF
--- a/src/mulder/server/extract_helpers.py
+++ b/src/mulder/server/extract_helpers.py
@@ -103,6 +103,56 @@ def _parse_timestamp(text: str, reference_year: int | None = None) -> str | None
 _INSERT_BATCH_SIZE = 5000
 
 
+def _line_aligned_windows(raw_output: str) -> Iterator[tuple[str, int, int]]:
+    """Yield ``(text, first_line, last_line)`` windows that never split a line.
+
+    Windows used to be cut at absolute character offsets
+    (``raw_output[offset : offset + 4096]``), which severs whichever record
+    straddles the boundary.  Around twenty callers then read *one* record out
+    of each window -- a PID, a module name, a command line -- so a severed row
+    does not merely lose data, it yields a **wrong** value: a truncated PID
+    that still parses as an integer, or a process name from one row paired
+    with the PID from another.  Two windows sampled from the same output can
+    then be diffed against each other and produce fabricated "hidden process"
+    or "hidden module" findings.
+
+    Line numbers are 1-based and inclusive -- which is what the ``line_start``
+    and ``line_end`` columns have always claimed to hold, and did not.
+
+    A single line longer than the window budget is still split, because it has
+    to be; that is pathological input (a whole file on one line) rather than
+    the routine case.
+    """
+    budget = _WINDOW_CHAR_BUDGET
+    current: list[str] = []
+    current_len = 0
+    first_line = 1
+    last_line = 1
+
+    for line_no, line in enumerate(raw_output.splitlines(keepends=True), start=1):
+        pieces = (
+            [line[i : i + budget] for i in range(0, len(line), budget)]
+            if len(line) > budget
+            else [line]
+        )
+        for piece in pieces:
+            if current and current_len + len(piece) > budget:
+                text = "".join(current)
+                if text.strip():
+                    yield text, first_line, last_line
+                current = []
+                current_len = 0
+                first_line = line_no
+            current.append(piece)
+            current_len += len(piece)
+            last_line = line_no
+
+    if current:
+        text = "".join(current)
+        if text.strip():
+            yield text, first_line, last_line
+
+
 def extract_and_index(
     raw_output: str,
     source_name: str,
@@ -156,20 +206,16 @@ def extract_and_index(
 
     total_indexed = 0
     batch: list[WindowRow] = []
-    budget = _WINDOW_CHAR_BUDGET
 
-    for offset in range(0, len(raw_output), budget):
-        chunk = raw_output[offset : offset + budget]
-        if not chunk.strip():
-            continue
-        event_time = _parse_timestamp(chunk)
+    for window_text, first_line, last_line in _line_aligned_windows(raw_output):
+        event_time = _parse_timestamp(window_text)
         batch.append(
             WindowRow(
                 source_id=source_id,
-                line_start=offset,
-                line_end=offset + len(chunk),
+                line_start=first_line,
+                line_end=last_line,
                 event_time=event_time,
-                raw_text=chunk,
+                raw_text=window_text,
             )
         )
         if len(batch) >= _INSERT_BATCH_SIZE:

--- a/tests/test_window_alignment.py
+++ b/tests/test_window_alignment.py
@@ -1,0 +1,89 @@
+"""Windows must never cut a record in half.
+
+The store used to slice ``raw_output[offset : offset + 4096]`` at absolute
+character offsets. Around twenty callers read one record per window, so a
+severed row does not merely lose data -- it yields a *wrong* value: a
+truncated PID that still parses as an integer, or a process name from one
+row paired with the PID from another.
+"""
+
+from __future__ import annotations
+
+from mulder.server.extract_helpers import _WINDOW_CHAR_BUDGET, _line_aligned_windows
+
+
+def _pslist(rows: int = 200) -> str:
+    """Realistically shaped ``windows.pslist`` output, wide enough to straddle."""
+    header = (
+        "PID\tPPID\tImageFileName\tOffset(V)\tThreads\tHandles\tSessionId\t"
+        "Wow64\tCreateTime\tExitTime\tFile output\n"
+    )
+    lines = [header]
+    for i in range(1, rows + 1):
+        lines.append(
+            f"{i * 4}\t{i * 4 - 4}\tsvchost{i}.exe\t0x{i:012x}\t"
+            f"{i % 40}\t{i * 3}\t0\tFalse\t"
+            f"2024-03-0{i % 9 + 1} 10:{i % 60:02d}:00.000000 UTC\tN/A\tDisabled\n"
+        )
+    return "".join(lines)
+
+
+class TestLineAlignedWindows:
+    def test_no_window_starts_or_ends_mid_record(self) -> None:
+        text = _pslist()
+        for window, _, _ in _line_aligned_windows(text):
+            for line in window.splitlines():
+                # Every real row has exactly ten tabs; a severed one does not.
+                assert line.count("\t") == 10, f"severed row: {line!r}"
+
+    def test_every_row_survives_exactly_once(self) -> None:
+        text = _pslist()
+        recovered = [
+            line for window, _, _ in _line_aligned_windows(text) for line in window.splitlines()
+        ]
+        assert recovered == text.splitlines()
+
+    def test_every_pid_is_recoverable(self) -> None:
+        """The failure this prevents: 40 processes indexed, 39 readable."""
+        text = _pslist(rows=200)
+        pids = {
+            int(line.split("\t")[0])
+            for window, _, _ in _line_aligned_windows(text)
+            for line in window.splitlines()
+            if line.split("\t")[0].isdigit()
+        }
+        assert pids == {i * 4 for i in range(1, 201)}
+
+    def test_line_numbers_are_contiguous_and_one_based(self) -> None:
+        windows = list(_line_aligned_windows(_pslist()))
+        assert windows[0][1] == 1
+        for (_, _, prev_end), (_, next_start, _) in zip(windows, windows[1:], strict=False):
+            assert next_start == prev_end + 1
+
+    def test_line_numbers_cover_the_whole_output(self) -> None:
+        text = _pslist()
+        windows = list(_line_aligned_windows(text))
+        assert windows[-1][2] == len(text.splitlines())
+
+    def test_windows_respect_the_budget(self) -> None:
+        for window, _, _ in _line_aligned_windows(_pslist()):
+            assert len(window) <= _WINDOW_CHAR_BUDGET
+
+    def test_a_single_overlong_line_is_still_split(self) -> None:
+        blob = "A" * (_WINDOW_CHAR_BUDGET * 3 + 17) + "\n"
+        windows = list(_line_aligned_windows(blob))
+        assert len(windows) == 4
+        assert "".join(w for w, _, _ in windows) == blob
+        assert all(s == 1 and e == 1 for _, s, e in windows)
+
+    def test_blank_only_windows_are_dropped(self) -> None:
+        assert list(_line_aligned_windows("\n\n   \n\n")) == []
+
+    def test_empty_input(self) -> None:
+        assert list(_line_aligned_windows("")) == []
+
+    def test_output_without_a_trailing_newline(self) -> None:
+        text = "a\nb\nc"
+        windows = list(_line_aligned_windows(text))
+        assert "".join(w for w, _, _ in windows) == text
+        assert windows[-1][2] == 3


### PR DESCRIPTION
## BLUF

- **What breaks:** `extract_and_index` cuts tool output into 4096-character windows at **absolute offsets**, so whichever record straddles offset 4096, 8192, … is severed mid-line.
- **Why it is not merely lossy:** ~20 callers read exactly *one* record per window (a PID, a module name, a command line). A severed row yields a **wrong** value, not a missing one — a truncated PID that still parses as an integer, or a process name from one row paired with the PID from another.
- **Worst consequence:** two differently-sampled window sets get diffed against each other, producing **fabricated "hidden process" / "hidden module" findings** an analyst cannot reproduce.
- **Fix:** accumulate whole lines up to the same budget. No record is ever split. An overlong single line is still cut, because it must be.
- **Bonus:** `line_start` / `line_end` now hold real 1-based inclusive **line numbers** — what their names always claimed. They held character offsets.
- **Risk:** Low. Nothing computes on those columns; `db.py` only orders by `line_start`, and the CLI and findings tools display them.

## Priority

**critical** — this single site is the root cause behind roughly twenty separate observable defects, including fabricated detections.

## The defect

```python
for offset in range(0, len(raw_output), budget):
    chunk = raw_output[offset : offset + budget]
```

Nothing here respects a record boundary. For a `windows.pslist` dump the boundary lands mid-row roughly every 38 rows.

## Why line numbers were wrong too

`line_start=offset` and `line_end=offset + len(chunk)` were character offsets stored in columns named for lines. A window citation of "lines 4096–8192" in a report is not a citation of anything. They are now the actual first and last line the window contains, contiguous across windows and covering the whole output.

## Tests

New `tests/test_window_alignment.py` (10 tests) drives realistically shaped `windows.pslist` output — 200 rows, 11 tab-separated columns, wide enough that rows genuinely straddle the budget:

- **every row has exactly ten tabs in every window** — a severed row does not, so this is the assertion that fails on `main`;
- **all 200 PIDs are recoverable** — the concrete failure being prevented (200 processes indexed, some fraction readable);
- round-trip: concatenating every window reproduces the input exactly;
- line numbers are 1-based, contiguous, and reach the last line;
- an overlong single line still splits and still round-trips;
- blank-only windows are dropped; empty input; no trailing newline.

`make lint format typecheck test` — 752 passed (742 baseline, +10), mypy clean, ruff clean.

## Follow-up, not in this PR

The other half of this cluster is in the **analysis** layer: `helpers.py::extract_pid` and `extract_module_names` use `re.search`, taking only the *first* match in a window. With line alignment fixed, a window now holds ~38 intact rows and those helpers still read one of them. Fixing the storage layer alone leaves that sampling in place; it is a separate root cause and gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
