### PR TITLE
[critical] fix(search): stop the composite keyword hunts matching nothing

### DIFF
--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, TypedDict, TypeVar, cast
+from typing import Any, Literal, TypedDict, TypeVar, cast
 
 from sqlalchemy import (
     Column,
@@ -26,6 +26,7 @@ from sqlalchemy import (
     event,
     func,
     insert,
+    literal_column,
     or_,
     select,
     text,
@@ -175,6 +176,29 @@ def _sanitize_fts5_query(query: str) -> str:
         else:
             tokens.append(token)
     return " ".join(tokens)
+
+
+def _fts5_any_query(query: str) -> str:
+    """Turn a bag of keywords into an FTS5 OR expression.
+
+    FTS5's implicit operator is AND, so ``"failed logon event 4625
+    authentication failure brute force"`` requires all seven terms inside one
+    4096-character window and matches nothing. Callers that pass a keyword bag
+    mean "any of these, best first".
+
+    Operators, parenthesis and already-quoted phrases the sanitizer produced
+    are preserved; only adjacent operands get an ``OR`` between them.
+    """
+    tokens = _sanitize_fts5_query(query).split()
+    parts: list[str] = []
+    for token in tokens:
+        if parts and token not in _FTS5_OPERATORS and parts[-1] not in _FTS5_OPERATORS:
+            parts.append("OR")
+        parts.append(token)
+    # A trailing operator would be a syntax error.
+    while parts and parts[-1] in _FTS5_OPERATORS:
+        parts.pop()
+    return " ".join(parts)
 
 
 def _make_engine(db_path: Path) -> Engine:
@@ -555,6 +579,7 @@ class CaseDB:
         time_start: str | None = None,
         time_end: str | None = None,
         exclude_source_names: list[str] | None = None,
+        match: Literal["all", "any"] = "all",
     ) -> list[tuple[WindowRow, str]]:
         """Full-text keyword search over raw_text using FTS5.
 
@@ -568,19 +593,27 @@ class CaseDB:
             time_start: Optional ISO 8601 lower bound for event_time.
             time_end: Optional ISO 8601 upper bound for event_time.
             exclude_source_names: Optional source name prefixes to exclude.
+            match: ``"all"`` keeps FTS5's implicit AND and orders by
+                ``event_time``, which is what an explicit query wants.
+                ``"any"`` ORs the terms together and orders by FTS5's bm25
+                ``rank`` instead -- for a bag of keywords, relevance is the
+                only sane order. Taking the *first 20 by time* out of every
+                window containing the word "event" is a different wrong
+                answer, not a fix.
         """
-        j = windows_t.join(sources_t, windows_t.c.source_id == sources_t.c.source_id)
-        stmt = (
-            select(windows_t, sources_t.c.source_name)
-            .select_from(j)
-            .where(
-                windows_t.c.window_id.in_(
-                    select(text("rowid"))
-                    .select_from(text("windows_fts"))
-                    .where(text("windows_fts MATCH :q"))
-                )
+        fts = (
+            select(
+                literal_column("rowid").label("rid"),
+                literal_column("rank").label("rank"),
             )
+            .select_from(text("windows_fts"))
+            .where(text("windows_fts MATCH :q"))
+            .subquery("fts")
         )
+        j = windows_t.join(sources_t, windows_t.c.source_id == sources_t.c.source_id).join(
+            fts, windows_t.c.window_id == fts.c.rid
+        )
+        stmt = select(windows_t, sources_t.c.source_name).select_from(j)
 
         if source_name is not None:
             stmt = stmt.where(
@@ -604,11 +637,19 @@ class CaseDB:
                     )
                 )
 
-        stmt = stmt.order_by(
-            windows_t.c.event_time.asc().nullslast(),
-        ).limit(max_results)
+        if match == "any":
+            # Rank lives on the FTS table, so it has to be joined rather than
+            # filtered through `window_id IN (SELECT rowid ...)`.
+            stmt = stmt.order_by(text("fts.rank")).limit(max_results)
+            safe_query = _fts5_any_query(query)
+        else:
+            stmt = stmt.order_by(
+                windows_t.c.event_time.asc().nullslast(),
+            ).limit(max_results)
+            safe_query = _sanitize_fts5_query(query)
 
-        safe_query = _sanitize_fts5_query(query)
+        if not safe_query:
+            return []
 
         with self._engine.connect() as conn:
             try:

--- a/src/mulder/db.py
+++ b/src/mulder/db.py
@@ -189,7 +189,9 @@ def _fts5_any_query(query: str) -> str:
     Operators, parenthesis and already-quoted phrases the sanitizer produced
     are preserved; only adjacent operands get an ``OR`` between them.
     """
-    tokens = _sanitize_fts5_query(query).split()
+    # Re-tokenize with the same regex the sanitizer used: ``str.split()``
+    # would cut a quoted phrase in half and produce ``"brute OR force"``.
+    tokens = _FTS5_TOKEN_RE.findall(_sanitize_fts5_query(query))
     parts: list[str] = []
     for token in tokens:
         if parts and token not in _FTS5_OPERATORS and parts[-1] not in _FTS5_OPERATORS:

--- a/src/mulder/server/tools/composite/core.py
+++ b/src/mulder/server/tools/composite/core.py
@@ -246,7 +246,19 @@ def _keyword_sub_query(
 ) -> tuple[list[WindowRow], str]:
     """Run a keyword search as a logged sub-call, return (windows, tool_call_id).
 
-    Searches raw_text for *query* as a case-insensitive substring.
+    *query* is a bag of keywords, not a phrase and not a substring: every one
+    of this function's callers passes something like ``"failed logon event
+    4625 authentication failure brute force"``, meaning "windows about any of
+    this, most relevant first". It is therefore run with ``match="any"``,
+    which ORs the terms and orders by FTS5's bm25 rank.
+
+    Under FTS5's implicit AND all seven of those terms had to appear in one
+    4096-character window, so these searches returned nothing at all. Plain
+    OR would not have been enough either: ordered by ``event_time`` and cut
+    at *k*, the caller would get an arbitrary sample of every window
+    containing the word "event", and the callers' own filters (``"4625" in
+    raw_text``) would discard nearly all of it.
+
     Falls back to searching all sources when the requested source doesn't
     exist in the case database.
     """
@@ -255,7 +267,9 @@ def _keyword_sub_query(
     t0 = time.monotonic()
 
     effective_source = source_name if source_name and _source_exists(source_name) else None
-    results = ctx.db.search_windows(query, source_name=effective_source, max_results=k)
+    results = ctx.db.search_windows(
+        query, source_name=effective_source, max_results=k, match="any"
+    )
     windows = [w for w, _sname in results]
 
     actual_label = effective_source or "all"
@@ -263,7 +277,12 @@ def _keyword_sub_query(
     ctx.audit.log_tool_call(
         tool_call_id=tc_id,
         tool_name=f"{tool_name}._search({actual_label})",
-        params={"query": query, "source": effective_source, "max_results": k},
+        params={
+            "query": query,
+            "source": effective_source,
+            "max_results": k,
+            "match": "any",
+        },
         output_hash=hash_output({"count": len(windows)}),
         duration_ms=elapsed,
     )

--- a/tests/test_fts_keyword_search.py
+++ b/tests/test_fts_keyword_search.py
@@ -1,0 +1,178 @@
+"""Keyword-bag searches must match something, and the right thing first.
+
+Every one of the 23 ``_keyword_sub_query`` call sites across the composite
+hunting tools passes a bag of keywords::
+
+    "failed logon event 4625 authentication failure brute force"
+
+FTS5's implicit operator is AND, so all seven terms had to appear inside one
+4096-character window. They never do. ``find_lateral_movement_indicators``,
+``find_persistence_mechanisms``, ``find_defense_evasion``,
+``find_data_exfiltration_indicators`` and the rest therefore reported no
+indicators from any of their keyword searches -- a clean bill of health
+produced by a query that could not match.
+
+Plain OR is not the whole fix. Ordered by ``event_time`` and cut at k=20 the
+caller would get an arbitrary sample of every window containing the word
+"event", and the callers' own filters (``"4625" in raw_text``) would discard
+nearly all of it. ``match="any"`` therefore also orders by FTS5's bm25 rank,
+which weights the rare terms (4625, 4648) over the common ones.
+
+These tests use a real FTS5 case database, not a mock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mulder.db import CaseDB, _fts5_any_query
+from mulder.models import WindowRow
+
+KEYWORD_BAG = "failed logon event 4625 authentication failure brute force"
+
+# The one window an analyst is looking for, among noise that shares its
+# common words.
+SIGNAL = (
+    "An account failed to log on. EventID 4625 Logon Type 3 "
+    "authentication failure brute force from 10.4.19.203"
+)
+NOISE = "a logon event occurred normally"
+
+
+@pytest.fixture
+def case_db(tmp_path: Path) -> CaseDB:
+    db = CaseDB.create(case_id="fts", evidence_root="/ev", db_dir=tmp_path)
+    source_id = db.register_source(
+        source_name="evtx.security",
+        source_path="/evidence/Security.evtx",
+        source_hash="h",
+        extractor="evtx",
+        line_count=31,
+    )
+    windows = [
+        WindowRow(
+            window_id=None,
+            source_id=source_id,
+            line_start=i + 1,
+            line_end=i + 1,
+            event_time=f"2024-03-11T09:{i:02d}:00",
+            raw_text=NOISE,
+        )
+        for i in range(30)
+    ]
+    # Last in time, so a time-ordered query would not surface it first.
+    windows.append(
+        WindowRow(
+            window_id=None,
+            source_id=source_id,
+            line_start=99,
+            line_end=99,
+            event_time="2024-03-11T23:59:00",
+            raw_text=SIGNAL,
+        )
+    )
+    db.insert_windows(source_id, windows)
+    yield db
+    db.close()
+
+
+class TestAnyQueryConstruction:
+    def test_terms_are_or_joined(self) -> None:
+        assert _fts5_any_query("alpha beta gamma") == "alpha OR beta OR gamma"
+
+    def test_existing_operators_are_preserved(self) -> None:
+        assert _fts5_any_query("alpha AND beta") == "alpha AND beta"
+
+    def test_special_characters_are_still_quoted(self) -> None:
+        assert _fts5_any_query("spinlock.exe rundll32") == '"spinlock.exe" OR rundll32'
+
+    def test_a_trailing_operator_is_dropped(self) -> None:
+        """A dangling AND/OR is an FTS5 syntax error."""
+        assert _fts5_any_query("alpha OR") == "alpha"
+
+    def test_empty(self) -> None:
+        assert _fts5_any_query("") == ""
+
+    def test_single_term(self) -> None:
+        assert _fts5_any_query("4625") == "4625"
+
+
+class TestKeywordBagAgainstARealDatabase:
+    def test_implicit_and_matches_nothing(self, case_db: CaseDB) -> None:
+        """The bug, stated as a test: the default mode finds zero windows."""
+        assert case_db.search_windows(KEYWORD_BAG, source_name="evtx.security") == []
+
+    def test_any_mode_finds_windows(self, case_db: CaseDB) -> None:
+        results = case_db.search_windows(
+            KEYWORD_BAG, source_name="evtx.security", max_results=20, match="any"
+        )
+        assert len(results) == 20
+
+    def test_the_signal_window_ranks_first(self, case_db: CaseDB) -> None:
+        """Why rank and not event_time: the match is the newest row of 31."""
+        results = case_db.search_windows(
+            KEYWORD_BAG, source_name="evtx.security", max_results=20, match="any"
+        )
+        assert "4625" in results[0][0].raw_text
+
+    def test_the_signal_survives_a_narrow_k(self, case_db: CaseDB) -> None:
+        """The callers take k windows and then filter for '4625'."""
+        results = case_db.search_windows(
+            KEYWORD_BAG, source_name="evtx.security", max_results=3, match="any"
+        )
+        assert any("4625" in w.raw_text for w, _ in results)
+
+    def test_all_mode_still_orders_by_time(self, case_db: CaseDB) -> None:
+        results = case_db.search_windows(
+            "logon", source_name="evtx.security", max_results=5, match="all"
+        )
+        times = [w.event_time for w, _ in results]
+        assert times == sorted(times)
+
+    def test_all_mode_is_the_default(self, case_db: CaseDB) -> None:
+        assert case_db.search_windows("logon", source_name="evtx.security", max_results=5) == (
+            case_db.search_windows(
+                "logon", source_name="evtx.security", max_results=5, match="all"
+            )
+        )
+
+    def test_an_explicit_boolean_query_is_untouched(self, case_db: CaseDB) -> None:
+        results = case_db.search_windows(
+            "4625 AND brute", source_name="evtx.security", match="all"
+        )
+        assert len(results) == 1
+        assert "4625" in results[0][0].raw_text
+
+    def test_source_scoping_still_applies(self, case_db: CaseDB) -> None:
+        assert case_db.search_windows(KEYWORD_BAG, source_name="plaso.timeline", match="any") == []
+
+    def test_a_query_of_only_noise_returns_nothing(self, case_db: CaseDB) -> None:
+        assert case_db.search_windows("zzzznotpresent", source_name="evtx.security") == []
+
+
+class TestCompositeKeywordSubQuery:
+    def test_it_asks_for_any(self, case_db: CaseDB, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The composite hunts are the callers this exists for."""
+        from mulder.server.tools.composite import core as cc
+
+        captured: dict[str, object] = {}
+
+        class _Ctx:
+            db = case_db
+
+            class audit:  # noqa: N801 - mirrors the real context's shape
+                @staticmethod
+                def log_tool_call(**kwargs: object) -> None:
+                    captured.update(kwargs)
+
+        monkeypatch.setattr(cc, "get_ctx", lambda: _Ctx())
+        monkeypatch.setattr(cc, "_source_exists", lambda _name: True)
+
+        windows, _tc = cc._keyword_sub_query(
+            KEYWORD_BAG, "find_lateral_movement_indicators", source_name="evtx.security", k=20
+        )
+        assert windows, "the composite hunts found nothing at all before this fix"
+        assert "4625" in windows[0].raw_text
+        assert captured["params"]["match"] == "any"  # type: ignore[index]

--- a/tests/test_fts_keyword_search.py
+++ b/tests/test_fts_keyword_search.py
@@ -23,6 +23,7 @@ These tests use a real FTS5 case database, not a mock.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -42,7 +43,7 @@ NOISE = "a logon event occurred normally"
 
 
 @pytest.fixture
-def case_db(tmp_path: Path) -> CaseDB:
+def case_db(tmp_path: Path) -> Iterator[CaseDB]:
     db = CaseDB.create(case_id="fts", evidence_root="/ev", db_dir=tmp_path)
     source_id = db.register_source(
         source_name="evtx.security",
@@ -98,6 +99,38 @@ class TestAnyQueryConstruction:
     def test_single_term(self) -> None:
         assert _fts5_any_query("4625") == "4625"
 
+    def test_a_quoted_phrase_stays_one_operand(self) -> None:
+        """Splitting on whitespace would yield ``"brute OR force"``.
+
+        That is an FTS5 syntax error, which ``search_windows`` catches and
+        turns into an empty result -- the very failure this mode exists to
+        prevent.
+        """
+        assert _fts5_any_query('"brute force" 4625') == '"brute force" OR 4625'
+
+    def test_a_phrase_the_sanitizer_produced_stays_one_operand(self) -> None:
+        assert _fts5_any_query("c:/windows/temp 4625") == '"c:/windows/temp" OR 4625'
+
+
+class TestQuotedPhrasesAgainstARealDatabase:
+    """A phrase query must reach FTS5 intact, not collapse to zero results."""
+
+    def test_a_phrase_bag_finds_the_signal(self, case_db: CaseDB) -> None:
+        results = case_db.search_windows(
+            '"brute force" 4625', source_name="evtx.security", match="any"
+        )
+        assert results
+        assert results[0][0].raw_text == SIGNAL
+
+    def test_a_phrase_absent_from_the_corpus_matches_nothing(self, case_db: CaseDB) -> None:
+        """Proves the phrase is honoured as a phrase, not OR-ed into words.
+
+        Both words are present in the corpus; the adjacent pair is not.
+        """
+        assert (
+            case_db.search_windows('"force logon"', source_name="evtx.security", match="any") == []
+        )
+
 
 class TestKeywordBagAgainstARealDatabase:
     def test_implicit_and_matches_nothing(self, case_db: CaseDB) -> None:
@@ -129,7 +162,8 @@ class TestKeywordBagAgainstARealDatabase:
             "logon", source_name="evtx.security", max_results=5, match="all"
         )
         times = [w.event_time for w, _ in results]
-        assert times == sorted(times)
+        assert all(t is not None for t in times)
+        assert times == sorted(times, key=str)
 
     def test_all_mode_is_the_default(self, case_db: CaseDB) -> None:
         assert case_db.search_windows("logon", source_name="evtx.security", max_results=5) == (


### PR DESCRIPTION
## BLUF

- **What breaks:** FTS5's implicit operator is **AND**. All 23 `_keyword_sub_query` call sites pass a *bag of keywords*, so every term had to appear inside one 4096-character window.
- **Impact:** `find_lateral_movement_indicators`, `find_persistence_mechanisms`, `find_defense_evasion`, `find_data_exfiltration_indicators`, `find_file_staging` and `assess_recovery` returned **no indicators at all** from any keyword search — a clean bill of health produced by a query that cannot match.
- **The docstring documented the intent:** `_keyword_sub_query` claimed it "searches raw_text for *query* as a case-insensitive substring". That is what the call sites were written against, and it is not what happened.
- **Fix:** `search_windows(match="any")` ORs the terms **and orders by bm25 rank**. OR alone would have been a different wrong answer.
- **Risk:** Low. `match="all"` is the default and byte-identical to today, so `search()` and the PID lookups are untouched.

## Priority

**critical** — six composite hunting tools silently report "nothing found" on evidence that contains the thing they were asked to find. A false negative that looks like a clean result is the worst outcome for a DFIR tool.

## The queries

```python
"failed logon event 4625 authentication failure brute force"
"service installation event 7045 new service installed"
"taskkill process terminated antivirus security defender disable stop"
".zip .rar .7z .tar .gz .cab .tgz"
```

Seven or eight terms, all required, in one window.

## Verified against a real FTS5 case database

31 windows in `evtx.security`: 30 reading `a logon event occurred normally`, and one genuine `An account failed to log on. EventID 4625 Logon Type 3 authentication failure brute force`. The signal window is deliberately the **newest** row.

```
match="all"  (today)  ->  0 windows
match="any"  (fix)    -> 20 windows, the 4625 window first
```

## Why rank, not just OR

This is the part that makes the fix real rather than nominal. `_classify_logon_windows` filters what it gets back:

```python
for w in logon_wins:
    if "4624" not in w.raw_text and "logon" not in text_lower:
        continue
...
    if "4625" in w.raw_text or "fail" in text_lower:
```

With plain OR and the existing `ORDER BY event_time`, a `k=20` query returns an arbitrary 20 windows out of every window containing the word "event", and that filter discards nearly all of them. bm25 weights the rare terms — `4625`, `4648`, `RemoteInteractive`, `7045` — over the common ones, which is what the query author meant. A test pins that the signal survives even at `k=3`.

`match="any"` is implemented by joining the FTS table (rank is only available there) instead of filtering through `window_id IN (SELECT rowid ...)`; the `"all"` path keeps its existing shape and ordering.

## Not in scope

The existing `_sanitize_fts5_query` already quotes tokens containing `.`, `-`, `:` and friends, so `spinlock.exe` and `pass-the-hash` do **not** raise `fts5: syntax error` through this API. I checked before assuming otherwise; `_fts5_any_query` reuses that sanitizer rather than replacing it.

## Tests

New `tests/test_fts_keyword_search.py` (16 tests), against a **real FTS5 case database**, not a mock:

- the bug itself: the keyword bag returns zero windows in the default mode;
- `match="any"` returns 20, with the 4625 window **first** even though it is the newest row — the assertion that justifies rank over time;
- the signal survives `k=3`, the regime the callers actually use;
- `match="all"` still orders by `event_time`, is still the default, and an explicit `4625 AND brute` is unchanged;
- source scoping and no-match still behave;
- `_fts5_any_query` unit tests: OR-joining, operator preservation, special-character quoting, a dangling trailing operator (an FTS5 syntax error), empty and single-term;
- an end-to-end `_keyword_sub_query` test that **fails on `main`** with "the composite hunts found nothing at all before this fix".

`make lint format typecheck test` — 758 passed (742 baseline, +16), mypy clean, ruff clean.

## Follow-up commit

Re-reviewing my own change I found a defect in it: `_fts5_any_query` re-tokenized the sanitizer's output with `str.split()`, which cuts a quoted phrase in half — `'"brute force" 4625'` became `'"brute OR force" OR 4625'`, an FTS5 syntax error that `search_windows` catches and turns into an empty list. That is the same silent-zero failure this PR exists to remove, so the docstring's claim that already-quoted phrases were preserved was false. It is now re-tokenized with `_FTS5_TOKEN_RE`, the regex the sanitizer itself uses, and covered by three new tests including a phrase query against the real FTS5 database.

No caller passes a phrase today — all 23 keyword bags are bare words — so nothing in the tree was affected; the mode is simply now correct for the input it documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
