### PR TITLE
[high] fix(correlate): read every record in a window, not just the first

### DIFF
--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -398,38 +398,77 @@ def error_response(
     return result
 
 
-_PID_RE = re.compile(r"(?:^|\t)(\d{1,6})(?:\t|$)", re.MULTILINE)
-_MODULE_NAME_RE = re.compile(r"^([^\t]+\.sys)", re.MULTILINE | re.IGNORECASE)
+_PID_RE = re.compile(r"(?:^|\t)(\d{1,6})(?:\t|$)")
+_MODULE_NAME_RE = re.compile(r"^([^\t]+\.sys)", re.IGNORECASE)
 
 
 def extract_pid(text: str) -> int | None:
-    """Parse the first PID value from a Volatility output line."""
-    m = _PID_RE.search(text)
-    if m:
-        val = int(m.group(1))
-        if val > 0:
-            return val
+    """The first PID value in *text*.
+
+    Prefer :func:`extract_pids` when *text* is a whole window: a window holds
+    many records, and "the first one" is rarely the question being asked.
+    """
+    for line in text.splitlines():
+        m = _PID_RE.search(line)
+        if m:
+            val = int(m.group(1))
+            if val > 0:
+                return val
     return None
 
 
+def extract_pids(text: str) -> list[int]:
+    """Every PID in *text*, one per record, in order and without duplicates.
+
+    One window holds many records. Reading only the first -- which is what
+    ``re.search`` over the whole window did -- means a window of forty
+    processes contributes exactly one of them and the other thirty-nine are
+    invisible to every correlation built on top: process trees miss parents,
+    "hidden process" diffs compare two differently-sampled sets and report
+    processes that are in both, and per-PID lookups silently return nothing.
+
+    Which column holds the PID still varies by Volatility plugin
+    (``windows.pslist`` puts it first, ``windows.netscan`` eighth), so the
+    per-line match is deliberately unchanged from what it always was. Only
+    the number of lines examined changes: all of them, rather than one.
+    """
+    seen: dict[int, None] = {}
+    for line in text.splitlines():
+        m = _PID_RE.search(line)
+        if m:
+            val = int(m.group(1))
+            if val > 0:
+                seen.setdefault(val, None)
+    return list(seen)
+
+
+def window_has_pid(text: str, pid: int) -> bool:
+    """Whether *text* contains a record for *pid*."""
+    return pid in extract_pids(text)
+
+
 def extract_pids_from_windows(windows: Sequence[Any]) -> dict[int, list[Any]]:
-    """Group windows by the PID found in their text."""
+    """Map every PID in every window to the windows that mention it."""
     pid_map: dict[int, list[Any]] = defaultdict(list)
     for w in windows:
-        pid = extract_pid(w.raw_text)
-        if pid is not None:
+        for pid in extract_pids(w.raw_text):
             pid_map[pid].append(w)
     return dict(pid_map)
 
 
 def extract_module_names(windows: Sequence[Any]) -> dict[str, list[Any]]:
-    """Group windows by the kernel module name found in their text."""
+    """Map every kernel module name in every window to the windows naming it."""
     mod_map: dict[str, list[Any]] = defaultdict(list)
     for w in windows:
-        m = _MODULE_NAME_RE.search(w.raw_text)
-        if m:
+        seen: set[str] = set()
+        for line in w.raw_text.splitlines():
+            m = _MODULE_NAME_RE.match(line)
+            if not m:
+                continue
             name = m.group(1).strip().lower()
-            mod_map[name].append(w)
+            if name not in seen:
+                seen.add(name)
+                mod_map[name].append(w)
     return dict(mod_map)
 
 

--- a/src/mulder/server/tools/composite/core.py
+++ b/src/mulder/server/tools/composite/core.py
@@ -95,7 +95,7 @@ _EXE_CMD = "cmd.exe"
 
 _PORT_RE = re.compile(r":(\d{1,5})(?:\s|$)")
 _PROC_NAME_RE = re.compile(r"^([^\t]+\.exe)", re.MULTILINE | re.IGNORECASE)
-_PPID_RE = re.compile(r"(?:^|\t)(\d{1,6})\t(\d{1,6})(?:\t|$)", re.MULTILINE)
+_PPID_RE = re.compile(r"(?:^|\t)(\d{1,6})\t(\d{1,6})(?:\t|$)")
 
 # ---------------------------------------------------------------------------
 # Caching
@@ -295,16 +295,18 @@ def _build_pid_metadata(
     parent_map: dict[int, int] = {}
     pid_names: dict[int, str] = {}
     for w in pstree_wins:
-        m = _PPID_RE.search(w.raw_text)
-        if m:
-            parent_map[int(m.group(1))] = int(m.group(2))
-        pid = extract_pid(w.raw_text)
-        if pid is not None:
-            pid_names[pid] = _extract_process_name(w.raw_text)
+        for line in w.raw_text.splitlines():
+            m = _PPID_RE.search(line)
+            if m:
+                parent_map[int(m.group(1))] = int(m.group(2))
+            pid = extract_pid(line)
+            if pid is not None:
+                pid_names[pid] = _extract_process_name(line)
     for w in cmdline_wins:
-        pid = extract_pid(w.raw_text)
-        if pid is not None and pid not in pid_names:
-            pid_names[pid] = _extract_process_name(w.raw_text)
+        for line in w.raw_text.splitlines():
+            pid = extract_pid(line)
+            if pid is not None and pid not in pid_names:
+                pid_names[pid] = _extract_process_name(line)
     return parent_map, pid_names
 
 

--- a/src/mulder/server/tools/composite/misc.py
+++ b/src/mulder/server/tools/composite/misc.py
@@ -456,18 +456,20 @@ def _correlate_with_netscan(
     ip_re = IP_RE
 
     for w in netscan_wins:
-        netscan_ips = {m.group() for m in ip_re.finditer(w.raw_text)}
-        overlap = netscan_ips & pcap_ips
-        if overlap:
-            pid = extract_pid(w.raw_text)
-            proc_name = _extract_process_name(w.raw_text)
+        for line in w.raw_text.splitlines():
+            netscan_ips = {m.group() for m in ip_re.finditer(line)}
+            overlap = netscan_ips & pcap_ips
+            if not overlap:
+                continue
+            pid = extract_pid(line)
+            proc_name = _extract_process_name(line)
             correlations.append(
                 {
                     "type": "pcap_netscan_ip_match",
                     "matched_ips": sorted(overlap),
                     "pid": pid,
                     "process": proc_name,
-                    "netscan_text": w.raw_text.strip()[:300],
+                    "netscan_text": line.strip()[:300],
                 }
             )
 

--- a/src/mulder/server/tools/core.py
+++ b/src/mulder/server/tools/core.py
@@ -27,12 +27,12 @@ from mulder.server.helpers import (
     _PREVIEW_CHAR_LIMIT,
     audited_tool,
     extract_module_names,
-    extract_pid,
     extract_pids_from_windows,
     hash_output,
     make_tool_call_id,
     serialize_windows,
     truncate_raw_text,
+    window_has_pid,
     windowed_response,
 )
 from mulder.server.tool_access import PLANNERS, Role, tool_access
@@ -692,7 +692,7 @@ def get_process_environment(pid: int) -> dict[str, object]:
 
     pid_str = str(pid)
     search_results = ctx.db.search_windows(pid_str, source_name=_SRC_ENVARS)
-    matching = [row[0] for row in search_results if extract_pid(row[0].raw_text) == pid]
+    matching = [row[0] for row in search_results if window_has_pid(row[0].raw_text, pid)]
     elapsed = (time.monotonic() - t0) * 1000
     return windowed_response(
         tc_id, matching, _SRC_ENVARS, "get_process_environment", {"pid": pid}, elapsed
@@ -714,7 +714,7 @@ def get_process_privileges(pid: int) -> dict[str, object]:
 
     pid_str = str(pid)
     search_results = ctx.db.search_windows(pid_str, source_name=_SRC_PRIVS)
-    matching = [row[0] for row in search_results if extract_pid(row[0].raw_text) == pid]
+    matching = [row[0] for row in search_results if window_has_pid(row[0].raw_text, pid)]
     elapsed = (time.monotonic() - t0) * 1000
     return windowed_response(
         tc_id, matching, _SRC_PRIVS, "get_process_privileges", {"pid": pid}, elapsed

--- a/tests/test_per_record_extraction.py
+++ b/tests/test_per_record_extraction.py
@@ -1,0 +1,95 @@
+"""A window holds many records; the extractors used to read exactly one.
+
+``extract_pids_from_windows`` and ``extract_module_names`` ran ``re.search``
+over the whole window text, so a window of forty processes contributed one
+PID and the other thirty-nine were invisible to every correlation built on
+top of them.
+"""
+
+from __future__ import annotations
+
+from mulder.models import WindowRow
+from mulder.server.helpers import (
+    extract_module_names,
+    extract_pid,
+    extract_pids,
+    extract_pids_from_windows,
+    window_has_pid,
+)
+
+
+def _window(text: str, source_id: int = 1) -> WindowRow:
+    return WindowRow(source_id=source_id, line_start=1, line_end=1, event_time=None, raw_text=text)
+
+
+PSLIST = "\n".join(
+    f"{pid}\t{pid - 4}\tsvchost{i}.exe\t0x{pid:012x}\t12\t340\t0\tFalse\tN/A"
+    for i, pid in enumerate(range(4, 4 * 41, 4), start=1)
+)
+
+MODULES = "\n".join(
+    f"driver{i}.sys\t0x{i:08x}\t\\SystemRoot\\System32\\drivers\\driver{i}.sys"
+    for i in range(1, 21)
+)
+
+
+class TestExtractPids:
+    def test_every_pid_in_a_multi_record_window(self) -> None:
+        assert extract_pids(PSLIST) == list(range(4, 4 * 41, 4))
+
+    def test_first_pid_is_unchanged(self) -> None:
+        assert extract_pid(PSLIST) == 4
+
+    def test_duplicates_collapse_but_order_is_kept(self) -> None:
+        assert extract_pids("9\t0\ta\n4\t0\tb\n9\t0\tc") == [9, 4]
+
+    def test_zero_is_not_a_pid(self) -> None:
+        assert extract_pids("0\t0\tidle") == []
+
+    def test_no_records(self) -> None:
+        assert extract_pids("no numeric pid here") == []
+        assert extract_pids("") == []
+
+    def test_the_per_line_match_is_unchanged(self) -> None:
+        """Which column holds the PID varies by plugin; only the line count changed."""
+        # windows.netscan puts the PID eighth; the historical match takes the
+        # first tab-delimited number on the line either way.
+        assert extract_pids("svchost.exe\t1234\t456\t...") == [1234]
+
+
+class TestExtractPidsFromWindows:
+    def test_all_forty_processes_are_grouped(self) -> None:
+        mapping = extract_pids_from_windows([_window(PSLIST)])
+        assert set(mapping) == set(range(4, 4 * 41, 4))
+
+    def test_a_pid_spanning_two_windows_maps_to_both(self) -> None:
+        mapping = extract_pids_from_windows([_window("7\t0\ta"), _window("7\t0\tb\n9\t0\tc")])
+        assert len(mapping[7]) == 2
+        assert len(mapping[9]) == 1
+
+    def test_empty_input(self) -> None:
+        assert extract_pids_from_windows([]) == {}
+
+
+class TestWindowHasPid:
+    def test_finds_a_pid_that_is_not_the_first(self) -> None:
+        assert window_has_pid(PSLIST, 160) is True
+
+    def test_absent_pid(self) -> None:
+        assert window_has_pid(PSLIST, 999999) is False
+
+
+class TestExtractModuleNames:
+    def test_all_modules_in_one_window(self) -> None:
+        mapping = extract_module_names([_window(MODULES)])
+        assert set(mapping) == {f"driver{i}.sys" for i in range(1, 21)}
+
+    def test_only_the_first_column_is_a_module_name(self) -> None:
+        """A .sys path in a later column is the same module, not a second one."""
+        mapping = extract_module_names([_window("tcpip.sys\t0x1\t\\SystemRoot\\other.sys")])
+        assert set(mapping) == {"tcpip.sys"}
+
+    def test_a_module_in_two_windows_maps_to_both(self) -> None:
+        mapping = extract_module_names([_window("a.sys\t1"), _window("a.sys\t2\nb.sys\t3")])
+        assert len(mapping["a.sys"]) == 2
+        assert len(mapping["b.sys"]) == 1


### PR DESCRIPTION
## BLUF

- **What breaks:** `extract_pids_from_windows` and `extract_module_names` run `re.search` over the whole window and keep the **single first match**.
- **Impact:** a window holds ~40 `windows.pslist` rows. One process gets grouped; the other 39 are invisible to everything built on top — process trees miss parents, per-PID lookups return nothing, and the *hidden process* / *hidden module* checks compare two differently-sampled sets and flag processes that are present in both.
- **Fix:** visit every line. The **per-line match is deliberately unchanged**, because which column holds the PID varies by plugin (`windows.pslist` first, `windows.netscan` eighth). Only the number of lines examined changes.
- **Also fixed:** two pairing bugs where a PID and a process name were read from *different rows* of the same window.
- **Risk:** Low, and bounded by that deliberate choice — no line that matched before stops matching.

## Priority

**high** — silent under-reporting across every memory-forensics correlation, plus fabricated hidden-process findings.

## Why not anchor the PID to column 1

The obvious fix is to read the PID from the first column of each line. That is right for `pslist`, `cmdline`, `malfind`, `dlllist`, `privs` and `envars` — and **wrong for `netscan`**, where the layout is `Offset Proto LocalAddr LocalPort ForeignAddr ForeignPort State PID Owner Created` and the PID is eighth.

Choosing the column correctly requires knowing the source plugin, which is a larger change than this fix. Keeping the historical per-line match makes this PR a strict improvement with no new failure mode. The column ambiguity is real and worth a maintainer decision — on `netscan` the current regex takes `LocalPort`, not the PID — but it is a separate defect and is not silently changed here.

## The pairing bugs

`composite/core.py::_build_process_maps` did three independent searches over the same window:

```python
m = _PPID_RE.search(w.raw_text)      # row 1, say
pid = extract_pid(w.raw_text)        # row 1
pid_names[pid] = _extract_process_name(w.raw_text)   # could be row 7's name
```

`_PROC_NAME_RE` matches the first `*.exe` anywhere in the window, which is not necessarily on the PID's row. The map could therefore assert that PID 4 is named `chrome.exe`. All three values are now read off one line.

`composite/misc.py` had the same shape in the pcap↔netscan correlation: one PID reported per window even when several rows matched the pcap IP set, with the entire window quoted as evidence. It now walks rows and cites the matching one.

## Tests

New `tests/test_per_record_extraction.py` (14 tests) uses a realistic 40-row `pslist` window and a 20-row `modules` window:

- **all 40 PIDs come back** — the assertion that fails on `main`, where exactly one does;
- `extract_pid` still returns the first, so existing callers are unaffected;
- a PID appearing in two windows maps to both; duplicates within a window collapse but order is kept;
- `window_has_pid` finds a PID that is *not* the first record;
- a `.sys` path in a later column is the same module, not a second one;
- the historical per-line match is pinned by a test, so a later column-anchoring change has to be deliberate.

`make lint format typecheck test` — 756 passed (742 baseline, +14), mypy clean, ruff clean.

## Relationship to the window-alignment PR

That PR stops windows being cut mid-record; this one stops the extractors reading one record out of each window. They are independent — this fix is correct with or without it — but neither alone gives complete correlations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
