### PR TITLE
[critical] fix(report): close template injection and XSS in the HTML report

### DIFF
--- a/src/mulder/report/renderer.py
+++ b/src/mulder/report/renderer.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import jinja2
 import markdown
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 
 from mulder.models import AuditSummary, CaseMetadataRow, Finding, SourceRow
 from mulder.patterns import (
@@ -937,17 +939,46 @@ def _clean_finding_description(text: str) -> str:
     return cleaned
 
 
+_MD_EXTENSIONS = ["fenced_code", "tables", "nl2br"]
+
+
+def _markdown_to_safe_html(text: str) -> str:
+    """Convert *text* to HTML without letting it inject markup.
+
+    Python-Markdown passes raw HTML straight through -- it has had no safe
+    mode since 3.0 -- and both the finding descriptions and the case
+    narrative are built from evidence content: filenames, command lines,
+    registry values, strings carved out of a disk image. Escaping the three
+    markup characters first keeps every markdown construct working (they use
+    ``*``, ``_``, backticks and brackets) while making ``<script>`` inert.
+    """
+    if not text:
+        return ""
+    escaped = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    html: str = markdown.markdown(escaped, extensions=_MD_EXTENSIONS)
+    return html
+
+
 class ReportRenderer:
     """Renders validated findings into markdown and HTML investigation reports."""
 
     def __init__(self) -> None:
         """Configure Jinja to load package templates.
 
-        ``autoescape=False`` preserves markdown until HTML conversion.
+        Autoescaping is on for ``.html.j2`` and off for ``.md.j2``. A single
+        ``autoescape=False`` environment served both, so every value that
+        reaches the HTML report -- filenames, command lines, registry values,
+        all of it read straight off the evidence -- was interpolated as raw
+        markup. Anything already converted to HTML on purpose is marked
+        ``| safe`` in the template.
         """
         self._env = jinja2.Environment(
             loader=jinja2.PackageLoader("mulder", "report/templates"),
-            autoescape=False,
+            autoescape=jinja2.select_autoescape(
+                enabled_extensions=("html", "html.j2"),
+                default_for_string=False,
+                default=False,
+            ),
             keep_trailing_newline=True,
         )
         self._env.filters["attack_url"] = _attack_id_to_url
@@ -975,10 +1006,15 @@ class ReportRenderer:
         if not narrative:
             return narrative
         try:
-            env = jinja2.Environment(undefined=jinja2.Undefined)
+            # SandboxedEnvironment, not Environment: the narrative is
+            # model-authored prose summarising attacker-controlled evidence,
+            # and a plain environment would execute
+            # ``{{ cycler.__init__.__globals__ }}`` and everything reachable
+            # from it as the user running the server.
+            env = SandboxedEnvironment(undefined=jinja2.Undefined)
             template = env.from_string(narrative)
             return template.render(**ctx)
-        except Exception:
+        except (jinja2.TemplateError, SecurityError, TypeError, ValueError):
             return narrative
 
     def build_context(
@@ -1154,14 +1190,7 @@ class ReportRenderer:
 
         rendered_narrative = self._render_narrative_template(case_metadata.narrative or "", ctx)
         ctx["narrative"] = rendered_narrative
-        ctx["narrative_html"] = (
-            markdown.markdown(
-                rendered_narrative,
-                extensions=["fenced_code", "tables", "nl2br"],
-            )
-            if rendered_narrative
-            else ""
-        )
+        ctx["narrative_html"] = _markdown_to_safe_html(rendered_narrative)
 
         return ctx
 
@@ -1309,12 +1338,11 @@ class ReportRenderer:
         Returns:
             Rendered HTML report string.
         """
-        md_extensions = ["fenced_code", "tables", "nl2br"]
         html_findings = []
         for f in ctx["findings"]:
             fd = f.model_dump()
             cleaned_desc = _clean_finding_description(fd.get("description", ""))
-            fd["description_html"] = markdown.markdown(cleaned_desc, extensions=md_extensions)
+            fd["description_html"] = _markdown_to_safe_html(cleaned_desc)
             html_findings.append(SimpleNamespace(**fd))
         ctx["findings"] = html_findings
 

--- a/src/mulder/report/templates/report.html.j2
+++ b/src/mulder/report/templates/report.html.j2
@@ -1330,14 +1330,14 @@ table.data-table code { font-family: var(--mono); font-size: 0.78em; color: var(
 /* ========== DATA ========== */
 var AUDIT_DATA = {{ audit_entries | tojson }};
 var TOOL_COUNTS = {{ tool_call_counts | tojson }};
-var FINDINGS_TITLES = { {% for f in findings %}"{{ f.finding_id }}": {{ f.title | tojson }}{% if not loop.last %},{% endif %}{% endfor %} };
+var FINDINGS_TITLES = { {% for f in findings %}{{ f.finding_id | tojson }}: {{ f.title | tojson }}{% if not loop.last %},{% endif %}{% endfor %} };
 var SOURCE_WINDOWS = {{ source_windows | tojson }};
-var SOURCES_META = { {% for s in sources_list %}"{{ s.source_name }}": {"extractor":"{{ s.extractor }}","line_count":{{ s.line_count }},"hash":"{{ s.source_hash[:16] }}"}{% if not loop.last %},{% endif %}{% endfor %} };
+var SOURCES_META = { {% for s in sources_list %}{{ s.source_name | tojson }}: {"extractor":{{ s.extractor | tojson }},"line_count":{{ s.line_count }},"hash":{{ s.source_hash[:16] | tojson }}}{% if not loop.last %},{% endif %}{% endfor %} };
 
 var AUDIT_INDEX = {};
 AUDIT_DATA.forEach(function(e) { AUDIT_INDEX[e.tool_call_id] = e; });
 var FINDING_REFS = {};
-{% for f in findings %}FINDING_REFS["{{ f.finding_id }}"] = {{ f.evidence_refs | tojson }};
+{% for f in findings %}FINDING_REFS[{{ f.finding_id | tojson }}] = {{ f.evidence_refs | tojson }};
 {% endfor %}
 var TC_TO_FINDINGS = {};
 Object.keys(FINDING_REFS).forEach(function(fid) {
@@ -1738,7 +1738,7 @@ function renderThroughputChart() {
   /* Per-model token data */
   var models=[
     {% for entry in model_token_breakdown %}
-    {name:'{{ entry.model }}',total:{{ entry.input + entry.output }}},
+    {name:{{ entry.model | tojson }},total:{{ entry.input + entry.output }}},
     {% endfor %}
   ];
   var totalTok=0;

--- a/src/mulder/report/templates/report.html.j2
+++ b/src/mulder/report/templates/report.html.j2
@@ -770,7 +770,7 @@ table.data-table code { font-family: var(--mono); font-size: 0.78em; color: var(
     <div class="subtitle">Case <span class="mono">{{ case_id }}</span></div>
   </div>
   <div class="report-narrative">
-    {{ narrative_html }}
+    {{ narrative_html | safe }}
   </div>
 </div>
 {% endif %}
@@ -808,7 +808,7 @@ table.data-table code { font-family: var(--mono); font-size: 0.78em; color: var(
         <div class="tl-sources">{{ f.sources | join(', ') }}</div>
       </div>
       <div class="tl-detail-panel" id="tld_{{ f.finding_id }}">
-        {{ f.description_html }}
+        {{ f.description_html | safe }}
         <div style="margin-top:0.75rem;">
           <a style="color:var(--accent);cursor:pointer;font-size:0.8rem;" onclick="event.stopPropagation();navigateToFinding('{{ f.finding_id }}')">View full finding &rarr;</a>
         </div>
@@ -855,7 +855,7 @@ table.data-table code { font-family: var(--mono); font-size: 0.78em; color: var(
       <span class="finding-name">{{ f.title }}</span>
     </div>
     <div class="finding-body">
-      <div class="finding-desc">{{ f.description_html }}</div>
+      <div class="finding-desc">{{ f.description_html | safe }}</div>
       <div class="evidence-strength">
         <span>Evidence strength:</span>
         <div class="evidence-strength-bar"><div class="evidence-strength-fill" style="width:{{ [f.evidence_refs | length * 20, 100] | min }}%"></div></div>

--- a/tests/test_report_injection.py
+++ b/tests/test_report_injection.py
@@ -1,0 +1,119 @@
+"""The HTML report must not execute what the evidence says.
+
+Two separate holes closed here:
+
+* the case narrative was compiled with a plain ``jinja2.Environment``, so
+  ``{{ cycler.__init__.__globals__ }}`` and everything reachable from it ran
+  as the user running the server (server-side template injection);
+* the report environment used ``autoescape=False`` for *both* templates, and
+  ``markdown.markdown`` passes raw HTML straight through, so any string read
+  off the evidence -- a filename, a command line, a carved registry value --
+  landed in the report as live markup.
+"""
+
+from __future__ import annotations
+
+import jinja2
+import pytest
+
+from mulder.report.renderer import ReportRenderer, _markdown_to_safe_html
+
+SSTI_PAYLOADS = [
+    "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+    "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+    "{{ self.__init__.__globals__ }}",
+    "{{ lipsum.__globals__['os'].popen('id').read() }}",
+    "{{ config.__class__.__init__.__globals__['os'].popen('id').read() }}",
+]
+
+
+class TestNarrativeTemplateInjection:
+    @pytest.mark.parametrize("payload", SSTI_PAYLOADS)
+    def test_payload_does_not_execute(self, payload: str) -> None:
+        out = ReportRenderer._render_narrative_template(payload, {"finding_count": 3})
+        # Either the sandbox refuses (falling back to the raw text) or the
+        # expression yields nothing. What must never appear is a uid line or
+        # a Python repr of the interpreter internals.
+        assert "uid=" not in out
+        assert "<class " not in out
+        assert "__globals__" not in out or out == payload
+
+    def test_legitimate_placeholders_still_render(self) -> None:
+        out = ReportRenderer._render_narrative_template(
+            "The investigation produced {{ finding_count }} findings.",
+            {"finding_count": 7},
+        )
+        assert out == "The investigation produced 7 findings."
+
+    def test_plain_prose_is_untouched(self) -> None:
+        text = "No templating here at all."
+        assert ReportRenderer._render_narrative_template(text, {}) == text
+
+    def test_broken_template_falls_back_to_the_raw_text(self) -> None:
+        text = "unterminated {{ oops"
+        assert ReportRenderer._render_narrative_template(text, {}) == text
+
+    def test_empty_narrative(self) -> None:
+        assert ReportRenderer._render_narrative_template("", {}) == ""
+
+
+class TestMarkdownDoesNotPassRawHtml:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "<script>alert(1)</script>",
+            "<img src=x onerror=alert(1)>",
+            "<iframe src='javascript:alert(1)'></iframe>",
+            "<svg/onload=alert(1)>",
+            "</td></tr><script>alert(1)</script>",
+        ],
+    )
+    def test_markup_is_inert(self, payload: str) -> None:
+        html = _markdown_to_safe_html(f"Found this on disk: {payload}")
+        assert "<script" not in html.lower()
+        assert "<img" not in html.lower()
+        assert "<iframe" not in html.lower()
+        assert "<svg" not in html.lower()
+        assert "&lt;" in html
+
+    def test_markdown_formatting_still_works(self) -> None:
+        html = _markdown_to_safe_html("**bold** and `code` and [link](http://example.com)")
+        assert "<strong>bold</strong>" in html
+        assert "<code>code</code>" in html
+        assert 'href="http://example.com"' in html
+
+    def test_fenced_code_still_works(self) -> None:
+        html = _markdown_to_safe_html("```\ncmd.exe /c whoami\n```")
+        assert "<pre>" in html
+        assert "cmd.exe /c whoami" in html
+
+    def test_ampersand_is_not_double_escaped(self) -> None:
+        assert "&amp;amp;" not in _markdown_to_safe_html("Rock & Roll")
+
+    def test_empty(self) -> None:
+        assert _markdown_to_safe_html("") == ""
+
+
+class TestAutoescapeSelection:
+    def test_html_template_autoescapes(self) -> None:
+        env = ReportRenderer()._env
+        assert env.autoescape("report.html.j2") is True
+
+    def test_markdown_template_does_not_autoescape(self) -> None:
+        env = ReportRenderer()._env
+        assert env.autoescape("report.md.j2") is False
+
+    def test_a_value_reaching_the_html_template_is_escaped(self) -> None:
+        env = ReportRenderer()._env
+        tpl = env.from_string("<p>{{ v }}</p>")
+        # from_string has no name, so assert the environment's policy directly
+        # on a named template instead.
+        assert isinstance(tpl.render(v="<b>x</b>"), str)
+
+        loaded = jinja2.Environment(
+            loader=jinja2.DictLoader({"x.html.j2": "<p>{{ v }}</p>"}),
+            autoescape=env.autoescape,
+        )
+        rendered = loaded.get_template("x.html.j2").render(v="<script>alert(1)</script>")
+        assert "<script>" not in rendered
+        assert "&lt;script&gt;" in rendered

--- a/tests/test_report_injection.py
+++ b/tests/test_report_injection.py
@@ -13,6 +13,9 @@ Two separate holes closed here:
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import cast
+
 import jinja2
 import pytest
 
@@ -95,21 +98,28 @@ class TestMarkdownDoesNotPassRawHtml:
 
 
 class TestAutoescapeSelection:
+    @staticmethod
+    def _policy(env: jinja2.Environment) -> Callable[[str | None], bool]:
+        """The select_autoescape callable the renderer installed.
+
+        jinja2 types ``Environment.autoescape`` as ``bool`` because that is the
+        common case; here it is the callable returned by select_autoescape, and
+        calling it is the whole point of the test.
+        """
+        return cast("Callable[[str | None], bool]", env.autoescape)
+
     def test_html_template_autoescapes(self) -> None:
         env = ReportRenderer()._env
-        assert env.autoescape("report.html.j2") is True
+        assert self._policy(env)("report.html.j2") is True
 
     def test_markdown_template_does_not_autoescape(self) -> None:
         env = ReportRenderer()._env
-        assert env.autoescape("report.md.j2") is False
+        assert self._policy(env)("report.md.j2") is False
 
     def test_a_value_reaching_the_html_template_is_escaped(self) -> None:
         env = ReportRenderer()._env
-        tpl = env.from_string("<p>{{ v }}</p>")
-        # from_string has no name, so assert the environment's policy directly
-        # on a named template instead.
-        assert isinstance(tpl.render(v="<b>x</b>"), str)
-
+        # from_string has no name, so assert the environment's policy on a
+        # named template instead.
         loaded = jinja2.Environment(
             loader=jinja2.DictLoader({"x.html.j2": "<p>{{ v }}</p>"}),
             autoescape=env.autoescape,
@@ -117,3 +127,42 @@ class TestAutoescapeSelection:
         rendered = loaded.get_template("x.html.j2").render(v="<script>alert(1)</script>")
         assert "<script>" not in rendered
         assert "&lt;script&gt;" in rendered
+
+
+class TestScriptBlockInterpolation:
+    """Autoescaping is an HTML-context escape, not a JavaScript one.
+
+    Inside ``<script>`` the browser does not decode entities, so a value
+    interpolated raw there is both broken (``&amp;`` arrives literally) and
+    unsafe (a source filename containing ``</script>`` closes the block).
+    Every string reaching a script block must go through ``| tojson``, which
+    emits a correctly quoted JS literal.
+    """
+
+    # Expressions that are integers by construction and so cannot carry markup.
+    NUMERIC = {
+        "s.line_count",
+        "t.finding_count",
+        "entry.input + entry.output",
+    }
+
+    def test_every_script_interpolation_is_json_encoded(self) -> None:
+        import re
+        from pathlib import Path
+
+        import mulder
+
+        tpl = Path(mulder.__file__).parent / "report" / "templates" / "report.html.j2"
+        offenders = []
+        inside = False
+        for lineno, line in enumerate(tpl.read_text().splitlines(), start=1):
+            if "<script" in line:
+                inside = True
+            if inside:
+                for m in re.finditer(r"\{\{(.+?)\}\}", line):
+                    expr = m.group(1).strip()
+                    if "tojson" not in expr and expr not in self.NUMERIC:
+                        offenders.append(f"{tpl.name}:{lineno} {m.group(0)}")
+            if "</script>" in line:
+                inside = False
+        assert offenders == []


### PR DESCRIPTION
## BLUF

- **Confirmed RCE.** `_render_narrative_template` compiles the case narrative with a plain `jinja2.Environment`. On `main`, `{{ cycler.__init__.__globals__.os.popen('id').read() }}` returns a real `uid=1000(...)` line — I ran it. The narrative is model-authored prose summarising **attacker-controlled evidence**.
- **Stored XSS.** One `Environment` with `autoescape=False` served both templates, so every value in the HTML report — filenames, command lines, registry values, strings carved out of a disk image — was interpolated as raw markup.
- **The obvious fix is not enough, twice over.** `markdown.markdown` passes raw HTML straight through (Python-Markdown has had no safe mode since 3.0), so marking the pre-rendered values `| safe` would have reopened the hole; and autoescaping is an *HTML*-context escape, so it does nothing for the values interpolated into the report's inline `<script>` blocks.
- **Fix:** sandbox the narrative environment; select autoescaping per template extension; escape markup before markdown conversion; JSON-encode every string reaching a script block.
- **Risk:** Low. Markdown formatting is preserved and the markdown report is untouched.

## Priority

**critical** — remote code execution as the user running the server, reachable from evidence content.

## 1. Server-side template injection

```python
env = jinja2.Environment(undefined=jinja2.Undefined)
template = env.from_string(narrative)     # narrative is untrusted
```

Verified on this branch's parent:

```
UNSANDBOXED (main): 'uid=1000(elhoim) gid=1000(elhoim) groups=1000(elhoim),4(adm)'
SANDBOXED (fix):    blocked -> SecurityError access to attribute '__init__' of 'type' object is unsafe.
```

Now `jinja2.sandbox.SandboxedEnvironment`, falling back to the raw narrative on `SecurityError`. The bare `except Exception` is narrowed at the same time, so a future refactor cannot quietly reclassify a `SecurityError` as a syntax error.

The legitimate use — injecting authoritative counts like `{{ finding_count }}` — is unaffected and covered by a test.

## 2. `autoescape=False` on the HTML template

The template has 184 interpolations and **zero** `|safe` markers, i.e. it was written as if escaping were on. Autoescaping is now selected by extension: on for `.html.j2`, off for `.md.j2` (which genuinely needs raw markdown). Exactly three values are deliberately pre-rendered HTML and are now marked `| safe`: `narrative_html` and two `f.description_html`.

## 3. Markdown as the second-order hole

Those three values come from `markdown.markdown()`, which emits raw HTML verbatim. Both conversions now route through `_markdown_to_safe_html`, which escapes `&`, `<` and `>` before converting. `&` is escaped first so nothing is double-escaped.

**Deliberate trade:** escaping `<` and `>` up front costs two markdown constructs that are spelled with those characters — `> blockquote` and `<http://autolink>`. Bold, italics, inline code, fenced code, links, lists, headings and tables all use `*`, `_`, backticks, brackets and pipes and are unaffected; tests assert they still render. Given the input is a summary of hostile evidence, losing blockquotes is the right side of that trade.

## 4. The JavaScript context, which autoescaping does not cover

Autoescaping escapes for HTML. Inside a `<script>` element the browser does **not** decode entities, so an escaped `&amp;` arrives in the JS source literally and a value containing `</script>` still closes the block. Turning autoescaping on therefore fixes nothing in the report's data block, and would have broken values that contain `&`.

Most of that block already used `| tojson`. Five values did not: `f.finding_id` (twice), `s.source_name`, `s.extractor`, `s.source_hash[:16]` and `entry.model`. **`s.source_name` is an evidence filename** — the same attacker-reachable path as the rest of the report. All five now go through `| tojson`, which emits a correctly quoted and escaped JS literal.

The only raw interpolations left inside script blocks are integers by construction (`line_count`, `finding_count`, `input + output`). A test walks the template and fails on any other unencoded value, naming those three explicitly so a string cannot be added silently later.

## Tests

New `tests/test_report_injection.py` (22 tests):

- five real SSTI payloads (`cycler`, `__mro__`/`__subclasses__`, `self`, `lipsum`, `config`) asserted not to yield a uid line or interpreter internals;
- legitimate `{{ finding_count }}` still renders; plain prose and malformed templates fall through unchanged;
- five XSS payloads (`<script>`, `<img onerror>`, `<iframe javascript:>`, `<svg onload>`, and a tag-breakout `</td></tr><script>`) asserted inert after markdown conversion;
- **bold, inline code, links and fenced code blocks still render** — the assertion that catches an over-aggressive escape;
- `&` is not double-escaped;
- the autoescape policy is asserted per extension, and a value routed through a `.html.j2` template comes out escaped;
- every interpolation inside a `<script>` block is JSON-encoded.

`make lint format typecheck test` — 764 passed (742 baseline, +22), mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
