### PR TITLE
[high] fix(cli): make --db-dir reach the code that writes the database

### DIFF
--- a/src/mulder/cli.py
+++ b/src/mulder/cli.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING
 import click
 
 from mulder import __version__
-from mulder.patterns import DEFAULT_DB_DIR, DEFAULT_WORKSPACE_DIR
+from mulder.patterns import (
+    DB_DIR_ENV_VAR,
+    DEFAULT_DB_DIR,
+    DEFAULT_WORKSPACE_DIR,
+    resolve_db_dir,
+)
 
 if TYPE_CHECKING:  # heavy imports stay inside the command bodies
     from rich.console import Console
@@ -43,8 +48,9 @@ def cli() -> None:
 @click.option(
     "--db-dir",
     default=DEFAULT_DB_DIR,
+    envvar=DB_DIR_ENV_VAR,
     show_default=True,
-    help="Directory containing per-case databases.",
+    help="Directory containing per-case databases (env: MULDER_DB_DIR).",
 )
 @click.option(
     "--transport",
@@ -131,8 +137,9 @@ def serve(
 @click.option(
     "--db-dir",
     default=DEFAULT_DB_DIR,
+    envvar=DB_DIR_ENV_VAR,
     show_default=True,
-    help="Directory containing per-case databases.",
+    help="Directory containing per-case databases (env: MULDER_DB_DIR).",
 )
 def report(case_id: str, db_dir: str) -> None:
     """Generate HTML + Markdown reports from an existing case database.
@@ -255,8 +262,9 @@ def report(case_id: str, db_dir: str) -> None:
 @click.option(
     "--db-dir",
     default=DEFAULT_DB_DIR,
+    envvar=DB_DIR_ENV_VAR,
     show_default=True,
-    help="Case database directory.",
+    help="Case database directory (env: MULDER_DB_DIR).",
 )
 @click.option(
     "--cwd",
@@ -337,7 +345,7 @@ def investigate(
             ) from exc
         click.echo(f"Created default MCP configuration at {mcp_config_file}", err=True)
 
-    log_dir = Path(db_dir).expanduser()
+    log_dir = resolve_db_dir(db_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "orchestrator.log"
     file_handler = logging.FileHandler(str(log_file), mode="a")
@@ -376,6 +384,7 @@ def investigate(
         parallel_extractions=workers,
         proxy_config=proxy_config,
         case_id=case_id,
+        db_dir=log_dir,
     )
 
     from mulder.orchestrator.errors import (
@@ -675,8 +684,9 @@ def _human_bytes(count: int) -> str:
 @click.option(
     "--db-dir",
     default=DEFAULT_DB_DIR,
+    envvar=DB_DIR_ENV_VAR,
     show_default=True,
-    help="Directory containing per-case databases.",
+    help="Directory containing per-case databases (env: MULDER_DB_DIR).",
 )
 def export_iocs_cmd(case_id: str, fmt: str, output_dir: str | None, db_dir: str) -> None:
     """Export IOCs from a completed investigation as STIX 2.1 or CSV."""
@@ -720,8 +730,9 @@ def export_iocs_cmd(case_id: str, fmt: str, output_dir: str | None, db_dir: str)
 @click.option(
     "--db-dir",
     default=DEFAULT_DB_DIR,
+    envvar=DB_DIR_ENV_VAR,
     show_default=True,
-    help="Directory containing per-case databases.",
+    help="Directory containing per-case databases (env: MULDER_DB_DIR).",
 )
 def export_navigator_cmd(case_id: str, output_dir: str | None, domain: str, db_dir: str) -> None:
     """Export a MITRE ATT&CK Navigator layer from investigation findings."""

--- a/src/mulder/orchestrator/evidence.py
+++ b/src/mulder/orchestrator/evidence.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from mulder.orchestrator.types import PhaseResult, extract_catalog_result
-from mulder.patterns import DEFAULT_DB_DIR, DISK_IMAGE_EXTS, extract_iocs_from_text
+from mulder.patterns import DISK_IMAGE_EXTS, extract_iocs_from_text, resolve_db_dir
 
 logger = logging.getLogger(__name__)
 
@@ -264,13 +264,16 @@ class ServerBridge:
     checks, and consistency analysis without spending LLM tokens.
     """
 
-    def __init__(self, case_id: str) -> None:
+    def __init__(self, case_id: str, db_dir: str | Path | None = None) -> None:
         """Initialize the server bridge.
 
         Args:
             case_id: Case identifier for loading the correct database.
+            db_dir: Directory holding the case database. Falls back to
+                ``$MULDER_DB_DIR`` and then the default when not given.
         """
         self._case_id = case_id
+        self._db_dir = db_dir
 
     def ensure_context(self) -> None:
         """Initialize a fresh server context for direct tool invocations.
@@ -283,8 +286,7 @@ class ServerBridge:
         if server_app._cfg is None:
             from mulder.server.app import ServerConfig
 
-            db_dir = Path(DEFAULT_DB_DIR).expanduser()
-            server_app._cfg = ServerConfig(db_dir=db_dir)
+            server_app._cfg = ServerConfig(db_dir=resolve_db_dir(self._db_dir))
 
         if self._case_id:
             server_app.load_case(self._case_id)

--- a/src/mulder/orchestrator/runner.py
+++ b/src/mulder/orchestrator/runner.py
@@ -46,7 +46,11 @@ from mulder.orchestrator.types import (
     PhaseResult,
     extract_catalog_result,
 )
-from mulder.patterns import DEFAULT_DB_DIR, DEFAULT_WORKSPACE_DIR
+from mulder.patterns import (
+    DB_DIR_ENV_VAR,
+    DEFAULT_WORKSPACE_DIR,
+    resolve_db_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +78,7 @@ class Orchestrator:
         parallel_extractions: int = 3,
         proxy_config: str | None = None,
         case_id: str = "",
+        db_dir: str | Path = "",
     ) -> None:
         """Initialize the orchestrator.
 
@@ -90,6 +95,10 @@ class Orchestrator:
                 custom model routing.
             case_id: Case identifier used for the database filename and
                 referenced by all phases.
+            db_dir: Directory holding the case database, its audit log and
+                the run's sidecar files. Exported to agent sessions so the
+                MCP servers they spawn write to the same place. Falls back to
+                ``$MULDER_DB_DIR`` and then the default when not given.
         """
         self.evidence_path = evidence_path
         self.cwd = str(cwd)
@@ -97,6 +106,10 @@ class Orchestrator:
         self.effort = effort
         self.env = env or {}
         self._case_id: str = case_id
+        self._db_dir = resolve_db_dir(db_dir)
+        # Agent sessions spawn their own `mulder serve`; without this the
+        # child server writes the case to the default directory instead.
+        self.env[DB_DIR_ENV_VAR] = str(self._db_dir)
         if self._case_id:
             self.env["MULDER_CASE_ID"] = self._case_id
         self._last_session_id: str = ""
@@ -128,10 +141,10 @@ class Orchestrator:
             cwd=self.cwd,
         )
         self._evidence = EvidenceContext(evidence_path=evidence_path)
-        self._server = ServerBridge(case_id=self._case_id)
+        self._server = ServerBridge(case_id=self._case_id, db_dir=self._db_dir)
         self._log_tailer = LogTailer(
             dashboard=self.dashboard,
-            log_path=Path(DEFAULT_DB_DIR).expanduser() / "mulder.log",
+            log_path=self._db_dir / "mulder.log",
         )
 
     async def run(self) -> InvestigationResult:
@@ -816,8 +829,7 @@ class Orchestrator:
         if not model_data or not self._case_id:
             return
 
-        db_dir = Path("~/.mulder/cases").expanduser()
-        usage_path = db_dir / f"{self._case_id}.model_usage.json"
+        usage_path = self._db_dir / f"{self._case_id}.model_usage.json"
         try:
             entries = []
             for model_name, counts in sorted(model_data.items()):

--- a/src/mulder/patterns.py
+++ b/src/mulder/patterns.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ipaddress
+import os
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 
 IP_RE: re.Pattern[str] = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 
@@ -44,6 +46,29 @@ DISK_IMAGE_EXTS: frozenset[str] = frozenset(
 )
 
 DEFAULT_DB_DIR: str = "~/.mulder/cases"
+
+#: Environment variable carrying the case-database directory to subprocesses.
+#: ``mulder investigate`` spawns agent sessions which spawn their own
+#: ``mulder serve``; without this the child server falls back to the default
+#: directory and writes the case somewhere ``mulder report --db-dir`` will
+#: never look. Mirrors the existing ``MULDER_CWD`` convention.
+DB_DIR_ENV_VAR: str = "MULDER_DB_DIR"
+
+
+def resolve_db_dir(db_dir: str | Path | None = None) -> Path:
+    """Resolve the case-database directory.
+
+    Args:
+        db_dir: An explicit directory. When *None* or empty, falls back to
+            ``$MULDER_DB_DIR`` and then to :data:`DEFAULT_DB_DIR`.
+
+    Returns:
+        The expanded directory. Never ``~``-relative, so callers can compare
+        and join paths without expanding again.
+    """
+    chosen = str(db_dir) if db_dir else (os.environ.get(DB_DIR_ENV_VAR) or DEFAULT_DB_DIR)
+    return Path(chosen).expanduser()
+
 
 DEFAULT_WORKSPACE_DIR: str = "~/.mulder/workspace"
 """Default working directory for agent sessions on a native install.

--- a/tests/test_db_dir_propagation.py
+++ b/tests/test_db_dir_propagation.py
@@ -1,0 +1,138 @@
+"""``--db-dir`` has to reach the thing that writes the database.
+
+``mulder investigate --db-dir /cases`` accepted the flag, wrote its log file
+there, and then dropped it: the orchestrator was constructed without it, the
+log tailer read ``~/.mulder/cases/mulder.log``, the model-usage sidecar was
+written to a hardcoded ``~/.mulder/cases``, and the ``mulder serve``
+processes the agent sessions spawn got no hint at all. The case therefore
+landed in the default directory, and the matching ``mulder report --db-dir
+/cases`` could never find it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from mulder.cli import cli
+from mulder.orchestrator.evidence import ServerBridge
+from mulder.orchestrator.runner import Orchestrator
+from mulder.patterns import DB_DIR_ENV_VAR, DEFAULT_DB_DIR, resolve_db_dir
+
+
+class TestResolveDbDir:
+    def test_an_explicit_directory_wins(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setenv(DB_DIR_ENV_VAR, "/from/env")
+        assert resolve_db_dir(tmp_path) == tmp_path
+
+    def test_the_environment_is_the_fallback(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setenv(DB_DIR_ENV_VAR, str(tmp_path))
+        assert resolve_db_dir() == tmp_path
+        assert resolve_db_dir("") == tmp_path
+
+    def test_the_default_is_the_last_resort(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(DB_DIR_ENV_VAR, raising=False)
+        assert resolve_db_dir() == Path(DEFAULT_DB_DIR).expanduser()
+
+    def test_the_result_is_always_expanded(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv(DB_DIR_ENV_VAR, raising=False)
+        assert "~" not in str(resolve_db_dir("~/somewhere"))
+
+
+class TestOrchestratorHonoursDbDir:
+    @staticmethod
+    def _make(db_dir: Path) -> Orchestrator:
+        return Orchestrator(evidence_path="/evidence", case_id="case-1", db_dir=db_dir)
+
+    def test_the_log_tailer_reads_the_chosen_directory(self, tmp_path: Path) -> None:
+        orch = self._make(tmp_path)
+        assert orch._log_tailer._log_path == tmp_path / "mulder.log"
+
+    def test_agent_sessions_inherit_the_directory(self, tmp_path: Path) -> None:
+        """Sessions spawn their own ``mulder serve``; without this it defaults."""
+        orch = self._make(tmp_path)
+        assert orch.env[DB_DIR_ENV_VAR] == str(tmp_path)
+
+    def test_the_server_bridge_gets_the_directory(self, tmp_path: Path) -> None:
+        orch = self._make(tmp_path)
+        assert resolve_db_dir(orch._server._db_dir) == tmp_path
+
+    def test_the_model_usage_sidecar_lands_in_it(self, tmp_path: Path) -> None:
+        orch = self._make(tmp_path)
+        orch.dashboard._model_tokens = {"claude-x": {"input": 10, "output": 20}}
+        orch._write_model_usage()
+
+        written = tmp_path / "case-1.model_usage.json"
+        assert written.exists()
+        payload = json.loads(written.read_text())
+        assert payload[0]["model"] == "claude-x"
+
+    def test_the_environment_is_the_fallback(self, tmp_path: Path, monkeypatch: Any) -> None:
+        monkeypatch.setenv(DB_DIR_ENV_VAR, str(tmp_path))
+        orch = Orchestrator(evidence_path="/evidence", case_id="case-1")
+        assert orch._log_tailer._log_path == tmp_path / "mulder.log"
+
+
+class TestServerBridgeHonoursDbDir:
+    def test_the_server_config_uses_the_chosen_directory(self, tmp_path: Path) -> None:
+        import mulder.server.app as server_app
+
+        bridge = ServerBridge(case_id="", db_dir=tmp_path)
+        with (
+            patch.object(server_app, "_cfg", None),
+            patch.object(server_app, "load_case") as load_case,
+        ):
+            bridge.ensure_context()
+            assert server_app._cfg is not None
+            assert server_app._cfg.db_dir == tmp_path
+        load_case.assert_not_called()
+
+
+class TestInvestigateForwardsDbDir:
+    @staticmethod
+    def _invoke(args: list[str], env: dict[str, str] | None = None) -> MagicMock:
+        runner = CliRunner()
+        with (
+            patch("mulder.orchestrator.runner.Orchestrator") as orchestrator_cls,
+            patch("asyncio.run", return_value=MagicMock(success=True)),
+        ):
+            result = runner.invoke(
+                cli,
+                ["investigate", "/evidence", "case-1", *args],
+                env=env,
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0, result.output
+        return orchestrator_cls
+
+    def test_the_flag_reaches_the_orchestrator(self, tmp_path: Path) -> None:
+        """The whole bug: the flag was read, logged to, and then dropped."""
+        cls = self._invoke(["--db-dir", str(tmp_path)])
+        assert resolve_db_dir(cls.call_args.kwargs["db_dir"]) == tmp_path
+
+    def test_the_environment_variable_reaches_the_orchestrator(self, tmp_path: Path) -> None:
+        cls = self._invoke([], env={DB_DIR_ENV_VAR: str(tmp_path)})
+        assert resolve_db_dir(cls.call_args.kwargs["db_dir"]) == tmp_path
+
+
+class TestReportReadsTheSameDirectory:
+    """``investigate`` and ``report`` must agree on where the case lives."""
+
+    @pytest.mark.parametrize("command", ["report", "export-iocs", "export-navigator"])
+    def test_the_environment_variable_selects_the_directory(
+        self, command: str, tmp_path: Path
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [command, "case-1"],
+            env={DB_DIR_ENV_VAR: str(tmp_path)},
+            catch_exceptions=False,
+        )
+        # The case does not exist, and the message names where it was sought.
+        assert str(tmp_path / "case-1.db") in result.output


### PR DESCRIPTION
## BLUF

- **What breaks:** `mulder investigate --db-dir /cases` reads the flag, writes its log file there, and then never passes it on. `Orchestrator` is constructed without it.
- **Impact:** the case database lands in `~/.mulder/cases` regardless, so `mulder report --db-dir /cases <case>` looks where the user said and finds nothing. The flag is worse than absent — it looks like it worked.
- **Four separate places** silently fell back to the default: the log tailer, the model-usage sidecar (a literal `Path("~/.mulder/cases")`), `ServerBridge`'s `ServerConfig`, and the `mulder serve` processes the agent sessions spawn.
- **Fix:** one `resolve_db_dir()` resolution point; `Orchestrator` takes and uses `db_dir`; `MULDER_DB_DIR` is exported to agent sessions so the child servers agree.
- **Risk:** Low. Defaults are unchanged — with no flag and no environment variable every path resolves exactly as before.

## Priority

**high** — the case database is written somewhere the user did not ask for and the reporting commands cannot find, with no error at any point.

## The four fallbacks

```python
# runner.py, LogTailer
log_path=Path(DEFAULT_DB_DIR).expanduser() / "mulder.log"

# runner.py, _write_model_usage
db_dir = Path("~/.mulder/cases").expanduser()

# evidence.py, ServerBridge.ensure_context
db_dir = Path(DEFAULT_DB_DIR).expanduser()
server_app._cfg = ServerConfig(db_dir=db_dir)

# and nothing at all told the spawned `mulder serve` where to write
```

The last one is the one that actually loses the case: `investigate` runs agent sessions, each of which starts its own MCP server, and that server is what creates the database.

## The fix

`resolve_db_dir()` in `patterns.py` is now the single resolution point — explicit argument, then `$MULDER_DB_DIR`, then `DEFAULT_DB_DIR` — and always returns an expanded path so callers can compare and join without expanding again.

`Orchestrator` gains `db_dir`, uses it for all three of its own sites, and sets `MULDER_DB_DIR` in the environment it hands to agent sessions. Every `--db-dir` option now carries `envvar="MULDER_DB_DIR"`, which is both how the child server picks the value up and how `report` / `export-iocs` / `export-navigator` inherit it. This mirrors the `--cwd` / `MULDER_CWD` convention already in the file rather than inventing a second one.

## The child-server chain, verified

The value only helps if it survives to the spawned server, so I checked each hop:

1. the packaged `src/mulder/data/mcp.json` runs `mulder serve` with **no explicit `--db-dir`**, so the environment variable is not shadowed by a flag;
2. `Orchestrator.env` is handed to the agent SDK as `env=self._env` (`session.py`), so the agent subprocess and the stdio MCP server it spawns inherit it;
3. this is the same hop `MULDER_CASE_ID` already relies on — `server/tools/case.py` reads it back out of `os.environ` — so the mechanism is the one already proven to work in this codebase, not a new one.

## Tests

New `tests/test_db_dir_propagation.py` (15 tests). **11 fail on `main`**:

- `resolve_db_dir` precedence: explicit > environment > default, and the result is always expanded;
- the orchestrator's log tailer, model-usage sidecar and server bridge all land in the chosen directory — the sidecar test writes a real file and reads it back;
- agent sessions inherit `MULDER_DB_DIR`;
- `investigate --db-dir X` reaches `Orchestrator(db_dir=X)`, and so does `MULDER_DB_DIR=X` with no flag — this is the bug itself;
- `report`, `export-iocs` and `export-navigator` each look for the case in the directory the environment names.

`make lint format typecheck test` — 757 passed (742 baseline, +15), mypy clean, ruff clean.

## Merge note

Conflicts with #77 in `src/mulder/patterns.py` — both branches add an import next to `from dataclasses import dataclass, field` (`import os` / `from pathlib import Path` here, `from typing import NamedTuple` there). The conflict is the import block only; the two changes are independent and either merge order resolves by keeping both lines. I checked every pair of my open PRs with `git merge-tree`; this is the only one that conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
