### PR TITLE
[high] fix(index): index the detections, not just how many there were

### DIFF
--- a/src/mulder/server/extract_helpers.py
+++ b/src/mulder/server/extract_helpers.py
@@ -8,13 +8,14 @@ mounting E01/raw disk images with thread-safe caching).
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import re
 import shutil
 import tempfile
 import threading
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -26,6 +27,56 @@ from mulder.models import WindowRow
 logger = logging.getLogger(__name__)
 
 _WINDOW_CHAR_BUDGET = 4096
+
+_RECORD_FIELD_CHARS = 400
+
+
+def _record_field(value: object) -> str:
+    """Render one field of a structured record as a single-line string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, (bool, int, float)):
+        text = str(value)
+    else:
+        text = json.dumps(value, default=str, separators=(",", ":"), sort_keys=True)
+    text = text.replace("\t", " ").replace("\r", " ").replace("\n", " ")
+    return text[:_RECORD_FIELD_CHARS]
+
+
+def format_records(
+    records: Sequence[Mapping[str, object]],
+    fields: Sequence[str] | None = None,
+) -> list[str]:
+    """Render structured tool output as one tab-separated line per record.
+
+    ``extract_and_index`` stores exactly the text it is handed. Several tools
+    handed it a summary -- "Total findings: 412" -- so not one rule name, host
+    or command line ever reached the case database, and the FTS index could
+    not answer the questions the tool was run to answer. This turns the
+    records themselves into indexable text.
+
+    One record per line matters twice over: the window builder splits on line
+    boundaries, so no detection is cut in half, and timestamp extraction runs
+    per window rather than finding a single timestamp for a whole summary.
+
+    Args:
+        records: The parsed records.
+        fields: Field order to emit. When *None* each record uses its own key
+            order, which is what tabular sources (LEAPP TSV) want.
+
+    Returns:
+        One tab-separated line per record. Non-scalar values are JSON-encoded
+        so nested event data stays searchable; every field is truncated to
+        keep one pathological value from filling a window.
+    """
+    lines: list[str] = []
+    for record in records:
+        keys = list(record) if fields is None else fields
+        lines.append("\t".join(_record_field(record.get(k)) for k in keys))
+    return lines
+
 
 _ISO_RE = re.compile(r"\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}")
 _PLASO_DATE_RE = re.compile(r"(\d{2})/(\d{2})/(\d{4})\s+(\d{2}):(\d{2}):(\d{2})")

--- a/src/mulder/server/extract_helpers.py
+++ b/src/mulder/server/extract_helpers.py
@@ -28,7 +28,12 @@ logger = logging.getLogger(__name__)
 
 _WINDOW_CHAR_BUDGET = 4096
 
-_RECORD_FIELD_CHARS = 400
+# Chainsaw falls back to the whole event document for `event_data`, which is
+# 2-4 KB of JSON. 400 characters cut everything past the first few keys --
+# Image, ParentCommandLine, TargetUserName -- so the fields an analyst
+# actually searches for were truncated away. 2000 still leaves room for the
+# other nine columns inside one 4096-character window.
+_RECORD_FIELD_CHARS = 2000
 
 
 def _record_field(value: object) -> str:

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -107,6 +107,50 @@ def run_subprocess(
         return f"Failed to run {cmd[0]}: {exc}"
 
 
+_EXIT_PREVIEW_CHARS = 500
+
+
+def classify_tool_exit(
+    proc: subprocess.CompletedProcess[str],
+    binary: str,
+    *,
+    produced_output: bool,
+) -> tuple[str, str]:
+    """Decide what a finished CLI tool's exit status means for the caller.
+
+    Returns ``(verdict, message)`` where *verdict* is one of:
+
+    ``"ok"``
+        The tool exited 0. Nothing to report.
+    ``"partial"``
+        The tool exited non-zero but still produced output. Several of the
+        wrapped tools exit non-zero on a single unreadable input file while
+        having processed every other one (chainsaw does this without
+        ``--skip-errors``), so the results are kept and the message is
+        surfaced as a warning.
+    ``"failed"``
+        The tool exited non-zero and produced nothing. Reporting this as a
+        successful scan with zero findings is the single worst thing a DFIR
+        tool can do, so callers must turn it into an error.
+
+    A tool that exits 0 without producing output is *not* classified here:
+    "no output" is a legitimate clean result for most of these tools, and
+    the ones where it is not (hayabusa refuses to overwrite and still exits
+    0) check for their own output file explicitly.
+    """
+    if proc.returncode == 0:
+        return "ok", ""
+
+    detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[:_EXIT_PREVIEW_CHARS]
+    if produced_output:
+        return (
+            "partial",
+            f"{binary} exited {proc.returncode} but produced output; "
+            f"results may be incomplete: {detail}",
+        )
+    return "failed", f"{binary} exited {proc.returncode} and produced no output: {detail}"
+
+
 def make_tool_call_id() -> str:
     """Generate a short unique identifier for a tool invocation."""
     return f"tc_{uuid4().hex[:8]}"
@@ -585,6 +629,21 @@ def run_cli_tool(
         return error_response(tc_id, tool_name, params, result, error_type="timeout")
     proc = result
 
-    summary = extract_and_index(proc.stdout.strip(), source_name, source_path, extractor_label)
+    stdout = proc.stdout.strip()
+    verdict, message = classify_tool_exit(proc, binary, produced_output=bool(stdout))
+    if verdict == "failed":
+        return error_response(
+            tc_id,
+            tool_name,
+            params,
+            message,
+            elapsed_ms=(time.monotonic() - t0) * 1000,
+            error_type="tool_failed",
+        )
+
+    summary = extract_and_index(stdout, source_name, source_path, extractor_label)
     elapsed = (time.monotonic() - t0) * 1000
-    return tool_response(tc_id, tool_name, params, summary, source_name, elapsed)
+    response = tool_response(tc_id, tool_name, params, summary, source_name, elapsed)
+    if verdict == "partial":
+        response["warning"] = message
+    return response

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -877,7 +877,7 @@ def run_capa(
             error_type="file_not_found",
         )
 
-    cmd = [capa_bin, "--format", "json", "--quiet"]
+    cmd = [capa_bin, "--json", "--quiet"]
     if rules_path:
         if not Path(rules_path).exists():
             return error_response(
@@ -1018,13 +1018,12 @@ def run_floss(
 
     cmd = [
         floss_bin,
-        "--format",
-        "json",
+        "--json",
         "--minimum-length",
         str(minimum_length),
     ]
     if not include_static:
-        cmd.append("--only")
+        cmd.extend(["--no", "static"])
     cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -1021,10 +1021,13 @@ def run_floss(
         "--json",
         "--minimum-length",
         str(minimum_length),
+        # The sample must precede --no/--only: both are nargs="+" with
+        # `choices`, so argparse consumes the following path as a string
+        # type and exits 2.
+        str(target),
     ]
     if not include_static:
         cmd.extend(["--no", "static"])
-    cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)
     try:

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -57,6 +57,16 @@ def _default_sigma_rules() -> Path:
     return asset_display_path("sigma-rules", "rules", "windows")
 
 
+def _default_chainsaw_mapping() -> Path:
+    """The Sigma-to-EVTX field mapping chainsaw requires for ``hunt -s``.
+
+    ``chainsaw hunt`` treats ``--mapping`` as *required* whenever Sigma rules
+    are supplied; the file ships in chainsaw's own ``mappings/`` directory,
+    which ``mulder setup`` fetches alongside the binary.
+    """
+    return asset_display_path("chainsaw", "mappings", "sigma-event-logs-all.yml")
+
+
 def _resolve_evtx_evidence(evidence_path: str) -> str:
     """Resolve a disk image path to its EVTX extraction directory.
 
@@ -108,6 +118,7 @@ def _run_chainsaw_hunt(
     binary: str,
     evidence_path: Path,
     sigma_rules_path: Path,
+    mapping_path: Path,
     output_dir: Path,
     time_start: str | None = None,
     time_end: str | None = None,
@@ -119,6 +130,7 @@ def _run_chainsaw_hunt(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         sigma_rules_path: Path to Sigma rules directory.
+        mapping_path: Path to the chainsaw Sigma field-mapping file.
         output_dir: Output directory for results.
         time_start: Optional time range start (ISO 8601).
         time_end: Optional time range end (ISO 8601).
@@ -137,6 +149,8 @@ def _run_chainsaw_hunt(
         str(evidence_path),
         "-s",
         str(sigma_rules_path),
+        "--mapping",
+        str(mapping_path),
         "--json",
         "--output",
         str(output_file),
@@ -208,13 +222,18 @@ def _run_chainsaw_search(
 
 
 def _run_chainsaw_srum(
-    binary: str, srum_path: Path, output_dir: Path, timeout: int = _CHAINSAW_TIMEOUT
+    binary: str,
+    srum_path: Path,
+    software_hive: Path,
+    output_dir: Path,
+    timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw SRUM parsing mode.
 
     Args:
         binary: Resolved Chainsaw executable.
         srum_path: Path to the SRUDB.dat file.
+        software_hive: Path to the SOFTWARE registry hive (required by chainsaw).
         output_dir: Output directory for results.
         timeout: Subprocess timeout in seconds.
 
@@ -230,7 +249,8 @@ def _run_chainsaw_srum(
         "analyse",
         "srum",
         str(srum_path),
-        "--json",
+        "--software",
+        str(software_hive),
         "--output",
         str(output_file),
     ]
@@ -248,8 +268,6 @@ def _run_chainsaw_timeline(
     binary: str,
     evidence_path: Path,
     output_dir: Path,
-    time_start: str | None = None,
-    time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw in dump/timeline mode against EVTX files.
@@ -258,8 +276,6 @@ def _run_chainsaw_timeline(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         output_dir: Output directory for results.
-        time_start: Optional time range start.
-        time_end: Optional time range end.
         timeout: Subprocess timeout in seconds.
 
     Returns:
@@ -277,10 +293,6 @@ def _run_chainsaw_timeline(
         "--output",
         str(output_file),
     ]
-    if time_start:
-        cmd.extend(["--from", time_start])
-    if time_end:
-        cmd.extend(["--to", time_end])
 
     subprocess.run(
         cmd,
@@ -420,6 +432,7 @@ def run_chainsaw(
     mode: Literal["hunt", "search", "srum", "timeline"] = "hunt",
     sigma_rules_path: str = "",
     search_term: str | None = None,
+    software_hive: str = "",
     time_range_start: str | None = None,
     time_range_end: str | None = None,
     force: bool = False,
@@ -442,10 +455,13 @@ def run_chainsaw(
             resolves to the rules installed by 'mulder setup'.
         search_term: Required when mode="search". The keyword or
             regex pattern to search for in EVTX records.
+        software_hive: Required when mode="srum". Path to the SOFTWARE
+            registry hive extracted from the same host as the SRUM
+            database; chainsaw needs it to resolve application IDs.
         time_range_start: Optional ISO 8601 timestamp to filter results
-            (inclusive start).
+            (inclusive start). Not supported in "timeline" mode.
         time_range_end: Optional ISO 8601 timestamp to filter results
-            (inclusive end).
+            (inclusive end). Not supported in "timeline" mode.
         force: Re-run extraction even if sources already exist.
     """
     tc_id = make_tool_call_id()
@@ -455,6 +471,7 @@ def run_chainsaw(
         "mode": mode,
         "sigma_rules_path": sigma_rules_path,
         "search_term": search_term,
+        "software_hive": software_hive,
         "time_range_start": time_range_start,
         "time_range_end": time_range_end,
         "force": force,
@@ -511,7 +528,37 @@ def run_chainsaw(
             error_type="invalid_argument",
         )
 
+    if mode == "srum" and not software_hive:
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "software_hive is required when mode='srum': chainsaw needs the "
+            "SOFTWARE registry hive to resolve SRUM application IDs",
+            error_type="invalid_argument",
+        )
+
+    if mode == "timeline" and (time_range_start or time_range_end):
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "chainsaw dump has no time-range filter; use mode='search' or "
+            "filter the returned timeline instead",
+            error_type="invalid_argument",
+        )
+
     rules = Path(sigma_rules_path) if sigma_rules_path else _default_sigma_rules()
+    mapping = _default_chainsaw_mapping()
+    if mode == "hunt" and not mapping.exists():
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            f"chainsaw Sigma mapping not found at {mapping}. Run 'mulder setup' "
+            "to provision chainsaw's mappings/ directory.",
+            error_type="asset_missing",
+        )
 
     timeout = adaptive_timeout(evidence_path, base=_CHAINSAW_TIMEOUT)
     with tempfile.TemporaryDirectory(prefix="mulder_chainsaw_") as tmpdir:
@@ -522,6 +569,7 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     rules,
+                    mapping,
                     output_dir,
                     time_range_start,
                     time_range_end,
@@ -544,7 +592,11 @@ def run_chainsaw(
                 source_name = "chainsaw.search"
             elif mode == "srum":
                 results_path = _run_chainsaw_srum(
-                    binary, Path(evidence_path), output_dir, timeout=timeout
+                    binary,
+                    Path(evidence_path),
+                    Path(software_hive),
+                    output_dir,
+                    timeout=timeout,
                 )
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"
@@ -553,8 +605,6 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     output_dir,
-                    time_range_start,
-                    time_range_end,
                     timeout=timeout,
                 )
                 result = _parse_chainsaw_timeline_results(results_path)

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -17,6 +17,7 @@ from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -123,7 +124,7 @@ def _run_chainsaw_hunt(
     time_start: str | None = None,
     time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in hunt mode against EVTX files.
 
     Args:
@@ -137,7 +138,10 @@ def _run_chainsaw_hunt(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -160,14 +164,14 @@ def _run_chainsaw_hunt(
     if time_end:
         cmd.extend(["--to", time_end])
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_search(
@@ -178,7 +182,7 @@ def _run_chainsaw_search(
     time_start: str | None = None,
     time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in search mode against EVTX files.
 
     Args:
@@ -191,7 +195,10 @@ def _run_chainsaw_search(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -211,14 +218,14 @@ def _run_chainsaw_search(
     if time_end:
         cmd.extend(["--to", time_end])
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_srum(
@@ -227,7 +234,7 @@ def _run_chainsaw_srum(
     software_hive: Path,
     output_dir: Path,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw SRUM parsing mode.
 
     Args:
@@ -238,7 +245,10 @@ def _run_chainsaw_srum(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -254,14 +264,14 @@ def _run_chainsaw_srum(
         "--output",
         str(output_file),
     ]
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_timeline(
@@ -269,7 +279,7 @@ def _run_chainsaw_timeline(
     evidence_path: Path,
     output_dir: Path,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in dump/timeline mode against EVTX files.
 
     Args:
@@ -279,7 +289,10 @@ def _run_chainsaw_timeline(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -294,14 +307,14 @@ def _run_chainsaw_timeline(
         str(output_file),
     ]
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _parse_chainsaw_hunt_results(results_path: Path) -> dict[str, Any]:
@@ -565,7 +578,7 @@ def run_chainsaw(
         output_dir = Path(tmpdir)
         try:
             if mode == "hunt":
-                results_path = _run_chainsaw_hunt(
+                results_path, proc = _run_chainsaw_hunt(
                     binary,
                     Path(evidence_path),
                     rules,
@@ -579,7 +592,7 @@ def run_chainsaw(
                 source_name = "chainsaw.hunt"
             elif mode == "search":
                 assert search_term is not None
-                results_path = _run_chainsaw_search(
+                results_path, proc = _run_chainsaw_search(
                     binary,
                     Path(evidence_path),
                     search_term,
@@ -591,7 +604,7 @@ def run_chainsaw(
                 result = _parse_chainsaw_hunt_results(results_path)
                 source_name = "chainsaw.search"
             elif mode == "srum":
-                results_path = _run_chainsaw_srum(
+                results_path, proc = _run_chainsaw_srum(
                     binary,
                     Path(evidence_path),
                     Path(software_hive),
@@ -601,7 +614,7 @@ def run_chainsaw(
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"
             else:
-                results_path = _run_chainsaw_timeline(
+                results_path, proc = _run_chainsaw_timeline(
                     binary,
                     Path(evidence_path),
                     output_dir,
@@ -629,6 +642,19 @@ def run_chainsaw(
                 error_type="os_error",
             )
 
+        verdict, message = classify_tool_exit(
+            proc, "chainsaw", produced_output=results_path.exists()
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_chainsaw",
+                params,
+                message,
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         text_parts = [f"Chainsaw {mode} analysis of {evidence_path}"]
         if mode in ("hunt", "search"):
             text_parts.append(f"Total findings: {result.get('total_findings', 0)}")
@@ -643,4 +669,7 @@ def run_chainsaw(
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000
-    return tool_response(tc_id, "run_chainsaw", params, summary, source_name, elapsed)
+    response = tool_response(tc_id, "run_chainsaw", params, summary, source_name, elapsed)
+    if verdict == "partial":
+        response["warning"] = message
+    return response

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 from mulder.assets.paths import asset_display_path, asset_path, asset_search_summary
 from mulder.patterns import DISK_IMAGE_EXTS
 from mulder.server.app import get_ctx, mcp
-from mulder.server.extract_helpers import extract_and_index
+from mulder.server.extract_helpers import extract_and_index, format_records
 from mulder.server.helpers import (
     adaptive_timeout,
     classify_tool_exit,
@@ -33,6 +33,33 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _CHAINSAW_TIMEOUT = 600
+
+# How many records the tool response carries back. The index is not bounded by
+# this: the records are indexed first and truncated only for the response.
+_MAX_DETECTIONS = 500
+_MAX_TIMELINE = 1000
+
+# Field order for the indexed lines. Timestamp first, so per-window timestamp
+# extraction picks up the record's own time rather than whatever appears first.
+_DETECTION_FIELDS = (
+    "timestamp",
+    "rule_level",
+    "rule_name",
+    "computer",
+    "channel",
+    "event_id",
+    "sigma_id",
+    "mitre_attack",
+    "source",
+    "event_data",
+)
+_SRUM_FIELDS = (
+    "timestamp",
+    "application",
+    "user_sid",
+    "bytes_sent",
+    "bytes_received",
+)
 
 
 def _chainsaw_binary() -> str | None:
@@ -367,7 +394,9 @@ def _parse_chainsaw_hunt_results(results_path: Path) -> dict[str, Any]:
         )
 
     return {
-        "detections": detections[:500],
+        # Not truncated here: the caller indexes these and then truncates for
+        # the response, so the case database sees every detection.
+        "detections": detections,
         "total_findings": len(detections),
         "severity_counts": severity_counts,
         "mitre_techniques": sorted(mitre_techniques),
@@ -407,7 +436,7 @@ def _parse_chainsaw_srum_results(results_path: Path) -> dict[str, Any]:
         )
 
     return {
-        "srum_entries": entries[:500],
+        "srum_entries": entries,
         "total_entries": len(entries),
     }
 
@@ -433,7 +462,7 @@ def _parse_chainsaw_timeline_results(results_path: Path) -> dict[str, Any]:
         raw = [raw] if raw else []
 
     return {
-        "timeline_entries": raw[:1000],
+        "timeline_entries": raw,
         "total_entries": len(raw),
     }
 
@@ -660,12 +689,26 @@ def run_chainsaw(
             text_parts.append(f"Total findings: {result.get('total_findings', 0)}")
             for level, count in result.get("severity_counts", {}).items():
                 text_parts.append(f"  {level}: {count}")
+            records_key, record_cap = "detections", _MAX_DETECTIONS
+            fields: tuple[str, ...] | None = _DETECTION_FIELDS
         elif mode == "srum":
             text_parts.append(f"SRUM entries: {result.get('total_entries', 0)}")
+            records_key, record_cap = "srum_entries", _MAX_DETECTIONS
+            fields = _SRUM_FIELDS
         else:
             text_parts.append(f"Timeline entries: {result.get('total_entries', 0)}")
+            records_key, record_cap = "timeline_entries", _MAX_TIMELINE
+            fields = None
+
+        # Index the detections themselves. Indexing only the counts above is
+        # why a hunt that found 412 things left nothing searchable behind.
+        records = result.get(records_key, [])
+        text_parts.extend(format_records(records, fields))
 
         summary = extract_and_index("\n".join(text_parts), source_name, evidence_path, "chainsaw")
+
+        # The response stays bounded; the index does not.
+        result[records_key] = records[:record_cap]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/extract/carving.py
+++ b/src/mulder/server/tools/extract/carving.py
@@ -18,6 +18,7 @@ from mulder.server.helpers import (
     _FILE_LIST_CAP,
     _PREVIEW_CHAR_LIMIT,
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -639,7 +640,7 @@ def run_photorec(image_path: str) -> dict[str, object]:
             f"search,{tmpdir}/",
         ]
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -656,6 +657,20 @@ def run_photorec(image_path: str) -> dict[str, object]:
             )
 
         report_path = Path(tmpdir) / "report.xml"
+        recovered_anything = report_path.exists() or any(
+            f.is_file() for f in Path(tmpdir).rglob("*")
+        )
+        verdict, message = classify_tool_exit(proc, "photorec", produced_output=recovered_anything)
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_photorec",
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         report_text = ""
         if report_path.exists():
             report_text = report_path.read_text(errors="replace")

--- a/src/mulder/server/tools/hayabusa.py
+++ b/src/mulder/server/tools/hayabusa.py
@@ -257,8 +257,8 @@ def run_hayabusa(
     if severity not in _VALID_SEVERITIES:
         severity = "medium"
 
-    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-        out_path = tmp.name
+    tmp_dir = tempfile.mkdtemp(prefix="mulder_hayabusa_")
+    out_path = str(Path(tmp_dir) / "timeline.csv")
 
     cmd = [
         hayabusa_bin,
@@ -267,6 +267,7 @@ def run_hayabusa(
         resolved_dir,
         "-o",
         out_path,
+        "--clobber",
         "-p",
         "super-verbose",
         "--no-wizard",
@@ -293,7 +294,7 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
-        if proc.returncode != 0 and not Path(out_path).exists():
+        if proc.returncode != 0:
             stderr_preview = (proc.stderr or "")[:_PREVIEW_CHAR_LIMIT]
             return error_response(
                 tc_id,
@@ -303,12 +304,24 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
+        if not Path(out_path).exists():
+            # Hayabusa reports several fatal conditions on stdout and still
+            # exits 0; a missing output file is the only reliable signal.
+            preview = ((proc.stderr or "") + (proc.stdout or ""))[-_PREVIEW_CHAR_LIMIT:]
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                f"Hayabusa produced no output file: {preview}",
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+            )
+
         try:
             csv_text = Path(out_path).read_text(errors="replace")
         except OSError:
             csv_text = ""
     finally:
-        Path(out_path).unlink(missing_ok=True)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
     if not csv_text.strip():
         elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/mvt.py
+++ b/src/mulder/server/tools/mvt.py
@@ -19,7 +19,12 @@ from pathlib import Path
 
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
-from mulder.server.helpers import error_response, make_tool_call_id, tool_response
+from mulder.server.helpers import (
+    classify_tool_exit,
+    error_response,
+    make_tool_call_id,
+    tool_response,
+)
 from mulder.server.tool_access import Role, tool_access
 
 logger = logging.getLogger(__name__)
@@ -123,6 +128,19 @@ def run_mvt_android(
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
 
+        verdict, message = classify_tool_exit(
+            proc, cmd[0], produced_output=bool(raw_output.strip())
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()
 
@@ -222,6 +240,19 @@ def run_mvt_ios(
             )
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
+
+        verdict, message = classify_tool_exit(
+            proc, cmd[0], produced_output=bool(raw_output.strip())
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
 
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()

--- a/src/mulder/server/tools/phone.py
+++ b/src/mulder/server/tools/phone.py
@@ -18,12 +18,13 @@ import subprocess
 import tempfile
 import time
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 from mulder.assets.paths import asset_display_path, register_cache_clear
 from mulder.server.app import get_ctx, mcp
-from mulder.server.extract_helpers import extract_and_index
+from mulder.server.extract_helpers import extract_and_index, format_records
 from mulder.server.helpers import (
     error_response,
     interpreter_candidates,
@@ -978,6 +979,35 @@ def _classify_artifact_category(artifact_type: str) -> str:
     return "other"
 
 
+# How many rows per artifact the tool response carries back. The index is not
+# bounded by this.
+_MAX_LEAPP_ROWS = 100
+
+
+def _leapp_artifact_lines(artifact: Mapping[str, Any]) -> list[str]:
+    """Render one parsed LEAPP artifact as indexable text.
+
+    ``_parse_tsv_file`` zips headers to values non-strictly, so a short row
+    yields a short dict. Taking the union of keys in first-seen order keeps
+    every row on the same columns instead of letting one truncated row shift
+    the whole artifact.
+    """
+    rows = artifact.get("data") or []
+    if not rows:
+        return []
+
+    fields: dict[str, None] = {}
+    for row in rows:
+        for key in row:
+            fields.setdefault(key, None)
+    columns = list(fields)
+
+    lines = [f"[{artifact.get('category', '')}] {artifact.get('artifact_type', '')}"]
+    lines.append("\t".join(columns))
+    lines.extend(format_records(rows, columns))
+    return lines
+
+
 def _parse_tsv_file(tsv_path: Path) -> list[dict[str, str]]:
     """Parse a TSV file into a list of row dicts.
 
@@ -1060,7 +1090,9 @@ def _parse_leapp_output(
                 "category": category,
                 "artifact_type": artifact_type,
                 "record_count": record_count,
-                "data": records[:100],
+                # Not truncated here: the caller indexes these and truncates
+                # for the response, so the case database sees every row.
+                "data": records,
                 "source_files": [str(tsv_file)],
             }
         )
@@ -1223,9 +1255,19 @@ def run_aleapp(
         for cat, count in result.get("categories", {}).items():
             text_parts.append(f"  {cat}: {count} records")
 
+        # Index the parsed rows. Without this the case database learned that
+        # ALEAPP found 12000 records and nothing about what they said -- no
+        # phone number, URL, filename or timestamp was searchable.
+        for artifact in result.get("artifacts", []):
+            text_parts.extend(_leapp_artifact_lines(artifact))
+
         summary = extract_and_index(
             "\n".join(text_parts), "phone.aleapp", extraction_path, "aleapp"
         )
+
+        # The response stays bounded; the index does not.
+        for artifact in result.get("artifacts", []):
+            artifact["data"] = artifact["data"][:_MAX_LEAPP_ROWS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000
@@ -1381,9 +1423,19 @@ def run_ileapp(
         for cat, count in result.get("categories", {}).items():
             text_parts.append(f"  {cat}: {count} records")
 
+        # Index the parsed rows. Without this the case database learned that
+        # iLEAPP found 12000 records and nothing about what they said -- no
+        # phone number, URL, filename or timestamp was searchable.
+        for artifact in result.get("artifacts", []):
+            text_parts.extend(_leapp_artifact_lines(artifact))
+
         summary = extract_and_index(
             "\n".join(text_parts), "phone.ileapp", extraction_path, "ileapp"
         )
+
+        # The response stays bounded; the index does not.
+        for artifact in result.get("artifacts", []):
+            artifact["data"] = artifact["data"][:_MAX_LEAPP_ROWS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -100,7 +100,6 @@ def _run_zircolite_process(
         str(events_path),
         "--ruleset",
         str(ruleset_path),
-        "--json",
         "--outfile",
         str(output_file),
         *format_flags,

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 
 from mulder.assets.paths import asset_display_path, asset_path, asset_search_summary
 from mulder.server.app import mcp
-from mulder.server.extract_helpers import extract_and_index
+from mulder.server.extract_helpers import extract_and_index, format_records
 from mulder.server.helpers import (
     classify_tool_exit,
     error_response,
@@ -62,6 +62,23 @@ _FORMAT_FLAGS: dict[str, list[str]] = {
 }
 
 _LEVEL_ORDER = ["informational", "low", "medium", "high", "critical"]
+
+# How many detections the tool response carries back. The index is not bounded
+# by this: detections are indexed first and truncated only for the response.
+_MAX_DETECTIONS = 500
+
+# Field order for the indexed lines. Timestamp first, so per-window timestamp
+# extraction picks up the detection's own time.
+_DETECTION_FIELDS = (
+    "timestamp",
+    "rule_level",
+    "rule_title",
+    "rule_id",
+    "count",
+    "mitre_attack",
+    "rule_description",
+    "matched_fields",
+)
 
 
 def _missing_zircolite_modules() -> list[str]:
@@ -241,7 +258,9 @@ def _parse_zircolite_output(
     return {
         "events_path": events_path,
         "log_format": log_format,
-        "detections": detections[:500],
+        # Not truncated here: run_zircolite indexes these before truncating
+        # for the response.
+        "detections": detections,
         "total_detections": len(detections),
         "total_events_processed": sum(level_counts.values()),
         "level_counts": level_counts,
@@ -417,9 +436,16 @@ def run_zircolite(
             for tactic, techniques in result["mitre_coverage"].items():
                 text_parts.append(f"  {tactic}: {', '.join(techniques[:5])}")
 
+        # Index the detections themselves, not just how many there were.
+        detections = result.get("detections", [])
+        text_parts.extend(format_records(detections, _DETECTION_FIELDS))
+
         summary = extract_and_index(
             "\n".join(text_parts), "zircolite.detections", events_path, "zircolite"
         )
+
+        # The response stays bounded; the index does not.
+        result["detections"] = detections[:_MAX_DETECTIONS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -16,6 +16,7 @@ from mulder.assets.paths import asset_display_path, asset_path, asset_search_sum
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     sources_already_indexed,
@@ -74,7 +75,7 @@ def _run_zircolite_process(
     log_format: str,
     ruleset_path: Path,
     output_dir: Path,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Zircolite against event logs.
 
     Args:
@@ -85,7 +86,10 @@ def _run_zircolite_process(
         output_dir: Output directory for results.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: Zircolite exits non-zero on a bad argument or ruleset and
+        writes no output file, which the parser would otherwise report as
+        zero detections.
 
     Raises:
         subprocess.TimeoutExpired: If Zircolite exceeds the timeout.
@@ -105,14 +109,14 @@ def _run_zircolite_process(
         *format_flags,
     ]
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=_ZIRCOLITE_TIMEOUT,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _build_detection_timeline(
@@ -360,7 +364,7 @@ def run_zircolite(
     with tempfile.TemporaryDirectory(prefix="mulder_zircolite_") as tmpdir:
         output_dir = Path(tmpdir)
         try:
-            results_path = _run_zircolite_process(
+            results_path, proc = _run_zircolite_process(
                 str(script),
                 Path(events_path),
                 log_format,
@@ -384,6 +388,19 @@ def run_zircolite(
                 f"Failed to execute Zircolite: {exc}",
                 (time.monotonic() - t0) * 1000,
                 error_type="os_error",
+            )
+
+        verdict, message = classify_tool_exit(
+            proc, "zircolite", produced_output=results_path.exists()
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_zircolite",
+                params,
+                message,
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
             )
 
         result = _parse_zircolite_output(results_path, events_path, log_format, sigma_level_filter)

--- a/tests/test_binary_resolution.py
+++ b/tests/test_binary_resolution.py
@@ -34,6 +34,14 @@ def _completed(**kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
+def _fake_mapping(root: Path) -> Path:
+    """chainsaw hunt refuses to start without --mapping; give it a real file."""
+    mapping = root / "chainsaw_mappings" / "sigma-event-logs-all.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("")
+    return mapping
+
+
 class TestChainsaw:
     def test_execs_the_binary_the_gate_found(self, tmp_path: Path) -> None:
         from mulder.server.tools.chainsaw import run_chainsaw
@@ -41,10 +49,15 @@ class TestChainsaw:
         chainsaw = _fake_binary(tmp_path, "chainsaw")
         evidence = tmp_path / "evtx"
         evidence.mkdir()
+        mapping = _fake_mapping(tmp_path)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=str(chainsaw)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -76,10 +89,15 @@ class TestChainsaw:
         binary = installed / "chainsaw"
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
+        mapping = _fake_mapping(asset_root)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=None),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -104,6 +122,9 @@ class TestChainsaw:
         chainsaw.mkdir()
         (chainsaw / "chainsaw").write_text("")
         (chainsaw / "chainsaw").chmod(0o755)
+        mappings = chainsaw / "mappings"
+        mappings.mkdir()
+        (mappings / "sigma-event-logs-all.yml").write_text("")
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
@@ -115,7 +136,11 @@ class TestChainsaw:
         ):
             run_chainsaw.__wrapped__(str(asset_root))  # type: ignore[attr-defined]
 
-        assert str(rules) in mock_run.call_args[0][0]
+        argv = mock_run.call_args[0][0]
+        assert str(rules) in argv
+        # chainsaw treats --mapping as required whenever Sigma rules are given.
+        assert "--mapping" in argv
+        assert str(mappings / "sigma-event-logs-all.yml") in argv
 
 
 def _eve_stub() -> dict[str, Any]:

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -1,0 +1,205 @@
+"""Regression tests for the argv mulder hands to each wrapped forensic tool.
+
+Every assertion below was checked against the pinned release of the tool
+(``src/mulder/assets/manifest.py``) by running the real binary:
+
+* ``chainsaw 2.16.0`` -- ``hunt -s <rules>`` without ``--mapping`` exits 2
+  ("the following required arguments were not provided: --mapping");
+  ``analyse srum`` requires ``--software`` and has no ``--json``;
+  ``dump`` has no ``--from`` / ``--to``.
+* ``hayabusa 3.8.1`` -- ``csv-timeline -o <existing file>`` refuses to run
+  **and exits 0**, so only ``--clobber`` (or an absent path) makes it work.
+* ``capa 9.4.0`` / ``floss 3.1.0`` -- ``--format`` selects the *sample*
+  format; ``--format json`` is an invalid choice and both exit 2.
+* ``Zircolite 2.20.0`` -- has no ``--json`` flag at all; JSON is the default.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestZircoliteArgv:
+    def test_no_json_flag(self, tmp_path: Path) -> None:
+        from mulder.server.tools.zircolite import _run_zircolite_process
+
+        with patch(
+            "mulder.server.tools.zircolite.subprocess.run", return_value=_completed()
+        ) as run:
+            _run_zircolite_process(
+                "zircolite.py", tmp_path, "evtx", tmp_path / "rules.json", tmp_path
+            )
+
+        argv = run.call_args[0][0]
+        assert "--json" not in argv, "Zircolite 2.20.0 has no --json flag; argparse exits 2"
+        assert "--events" in argv
+        assert "--ruleset" in argv
+        assert "--outfile" in argv
+
+
+class TestCapaFlossArgv:
+    def test_capa_uses_json_not_format_json(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        assert '[capa_bin, "--json", "--quiet"]' in source
+        assert '"--format",\n        "json"' not in source
+
+    def test_floss_excludes_static_with_no_static(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        # A bare `--only` is nargs="+" and swallowed the sample path.
+        assert 'cmd.extend(["--no", "static"])' in source
+        assert 'cmd.append("--only")' not in source
+
+
+class TestChainsawArgv:
+    @staticmethod
+    def _run(tmp_path: Path, **kwargs: Any) -> tuple[dict[str, object], list[str] | None]:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "mappings" / "sigma-event-logs-all.yml"
+        mapping.parent.mkdir(parents=True, exist_ok=True)
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir(exist_ok=True)
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch("mulder.server.tools.chainsaw._default_chainsaw_mapping", return_value=mapping),
+            patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+            patch("mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()) as run,
+        ):
+            result = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+                str(evidence), **kwargs
+            )
+        argv = list(run.call_args[0][0]) if run.call_args else None
+        return result, argv
+
+    def test_hunt_passes_mapping(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="hunt")
+        assert argv is not None
+        assert "--mapping" in argv
+
+    def test_hunt_errors_when_mapping_asset_is_absent(self, tmp_path: Path) -> None:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=tmp_path / "nope.yml",
+            ),
+        ):
+            result = run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+
+        assert result["error_type"] == "asset_missing"
+
+    def test_srum_requires_software_hive(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="srum")
+        assert result["error_type"] == "invalid_argument"
+        assert "software_hive" in str(result["error_message"])
+        assert argv is None, "chainsaw must not be executed without --software"
+
+    def test_srum_passes_software_and_no_json(self, tmp_path: Path) -> None:
+        hive = tmp_path / "SOFTWARE"
+        hive.write_bytes(b"regf")
+        _, argv = self._run(tmp_path, mode="srum", software_hive=str(hive))
+        assert argv is not None
+        assert "--software" in argv
+        assert str(hive) in argv
+        assert "--json" not in argv, "chainsaw analyse srum has no --json flag"
+
+    def test_timeline_rejects_a_time_range(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="timeline", time_range_start="2024-01-01T00:00:00")
+        assert result["error_type"] == "invalid_argument"
+        assert argv is None
+
+    def test_timeline_without_a_range_passes_no_from_to(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="timeline")
+        assert argv is not None
+        assert "--from" not in argv
+        assert "--to" not in argv
+
+
+class TestHayabusaArgv:
+    def test_clobber_is_passed_and_output_path_is_fresh(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        seen: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen["argv"] = cmd
+            out = Path(cmd[cmd.index("-o") + 1])
+            seen["existed_before"] = out.exists()
+            out.write_text("Timestamp,RuleTitle\n")
+            return _completed()
+
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(hb.subprocess, "run", side_effect=fake_run),
+        ):
+            hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert "--clobber" in seen["argv"]
+        assert seen["existed_before"] is False, (
+            "hayabusa refuses to overwrite an existing -o path and exits 0 while doing so"
+        )
+
+    def test_missing_output_file_is_an_error_not_zero_alerts(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        # The real refusal: exit 0, nothing written.
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(
+                hb.subprocess,
+                "run",
+                return_value=_completed(stdout="[ERROR] The file already exists."),
+            ),
+        ):
+            result = hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert result["status"] == "error"
+        assert result.get("total_alerts") != 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -16,6 +16,7 @@ Every assertion below was checked against the pinned release of the tool
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -46,17 +47,104 @@ class TestZircoliteArgv:
         assert "--outfile" in argv
 
 
-class TestCapaFlossArgv:
-    def test_capa_uses_json_not_format_json(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        assert '[capa_bin, "--json", "--quiet"]' in source
-        assert '"--format",\n        "json"' not in source
+def _floss_parser() -> argparse.ArgumentParser:
+    """floss 3.1.0's parser, for the options mulder passes.
 
-    def test_floss_excludes_static_with_no_static(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        # A bare `--only` is nargs="+" and swallowed the sample path.
-        assert 'cmd.extend(["--no", "static"])' in source
-        assert 'cmd.append("--only")' not in source
+    Mirrors floss/main.py v3.1.0: `-n/--minimum-length`, a positional
+    `sample`, `--no`/`--only` as ``action="extend", nargs="+"`` over
+    ``{static,stack,tight,decoded}``, `-f/--format` over
+    ``{auto,pe,sc32,sc64}`` and `-j/--json`. Parsing mulder's argv with it
+    is what catches a flag rename that argparse would still reject.
+    """
+
+    class _Extend(argparse.Action):
+        def __call__(  # type: ignore[override]
+            self,
+            parser: argparse.ArgumentParser,
+            namespace: argparse.Namespace,
+            values: Any,
+            option_string: str | None = None,
+        ) -> None:
+            items = list(getattr(namespace, self.dest, None) or [])
+            items.extend(values)
+            setattr(namespace, self.dest, items)
+
+    types = ["static", "stack", "tight", "decoded"]
+    parser = argparse.ArgumentParser(prog="floss", add_help=False)
+    parser.register("action", "extend", _Extend)
+    parser.add_argument("-n", "--minimum-length", dest="min_length", type=int, default=4)
+    parser.add_argument("sample")
+    parser.add_argument(
+        "--no", action="extend", dest="disabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument(
+        "--only", action="extend", dest="enabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument("-f", "--format", choices=["auto", "pe", "sc32", "sc64"], default="auto")
+    parser.add_argument("-j", "--json", action="store_true")
+    return parser
+
+
+def _capa_parser() -> argparse.ArgumentParser:
+    """capa 9.4.0's parser, for the options mulder passes."""
+    parser = argparse.ArgumentParser(prog="capa", add_help=False)
+    parser.add_argument("-q", "--quiet", action="store_true")
+    parser.add_argument("-j", "--json", action="store_true")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["auto", "pe", "dotnet", "elf", "sc32", "sc64", "cape", "freeze"],
+        default="auto",
+    )
+    parser.add_argument("-r", "--rules", action="append", default=[])
+    parser.add_argument("sample")
+    return parser
+
+
+class TestCapaFlossArgv:
+    """Parse mulder's argv with each tool's own parser, not with a substring."""
+
+    @staticmethod
+    def _argv(tool: str, tmp_path: Path, **kwargs: Any) -> list[str]:
+        from mulder.server.tools import binary as b
+
+        sample = tmp_path / "sample.bin"
+        sample.write_bytes(b"MZ\x90\x00")
+        fake = tmp_path / tool
+        fake.write_text("#!/bin/sh\n")
+        fake.chmod(0o755)
+
+        with (
+            patch.object(b, "require_binary", return_value=str(fake)),
+            patch.object(b, "extract_and_index", return_value={}),
+            patch.object(b.subprocess, "run", return_value=_completed(stdout="{}")) as run,
+        ):
+            fn = b.run_capa if tool == "capa" else b.run_floss
+            fn.__wrapped__("case", str(sample), **kwargs)  # type: ignore[attr-defined]
+        return list(run.call_args[0][0])
+
+    def test_capa_argv_parses(self, tmp_path: Path) -> None:
+        argv = self._argv("capa", tmp_path)
+        # capa's --format takes a *sample* format; "--format json" exits 2.
+        assert "--format" not in argv
+        _capa_parser().parse_args(argv[1:])
+
+    def test_floss_argv_parses_with_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=True)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.json is True
+        assert ns.disabled_types == []
+
+    def test_floss_argv_parses_without_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=False)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.disabled_types == ["static"]
+        assert ns.sample.endswith("sample.bin")
+
+    def test_floss_sample_precedes_the_type_flags(self, tmp_path: Path) -> None:
+        """`--no static <sample>` still exits 2: nargs="+" eats the path."""
+        argv = self._argv("floss", tmp_path, include_static=False)
+        assert argv.index("--no") > argv.index(next(a for a in argv if a.endswith("sample.bin")))
 
 
 class TestChainsawArgv:

--- a/tests/test_detection_indexing.py
+++ b/tests/test_detection_indexing.py
@@ -1,0 +1,353 @@
+"""Detections have to reach the case database, not just their count.
+
+``extract_and_index`` stores exactly the text it is handed. Chainsaw,
+Zircolite and both LEAPP wrappers handed it a summary::
+
+    Chainsaw hunt analysis of /evidence/evtx
+    Total findings: 412
+      critical: 3
+
+Nothing else. Not one rule name, host, sigma id or command line, so the FTS
+index -- the thing every downstream correlation, the report and the analyst's
+own searches read from -- could not answer a single question about what the
+tool had found. The counts came back in the tool response and were then
+dropped on the floor when the session ended.
+
+Each test below asserts on the text actually passed to ``extract_and_index``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from mulder.server.extract_helpers import format_records
+
+# A hunt result in the shape chainsaw 2.16.0 writes with --json.
+CHAINSAW_HUNT = [
+    {
+        "timestamp": "2024-03-11T09:14:02Z",
+        "name": "Suspicious PowerShell Encoded Command",
+        "level": "critical",
+        "source": "Security",
+        "event_id": 4688,
+        "computer": "WKSTN-042.corp.local",
+        "channel": "Microsoft-Windows-Sysmon/Operational",
+        "sigma_id": "ac7102e2-71b4-4d84-8bbf-e0e35a7d8d76",
+        "tags": ["attack.execution", "attack.t1059.001"],
+        "event_data": {
+            "CommandLine": "powershell.exe -enc SQBFAFgAKABOAGUAdwAtAE8AYgBqAA==",
+            "ParentImage": "C:\\\\Windows\\\\System32\\\\winword.exe",
+        },
+    },
+    {
+        "timestamp": "2024-03-11T09:16:44Z",
+        "name": "Rare Service Installation",
+        "level": "high",
+        "source": "System",
+        "event_id": 7045,
+        "computer": "DC01.corp.local",
+        "channel": "System",
+        "sigma_id": "5a604aa7-7f4d-4e5e-b0d3-1f4a02b8f9a1",
+        "tags": ["attack.persistence", "attack.t1543.003"],
+        "event_data": {"ServiceName": "UpdaterSvc", "ImagePath": "C:\\\\Users\\\\Public\\\\u.exe"},
+    },
+    {
+        "timestamp": "2024-03-11T11:02:10Z",
+        "name": "Logon From Unusual Source",
+        "level": "medium",
+        "source": "Security",
+        "event_id": 4624,
+        "computer": "WKSTN-042.corp.local",
+        "channel": "Security",
+        "sigma_id": "8f1c2b31-1a2e-4b9d-a0c4-2c9f1d5a6e77",
+        "tags": ["attack.lateral-movement"],
+        "event_data": {"IpAddress": "10.4.19.203", "TargetUserName": "svc_backup"},
+    },
+]
+
+ZIRCOLITE_HITS = [
+    {
+        "timestamp": "2024-03-11T09:14:02",
+        "rule_title": "Encoded PowerShell Command Line",
+        "rule_id": "ac7102e2-71b4-4d84-8bbf-e0e35a7d8d76",
+        "rule_level": "critical",
+        "rule_description": "Detects base64 encoded PowerShell command lines.",
+        "rule_mitre": [{"tactic": "execution", "technique": "T1059.001"}],
+        "matched_fields": {"CommandLine": "powershell.exe -enc SQBFAFgA"},
+        "count": 4,
+    },
+    {
+        "timestamp": "2024-03-11T09:16:44",
+        "rule_title": "Service Installed From User Writable Path",
+        "rule_id": "5a604aa7-7f4d-4e5e-b0d3-1f4a02b8f9a1",
+        "rule_level": "high",
+        "rule_description": "Detects services whose image sits under C:\\\\Users.",
+        "rule_mitre": [{"tactic": "persistence", "technique": "T1543.003"}],
+        "matched_fields": {"ImagePath": "C:\\\\Users\\\\Public\\\\u.exe"},
+        "count": 1,
+    },
+]
+
+
+def _completed(returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr="")
+
+
+class _Capture:
+    """Stands in for ``extract_and_index`` and keeps the text it was given."""
+
+    def __init__(self) -> None:
+        self.raw_output = ""
+
+    def __call__(self, raw_output: str, *args: object, **kwargs: object) -> dict[str, object]:
+        self.raw_output = raw_output if isinstance(raw_output, str) else str(raw_output)
+        return {"line_count": len(self.raw_output.splitlines())}
+
+
+class _CaptureSummary:
+    """Wraps ``tool_response`` and keeps the results dict it was given.
+
+    ``tool_response`` returns only a preview once the output has been indexed,
+    so the record lists are not visible in the response itself.
+    """
+
+    def __init__(self, real: Any) -> None:
+        self._real = real
+        self.results: dict[str, Any] = {}
+
+    def __call__(self, tc_id: str, tool_name: str, params: Any, results: Any, *a: object) -> Any:
+        if isinstance(results, dict):
+            self.results = dict(results)
+        return self._real(tc_id, tool_name, params, results, *a)
+
+
+class TestFormatRecords:
+    def test_one_line_per_record(self) -> None:
+        lines = format_records([{"a": 1}, {"a": 2}, {"a": 3}])
+        assert lines == ["1", "2", "3"]
+
+    def test_fields_fix_the_column_order(self) -> None:
+        lines = format_records([{"b": "x", "a": "y"}], ["a", "b"])
+        assert lines == ["y\tx"]
+
+    def test_a_missing_field_is_an_empty_column(self) -> None:
+        assert format_records([{"a": "y"}], ["a", "b", "c"]) == ["y\t\t"]
+
+    def test_nested_values_stay_searchable(self) -> None:
+        line = format_records([{"event_data": {"CommandLine": "whoami /all"}}])[0]
+        assert "whoami /all" in line
+
+    def test_embedded_newlines_cannot_split_a_record(self) -> None:
+        line = format_records([{"a": "one\ntwo\r\nthree", "b": "z"}])[0]
+        assert "\n" not in line
+        assert "\r" not in line
+        assert line.count("\t") == 1
+
+    def test_embedded_tabs_do_not_shift_columns(self) -> None:
+        line = format_records([{"a": "x\ty", "b": "z"}], ["a", "b"])[0]
+        assert line.count("\t") == 1
+
+    def test_one_huge_field_cannot_fill_a_window(self) -> None:
+        line = format_records([{"a": "x" * 100_000}])[0]
+        assert len(line) < 1000
+
+    def test_none_is_empty(self) -> None:
+        assert format_records([{"a": None, "b": "z"}], ["a", "b"]) == ["\tz"]
+
+    def test_no_records(self) -> None:
+        assert format_records([]) == []
+
+
+class TestChainsawIndexesDetections:
+    @staticmethod
+    def _run(
+        tmp_path: Path, hits: list[dict[str, Any]], mode: str = "hunt"
+    ) -> tuple[dict[str, object], str]:
+        from mulder.server.tools import chainsaw as cs
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "sigma-event-logs-all.yml"
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+        capture = _Capture()
+        summary = _CaptureSummary(cs.tool_response)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            Path(cmd[cmd.index("--output") + 1]).write_text(json.dumps(hits))
+            return _completed()
+
+        with (
+            patch.object(cs, "sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch.object(cs, "_default_chainsaw_mapping", return_value=mapping),
+            patch.object(cs, "extract_and_index", capture),
+            patch.object(cs, "tool_response", summary),
+            patch.object(cs.subprocess, "run", side_effect=fake_run),
+        ):
+            cs.run_chainsaw.__wrapped__(str(evidence), mode=mode)  # type: ignore[attr-defined]
+        return summary.results, capture.raw_output
+
+    def test_every_rule_name_is_indexed(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, CHAINSAW_HUNT)
+        for hit in CHAINSAW_HUNT:
+            assert hit["name"] in indexed
+
+    def test_the_command_line_is_indexed(self, tmp_path: Path) -> None:
+        """The single most searched-for field in an intrusion investigation."""
+        _, indexed = self._run(tmp_path, CHAINSAW_HUNT)
+        assert "powershell.exe -enc SQBFAFgA" in indexed
+
+    def test_hosts_and_sigma_ids_are_indexed(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, CHAINSAW_HUNT)
+        assert "DC01.corp.local" in indexed
+        assert "ac7102e2-71b4-4d84-8bbf-e0e35a7d8d76" in indexed
+
+    def test_each_detection_is_one_whole_line(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, CHAINSAW_HUNT)
+        detection_lines = [ln for ln in indexed.splitlines() if ln.startswith("2024-03-11T")]
+        assert len(detection_lines) == len(CHAINSAW_HUNT)
+        for line in detection_lines:
+            assert line.count("\t") == 9
+
+    def test_the_summary_counts_are_still_there(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, CHAINSAW_HUNT)
+        assert "Total findings: 3" in indexed
+        assert "  critical: 1" in indexed
+
+    def test_the_index_is_not_capped_at_the_response_limit(self, tmp_path: Path) -> None:
+        """The response carries 500 detections; the index must carry all 700."""
+        hits = [dict(CHAINSAW_HUNT[0], sigma_id=f"rule-{i:04d}") for i in range(700)]
+        result, indexed = self._run(tmp_path, hits)
+        assert "rule-0699" in indexed
+        assert len(result["detections"]) == 500  # type: ignore[arg-type]
+        assert result["total_findings"] == 700
+
+    def test_timeline_mode_indexes_its_entries(self, tmp_path: Path) -> None:
+        entries = [{"timestamp": "2024-03-11T09:14:02Z", "detail": "svchost.exe spawned cmd.exe"}]
+        _, indexed = self._run(tmp_path, entries, mode="timeline")
+        assert "svchost.exe spawned cmd.exe" in indexed
+
+
+class TestZircoliteIndexesDetections:
+    @staticmethod
+    def _run(tmp_path: Path, hits: list[dict[str, Any]]) -> tuple[dict[str, object], str]:
+        from mulder.server.tools import zircolite as zc
+
+        events = tmp_path / "events"
+        events.mkdir()
+        script = tmp_path / "zircolite.py"
+        script.write_text("")
+        ruleset = tmp_path / "rules.json"
+        ruleset.write_text("[]")
+        capture = _Capture()
+        summary = _CaptureSummary(zc.tool_response)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            Path(cmd[cmd.index("--outfile") + 1]).write_text(json.dumps(hits))
+            return _completed()
+
+        with (
+            patch.object(zc, "sources_already_indexed", return_value=[]),
+            patch.object(zc, "_zircolite_script", return_value=script),
+            patch.object(zc, "_missing_zircolite_modules", return_value=[]),
+            patch.object(zc, "extract_and_index", capture),
+            patch.object(zc, "tool_response", summary),
+            patch.object(zc.subprocess, "run", side_effect=fake_run),
+        ):
+            zc.run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+                str(events), ruleset_path=str(ruleset)
+            )
+        return summary.results, capture.raw_output
+
+    def test_rule_titles_and_matched_fields_are_indexed(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, ZIRCOLITE_HITS)
+        assert "Encoded PowerShell Command Line" in indexed
+        assert "Service Installed From User Writable Path" in indexed
+        assert "powershell.exe -enc SQBFAFgA" in indexed
+
+    def test_each_detection_is_one_whole_line(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, ZIRCOLITE_HITS)
+        lines = [ln for ln in indexed.splitlines() if ln.startswith("2024-03-11T")]
+        assert len(lines) == len(ZIRCOLITE_HITS)
+        for line in lines:
+            assert line.count("\t") == 7
+
+    def test_the_index_is_not_capped_at_the_response_limit(self, tmp_path: Path) -> None:
+        hits = [dict(ZIRCOLITE_HITS[0], rule_id=f"rule-{i:04d}") for i in range(700)]
+        result, indexed = self._run(tmp_path, hits)
+        assert "rule-0699" in indexed
+        assert len(result["detections"]) == 500  # type: ignore[arg-type]
+        assert result["total_detections"] == 700
+
+
+class TestLeappIndexesRows:
+    @staticmethod
+    def _run(tmp_path: Path, tsv: dict[str, str]) -> tuple[dict[str, object], str]:
+        from mulder.server.tools import phone as ph
+
+        extraction = tmp_path / "extraction"
+        extraction.mkdir()
+        script = tmp_path / "aleapp.py"
+        script.write_text("")
+        capture = _Capture()
+        summary = _CaptureSummary(ph.tool_response)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            out = Path(cmd[cmd.index("-o") + 1])
+            tsv_dir = out / "tsv"
+            tsv_dir.mkdir(parents=True, exist_ok=True)
+            for name, body in tsv.items():
+                (tsv_dir / f"{name}.tsv").write_text(body)
+            return _completed()
+
+        with (
+            patch.object(ph, "_aleapp_script", return_value=str(script)),
+            patch.object(ph, "_find_leapp_cmd", return_value=["aleapp"]),
+            patch.object(ph, "extract_and_index", capture),
+            patch.object(ph, "tool_response", summary),
+            patch.object(ph.subprocess, "run", side_effect=fake_run),
+        ):
+            ph.run_aleapp.__wrapped__(str(extraction))  # type: ignore[attr-defined]
+        return summary.results, capture.raw_output
+
+    TSV = {
+        "sms_messages": (
+            "Timestamp\tFrom\tTo\tBody\n"
+            "2024-03-09 21:04:11\t+32470112233\t+32470445566\tmeet at the usual place\n"
+            "2024-03-09 21:07:52\t+32470445566\t+32470112233\tbring the drive\n"
+        )
+    }
+
+    def test_message_bodies_are_indexed(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, self.TSV)
+        assert "meet at the usual place" in indexed
+        assert "bring the drive" in indexed
+
+    def test_phone_numbers_are_indexed(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, self.TSV)
+        assert "+32470112233" in indexed
+
+    def test_the_artifact_type_labels_its_rows(self, tmp_path: Path) -> None:
+        _, indexed = self._run(tmp_path, self.TSV)
+        assert "sms_messages" in indexed
+        assert "Timestamp\tFrom\tTo\tBody" in indexed
+
+    def test_the_index_is_not_capped_at_the_response_limit(self, tmp_path: Path) -> None:
+        rows = "\n".join(f"2024-03-09 21:04:11\tmsg-{i:04d}" for i in range(150))
+        _, indexed = self._run(tmp_path, {"sms_messages": f"Timestamp\tBody\n{rows}\n"})
+        assert "msg-0149" in indexed
+
+    def test_the_response_stays_bounded(self, tmp_path: Path) -> None:
+        rows = "\n".join(f"2024-03-09 21:04:11\tmsg-{i:04d}" for i in range(150))
+        result, _ = self._run(tmp_path, {"sms_messages": f"Timestamp\tBody\n{rows}\n"})
+        artifacts = result["artifacts"]
+        assert isinstance(artifacts, list)
+        assert len(artifacts[0]["data"]) == 100
+        assert artifacts[0]["record_count"] == 150

--- a/tests/test_detection_indexing.py
+++ b/tests/test_detection_indexing.py
@@ -153,7 +153,28 @@ class TestFormatRecords:
 
     def test_one_huge_field_cannot_fill_a_window(self) -> None:
         line = format_records([{"a": "x" * 100_000}])[0]
-        assert len(line) < 1000
+        assert len(line) < 4096
+
+    def test_a_realistic_event_document_keeps_its_late_fields(self) -> None:
+        """Chainsaw falls back to the whole event document for `event_data`.
+
+        That is 2-4 KB of JSON, and the fields an analyst searches for are not
+        the alphabetically first ones. A tight per-field cap would keep
+        `CommandLine` (which sorts early) and silently drop the rest.
+        """
+        document = {
+            "Channel": "Microsoft-Windows-Sysmon/Operational",
+            "CommandLine": "powershell.exe -enc SQBFAFgA",
+            "Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+            "ParentCommandLine": "C:\\Program Files\\Microsoft Office\\winword.exe /n",
+            "TargetUserName": "svc_backup",
+            "UtcTime": "2024-03-11 09:14:02.113",
+            "_padding": "y" * 800,
+        }
+        line = format_records([{"event_data": document}])[0]
+        assert "ParentCommandLine" in line
+        assert "svc_backup" in line
+        assert "winword.exe" in line
 
     def test_none_is_empty(self) -> None:
         assert format_records([{"a": None, "b": "z"}], ["a", "b"]) == ["\tz"]

--- a/tests/test_tool_exit_codes.py
+++ b/tests/test_tool_exit_codes.py
@@ -1,0 +1,174 @@
+"""A CLI tool that failed must not be reported as a clean scan.
+
+Every wrapped tool below used to discard its ``CompletedProcess``. When the
+tool exited non-zero and wrote nothing, the parser found no output file and
+returned "0 detections", which the MCP layer rendered as a **successful**
+tool call. That is a false negative that looks like a clean result -- the
+single worst outcome for a DFIR tool.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from mulder.server.helpers import classify_tool_exit
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestClassifyToolExit:
+    def test_zero_exit_is_ok(self) -> None:
+        verdict, message = classify_tool_exit(_completed(), "x", produced_output=False)
+        assert verdict == "ok"
+        assert message == ""
+
+    def test_nonzero_without_output_is_failed(self) -> None:
+        verdict, message = classify_tool_exit(
+            _completed(2, stderr="required argument --mapping"), "chainsaw", produced_output=False
+        )
+        assert verdict == "failed"
+        assert "chainsaw exited 2" in message
+        assert "--mapping" in message
+
+    def test_nonzero_with_output_is_partial_not_failed(self) -> None:
+        """chainsaw exits non-zero on one unreadable file without --skip-errors."""
+        verdict, message = classify_tool_exit(
+            _completed(1, stderr="failed to load a.evtx"), "chainsaw", produced_output=True
+        )
+        assert verdict == "partial"
+        assert "may be incomplete" in message
+
+    def test_stdout_is_used_when_stderr_is_empty(self) -> None:
+        _, message = classify_tool_exit(
+            _completed(1, stdout="boom"), "photorec", produced_output=False
+        )
+        assert "boom" in message
+
+    def test_message_is_bounded(self) -> None:
+        _, message = classify_tool_exit(
+            _completed(1, stderr="x" * 10_000), "t", produced_output=False
+        )
+        assert len(message) < 800
+
+
+class TestRunCliTool:
+    @staticmethod
+    def _run(tmp_path: Path, proc: subprocess.CompletedProcess[str]) -> dict[str, object]:
+        from mulder.server import helpers as h
+
+        target = tmp_path / "evidence.bin"
+        target.write_bytes(b"\x00")
+        with (
+            patch.object(h, "require_binary", return_value="/usr/bin/strings"),
+            patch.object(h, "run_subprocess", return_value=proc),
+            patch(
+                "mulder.server.extract_helpers.extract_and_index",
+                return_value={"line_count": 1},
+            ),
+        ):
+            return h.run_cli_tool(
+                binary="strings",
+                cmd=["strings", str(target)],
+                tool_name="run_strings",
+                params={},
+                source_name="strings.output",
+                source_path=str(target),
+                extractor_label="strings",
+            )
+
+    def test_failed_tool_is_an_error_not_an_empty_success(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(1, stderr="No such file"))
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"
+
+    def test_partial_run_keeps_results_and_warns(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(1, stdout="hello", stderr="one file unreadable"))
+        assert result["status"] == "success"
+        assert "may be incomplete" in str(result["warning"])
+
+    def test_clean_run_has_no_warning(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(0, stdout="hello"))
+        assert result["status"] == "success"
+        assert "warning" not in result
+
+
+class TestChainsawExitStatus:
+    @staticmethod
+    def _run(tmp_path: Path, returncode: int, write_output: bool) -> dict[str, object]:
+        from mulder.server.tools import chainsaw as cs
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "sigma-event-logs-all.yml"
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            if write_output:
+                out = Path(cmd[cmd.index("--output") + 1])
+                out.write_text("[]")
+            return _completed(returncode, stderr="required arguments were not provided")
+
+        with (
+            patch.object(cs, "sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch.object(cs, "_default_chainsaw_mapping", return_value=mapping),
+            patch.object(cs, "extract_and_index", return_value={}),
+            patch.object(cs.subprocess, "run", side_effect=fake_run),
+        ):
+            return cs.run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+
+    def test_exit_two_with_no_results_file_is_an_error(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=2, write_output=False)
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"
+
+    def test_clean_run_still_succeeds(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=0, write_output=True)
+        assert result["status"] == "success"
+
+    def test_partial_run_keeps_the_detections(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=1, write_output=True)
+        assert result["status"] == "success"
+        assert "may be incomplete" in str(result["warning"])
+
+
+class TestZircoliteExitStatus:
+    def test_failed_run_is_an_error(self, tmp_path: Path) -> None:
+        from mulder.server.tools import zircolite as zc
+
+        events = tmp_path / "events"
+        events.mkdir()
+        script = tmp_path / "zircolite.py"
+        script.write_text("")
+        ruleset = tmp_path / "rules.json"
+        ruleset.write_text("[]")
+
+        with (
+            patch.object(zc, "sources_already_indexed", return_value=[]),
+            patch.object(zc, "_zircolite_script", return_value=script),
+            patch.object(zc, "_missing_zircolite_modules", return_value=[]),
+            patch.object(zc, "extract_and_index", return_value={}),
+            patch.object(
+                zc.subprocess,
+                "run",
+                return_value=_completed(2, stderr="unrecognized arguments: --json"),
+            ),
+        ):
+            result = zc.run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+                str(events), ruleset_path=str(ruleset)
+            )
+
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"


### PR DESCRIPTION
## BLUF

- **What breaks:** `extract_and_index` stores exactly the text it is handed. Four tools handed it a count — `Total findings: 412` — and nothing else.
- **Impact:** no rule name, host, sigma id, service path, command line, phone number or message body from Chainsaw, Zircolite, ALEAPP or iLEAPP ever reached the case database. The FTS index that every correlation, the HTML report and the analyst's own `search()` read from could not answer one question about what the tool found. The records came back once in the tool response and were gone when the session ended.
- **Second-order:** the three parsers truncated their record lists *before* returning, so even after indexing the right thing the index would have inherited the response's cap.
- **Fix:** a shared `format_records` renders records as one tab-separated line each; parsers return everything and the caller truncates for the response. The wire response is unchanged.
- **Risk:** Low. Nothing that was indexed before stops being indexed; the summary lines are still there, with the records appended.

## Priority

**high** — silent, total loss of detection content from the case database, on the four tools that produce the most detections.

## Stacked on #70

Branched from `fix/tool-exit-codes`, because the lines this touches in `chainsaw.py` and `zircolite.py` are the ones that PR sits directly above. Review or merge that first.

## What was actually indexed

```
Chainsaw hunt analysis of /evidence/evtx
Total findings: 412
  critical: 3
  high: 27
```

412 detections found; zero searchable. Same shape in `run_zircolite`, `run_aleapp` and `run_ileapp`.

## `format_records`

One tab-separated line per record, in `extract_helpers` next to `extract_and_index`:

- **nested values are JSON-encoded**, so `event_data.CommandLine` — the single most searched-for field in an intrusion investigation — stays in the index;
- **embedded tabs and newlines are flattened**, so no record can split across lines or shift a neighbour's columns;
- **each field is truncated** at 2000 characters, so one pathological value cannot fill a window. Not tighter: Chainsaw falls back to the *whole event document* for `event_data`, 2-4 KB of JSON, and a 400-character cap kept `CommandLine` while dropping `Image`, `ParentCommandLine` and `TargetUserName` — the fields that answer what spawned it and as whom;
- **timestamp first**, so per-window timestamp extraction picks up the record's own time. A summary block contained no timestamp at all, which is why these windows previously had none.

One record per line also matters for the window builder, which splits on line boundaries: no detection is cut in half.

## The truncation that would have defeated the fix

`_parse_chainsaw_hunt_results` returned `detections[:500]`, the timeline parser `raw[:1000]`, `_parse_leapp_output` `records[:100]` per artifact. Indexing then saw only the truncated list. The parsers now return the full list, the caller indexes it, and the truncation moves to just before the response is built — so the response is byte-for-byte what it was and the index is complete. Tests pin both halves.

## Tests

New `tests/test_detection_indexing.py` (25 tests). **13 of them fail on this branch's parent**, which is the point:

- three realistic Chainsaw hunt detections and two Zircolite hits, in the shapes the pinned releases write — every rule name, host, sigma id and the encoded PowerShell command line asserted present in the indexed text;
- each detection is exactly one line with the expected column count;
- 700 detections: all 700 indexed, response still capped at 500, `total_findings` still 700;
- LEAPP: SMS bodies and phone numbers indexed, header row present, 150 rows indexed with the response bounded at 100;
- `format_records` unit tests for tab/newline flattening, field truncation, nested JSON, missing fields, `None` and the empty case, plus a realistic 2 KB event document whose interesting fields are deliberately not alphabetically first.

Tests assert on the text handed to `extract_and_index`, not on source contents.

`make lint format typecheck test` — 792 passed (767 on the parent branch, +25), mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
