### PR TITLE
[high] fix(email): stop the PST parser silently dropping messages

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import email as email_lib
 import email.parser
 import logging
+import re
 import subprocess
 import tempfile
 import time
+from datetime import datetime, timezone
+from email.header import decode_header, make_header
+from email.utils import getaddresses, parsedate_to_datetime
 from pathlib import Path
 
 from mulder.server.app import mcp
@@ -54,24 +58,63 @@ _SUSPICIOUS_EXTENSIONS: set[str] = {
 
 _VALID_PST_SUFFIXES: set[str] = {".pst", ".ost"}
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_WS_RE = re.compile(r"[ \t]*\n[ \t]*")
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
 # ---------------------------------------------------------------------------
 
 
+def _decode_header_value(raw: str | None) -> str:
+    """Decode an RFC 2047 header into text.
+
+    Subjects and display names arrive as ``=?utf-8?B?...?=``. Reading them
+    raw means a keyword search for "wire transfer" cannot match a subject
+    that says "wire transfer", and the report shows base64.
+    """
+    if not raw:
+        return ""
+    try:
+        return str(make_header(decode_header(raw)))
+    except (UnicodeDecodeError, LookupError, ValueError):
+        return raw
+
+
 def _parse_recipients(raw: str) -> list[str]:
-    """Parse a comma-separated recipient string into individual addresses.
+    """Parse a To/Cc header into individual addresses.
+
+    Splitting on "," is wrong: a display name may legitimately contain one.
+    ``"Doe, John" <john@example.com>, jane@example.com`` split that way
+    yields ``'"Doe'``, ``'John" <john@example.com>'`` and
+    ``'jane@example.com'`` -- two of the three are not addresses at all, so
+    recipient search and address IOC extraction both miss them.
 
     Args:
         raw: Raw To/CC header value.
 
     Returns:
-        List of individual email addresses or display names.
+        One entry per recipient, ``Display Name <addr>`` when a name is
+        present and the bare address otherwise.
     """
     if not raw:
         return []
-    return [r.strip() for r in raw.split(",") if r.strip()]
+    out: list[str] = []
+    for name, addr in getaddresses([raw]):
+        display = _decode_header_value(name)
+        if addr and display:
+            out.append(f"{display} <{addr}>")
+        elif addr:
+            out.append(addr)
+        elif display:
+            out.append(display)
+    return out
+
+
+def _recipient_addresses(recipients: list[str]) -> list[str]:
+    """The bare addresses out of ``_parse_recipients`` output."""
+    return [addr for _name, addr in getaddresses(recipients) if addr]
 
 
 def _get_body(
@@ -87,20 +130,101 @@ def _get_body(
     Returns:
         Body text or None if no matching part found.
     """
-    if msg.is_multipart():
-        for part in msg.walk():
-            if part.get_content_type() == content_type:
-                payload = part.get_payload(decode=True)
-                if isinstance(payload, bytes):
-                    charset = part.get_content_charset() or "utf-8"
-                    return payload.decode(charset, errors="replace")
-    else:
-        if msg.get_content_type() == content_type:
-            payload = msg.get_payload(decode=True)
-            if isinstance(payload, bytes):
-                charset = msg.get_content_charset() or "utf-8"
+    for part in msg.walk():
+        if part.is_multipart():
+            continue
+        if part.get_content_disposition() == "attachment":
+            continue
+        if part.get_content_type() != content_type:
+            continue
+        payload = part.get_payload(decode=True)
+        if isinstance(payload, bytes):
+            charset = part.get_content_charset() or "utf-8"
+            try:
                 return payload.decode(charset, errors="replace")
+            except LookupError:
+                return payload.decode("utf-8", errors="replace")
     return None
+
+
+def _html_to_text(html: str) -> str:
+    """Strip tags from an HTML body so its words are searchable."""
+    text = re.sub(r"(?is)<(script|style).*?</\1>", " ", html)
+    text = _HTML_TAG_RE.sub(" ", text)
+    for entity, char in (
+        ("&nbsp;", " "),
+        ("&amp;", "&"),
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&quot;", '"'),
+        ("&#39;", "'"),
+    ):
+        text = text.replace(entity, char)
+    return _HTML_WS_RE.sub("\n", text).strip()
+
+
+def _get_searchable_body(msg: email_lib.message.Message) -> str | None:
+    """The message body as text, whatever it was sent as.
+
+    ``text/plain`` when present, otherwise ``text/html`` with the tags
+    stripped. An HTML-only message -- most phishing -- previously had no
+    body at all, so no keyword could match it and nothing was indexed.
+    """
+    plain = _get_body(msg, "text/plain")
+    if plain and plain.strip():
+        return plain
+    html = _get_body(msg, "text/html")
+    if html and html.strip():
+        return _html_to_text(html)
+    return plain or html
+
+
+def _message_date(raw: str | None) -> datetime | None:
+    """Parse an RFC 5322 ``Date`` header into an aware datetime."""
+    if not raw:
+        return None
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _in_date_range(raw: str | None, start: str | None, end: str | None) -> bool:
+    """Whether a message's ``Date`` falls within an inclusive YYYY-MM-DD range.
+
+    The header is RFC 5322 -- ``Mon, 11 Mar 2024 09:14:02 +0100`` -- and was
+    previously compared to the bounds as a string. ``"Mon, ..." > "2024-12-31"``
+    is true for every message ever sent, because ``M`` sorts above any digit,
+    so ``date_end`` discarded the entire mailbox and ``date_start`` discarded
+    nothing. Any date-bounded search returned zero results.
+
+    A message whose date is missing or unparseable is kept, so a malformed
+    header cannot silently hide evidence.
+    """
+    if not start and not end:
+        return True
+    when = _message_date(raw)
+    if when is None:
+        return True
+    day = when.date()
+    if start:
+        try:
+            if day < datetime.strptime(start, "%Y-%m-%d").date():
+                return False
+        except ValueError:
+            pass
+    if end:
+        try:
+            if day > datetime.strptime(end, "%Y-%m-%d").date():
+                return False
+        except ValueError:
+            pass
+    return True
 
 
 def _matches_search(
@@ -109,15 +233,20 @@ def _matches_search(
     body: str | None,
     recipients: list[str],
     search_term: str,
+    attachments: list[str] | None = None,
 ) -> bool:
     """Check whether an email matches the search keyword.
 
     Args:
-        subject: Email subject line.
+        subject: Email subject line, already RFC 2047 decoded.
         sender: Sender address.
-        body: Plain text body (may be None).
-        recipients: List of recipient addresses.
+        body: Body text (may be None).
+        recipients: Every recipient -- To *and* Cc. Cc was parsed and then
+            never searched, so a search naming a copied recipient missed
+            the message.
         search_term: Keyword to search for (case insensitive).
+        attachments: Attachment filenames, which is how an analyst looks
+            for a named payload.
 
     Returns:
         True if the term appears in any searchable field.
@@ -129,7 +258,9 @@ def _matches_search(
         return True
     if body and term in body.lower():
         return True
-    return any(term in r.lower() for r in recipients)
+    if any(term in r.lower() for r in recipients):
+        return True
+    return any(term in a.lower() for a in attachments or [])
 
 
 def _parse_email_message(
@@ -149,21 +280,35 @@ def _parse_email_message(
     has_suspicious = False
 
     for part in msg.walk():
-        if part.get_content_disposition() == "attachment":
-            filename = part.get_filename() or "unnamed"
-            attachments.append(filename)
-            ext = Path(filename).suffix.lower()
-            if ext in _SUSPICIOUS_EXTENSIONS:
+        if part.is_multipart():
+            continue
+        filename = part.get_filename()
+        disposition = part.get_content_disposition()
+        # An attachment is anything carrying a filename, not only what
+        # declares `Content-Disposition: attachment`. Malicious payloads
+        # arrive as `inline` or with no disposition header at all, and both
+        # were previously invisible -- including to the suspicious-extension
+        # check, which is the point of this function.
+        if disposition == "attachment" or filename:
+            name = _decode_header_value(filename) or "unnamed"
+            attachments.append(name)
+            if Path(name).suffix.lower() in _SUSPICIOUS_EXTENSIONS:
                 has_suspicious = True
+
+    when = _message_date(msg.get("Date"))
 
     return {
         "message_id": msg.get("Message-ID"),
-        "subject": msg.get("Subject", "(no subject)"),
-        "sender": msg.get("From", ""),
+        "subject": _decode_header_value(msg.get("Subject")) or "(no subject)",
+        "sender": _decode_header_value(msg.get("From")),
         "recipients_to": _parse_recipients(msg.get("To", "")),
         "recipients_cc": _parse_recipients(msg.get("Cc", "")),
+        "recipients_bcc": _parse_recipients(msg.get("Bcc", "")),
+        "reply_to": _parse_recipients(msg.get("Reply-To", "")),
         "date": msg.get("Date"),
-        "body_text": _get_body(msg, "text/plain"),
+        # A sortable, comparable form alongside the header as sent.
+        "date_iso": when.isoformat() if when else None,
+        "body_text": _get_searchable_body(msg),
         "attachments": attachments,
         "folder": folder,
         "importance": msg.get("Importance", "normal"),
@@ -214,10 +359,7 @@ def _parse_extracted_emails(
 
         parsed = _parse_email_message(msg, folder)
 
-        date_val = str(parsed.get("date") or "")
-        if date_start and date_val and date_val < date_start:
-            continue
-        if date_end and date_val and date_val > date_end:
+        if not _in_date_range(str(parsed.get("date") or ""), date_start, date_end):
             continue
 
         if search_term:
@@ -225,9 +367,14 @@ def _parse_extracted_emails(
             sender = str(parsed.get("sender", ""))
             body_val = parsed.get("body_text")
             body_str = str(body_val) if body_val is not None else None
-            to_val = parsed.get("recipients_to")
-            to_list = [str(r) for r in to_val] if isinstance(to_val, list) else []
-            if not _matches_search(subject, sender, body_str, to_list, search_term):
+            recipients: list[str] = []
+            for key in ("recipients_to", "recipients_cc", "recipients_bcc"):
+                val = parsed.get(key)
+                if isinstance(val, list):
+                    recipients.extend(str(r) for r in val)
+            att_names = parsed.get("attachments")
+            att_list = [str(a) for a in att_names] if isinstance(att_names, list) else []
+            if not _matches_search(subject, sender, body_str, recipients, search_term, att_list):
                 continue
 
         if parsed.get("has_suspicious_attachment"):

--- a/tests/test_email_parsing.py
+++ b/tests/test_email_parsing.py
@@ -1,0 +1,257 @@
+"""A mailbox search that silently returns nothing is the wrong kind of empty.
+
+Five independent defects in the PST/OST path, each of which drops evidence
+without saying so:
+
+* the ``Date`` header is RFC 5322 (``Mon, 11 Mar 2024 09:14:02 +0100``) and
+  was compared to ``YYYY-MM-DD`` bounds **as a string**. ``"Mon, ..."`` sorts
+  above every digit, so ``date_end`` excluded the entire mailbox and
+  ``date_start`` excluded nothing: any date-bounded search returned zero
+  messages;
+* subjects and display names are RFC 2047 encoded, and were read raw, so a
+  search for "wire transfer" could not match a subject that says exactly
+  that;
+* ``To``/``Cc`` were split on ``","``, which is inside a quoted display name
+  as often as it is between recipients;
+* an HTML-only message -- most phishing -- had no body at all, because only
+  ``text/plain`` was read;
+* an attachment only counted if it declared
+  ``Content-Disposition: attachment``, so an ``inline`` payload skipped the
+  suspicious-extension check entirely.
+"""
+
+from __future__ import annotations
+
+import email.parser
+from email.header import Header
+from typing import Any
+
+import pytest
+
+from mulder.server.tools.email import (
+    _decode_header_value,
+    _get_searchable_body,
+    _in_date_range,
+    _matches_search,
+    _parse_email_message,
+    _parse_recipients,
+)
+
+
+def _msg(raw: str) -> Any:
+    return email.parser.Parser().parsestr(raw)
+
+
+PLAIN = (
+    "Message-ID: <1@x>\r\n"
+    "Subject: Quarterly report\r\n"
+    "From: alice@example.com\r\n"
+    "To: bob@example.com\r\n"
+    "Date: Mon, 11 Mar 2024 09:14:02 +0100\r\n"
+    "Content-Type: text/plain\r\n"
+    "\r\n"
+    "the numbers are attached\r\n"
+)
+
+# A subject and display name as a real client encodes them.
+ENCODED = (
+    "Message-ID: <2@x>\r\n"
+    "Subject: =?utf-8?B?VXJnZW50OiB3aXJlIHRyYW5zZmVy?=\r\n"
+    "From: =?utf-8?Q?Jos=C3=A9_Silva?= <jose@example.com>\r\n"
+    'To: "Doe, John" <john@example.com>, jane@example.com\r\n'
+    "Date: Tue, 12 Mar 2024 11:02:10 +0000\r\n"
+    "Content-Type: text/plain\r\n"
+    "\r\n"
+    "please action today\r\n"
+)
+
+HTML_ONLY = (
+    "Message-ID: <3@x>\r\n"
+    "Subject: Invoice\r\n"
+    "From: billing@example.com\r\n"
+    "To: bob@example.com\r\n"
+    "Date: Wed, 13 Mar 2024 08:00:00 +0000\r\n"
+    "Content-Type: text/html\r\n"
+    "\r\n"
+    "<html><body><p>Please <b>reset your password</b> at "
+    '<a href="http://evil.example">this link</a></p></body></html>\r\n'
+)
+
+INLINE_ATTACHMENT = (
+    "Message-ID: <4@x>\r\n"
+    "Subject: Photos\r\n"
+    "From: mallory@example.com\r\n"
+    "To: bob@example.com\r\n"
+    "Date: Thu, 14 Mar 2024 10:00:00 +0000\r\n"
+    'Content-Type: multipart/mixed; boundary="B"\r\n'
+    "\r\n"
+    "--B\r\n"
+    "Content-Type: text/plain\r\n"
+    "\r\n"
+    "see attached\r\n"
+    "--B\r\n"
+    "Content-Type: application/octet-stream\r\n"
+    'Content-Disposition: inline; filename="invoice.exe"\r\n'
+    "\r\n"
+    "MZ\r\n"
+    "--B--\r\n"
+)
+
+
+class TestDateRange:
+    """The defect that made date-bounded searches return nothing."""
+
+    HEADER = "Mon, 11 Mar 2024 09:14:02 +0100"
+
+    def test_a_message_inside_the_range_is_kept(self) -> None:
+        assert _in_date_range(self.HEADER, "2024-01-01", "2024-12-31") is True
+
+    def test_the_old_string_comparison_would_have_dropped_it(self) -> None:
+        """Pins why: 'M' sorts above every digit."""
+        assert self.HEADER > "2024-12-31"
+        assert not self.HEADER < "2024-01-01"
+
+    def test_a_message_before_the_start_is_dropped(self) -> None:
+        assert _in_date_range(self.HEADER, "2024-06-01", None) is False
+
+    def test_a_message_after_the_end_is_dropped(self) -> None:
+        assert _in_date_range(self.HEADER, None, "2024-01-31") is False
+
+    def test_the_bounds_are_inclusive(self) -> None:
+        assert _in_date_range(self.HEADER, "2024-03-11", "2024-03-11") is True
+
+    def test_no_bounds_keeps_everything(self) -> None:
+        assert _in_date_range(self.HEADER, None, None) is True
+
+    def test_a_timezone_is_respected(self) -> None:
+        """23:30 -0800 is the 12th in UTC but the 11th where it was sent."""
+        assert _in_date_range("Mon, 11 Mar 2024 23:30:00 -0800", "2024-03-11", "2024-03-11")
+
+    @pytest.mark.parametrize("raw", ["", "not a date", "Mon, 99 Xyz 9999"])
+    def test_an_unparseable_date_is_kept(self, raw: str) -> None:
+        """A malformed header must not silently hide a message."""
+        assert _in_date_range(raw, "2024-01-01", "2024-12-31") is True
+
+
+class TestHeaderDecoding:
+    def test_a_base64_subject_is_decoded(self) -> None:
+        assert _decode_header_value("=?utf-8?B?VXJnZW50OiB3aXJlIHRyYW5zZmVy?=") == (
+            "Urgent: wire transfer"
+        )
+
+    def test_a_quoted_printable_name_is_decoded(self) -> None:
+        assert _decode_header_value("=?utf-8?Q?Jos=C3=A9_Silva?=") == "José Silva"
+
+    def test_plain_text_is_unchanged(self) -> None:
+        assert _decode_header_value("Quarterly report") == "Quarterly report"
+
+    def test_none_is_empty(self) -> None:
+        assert _decode_header_value(None) == ""
+
+    def test_a_round_trip_through_the_stdlib(self) -> None:
+        original = "Betreff: Überweisung"
+        encoded = Header(original, "utf-8").encode()
+        assert _decode_header_value(encoded) == original
+
+    def test_the_parsed_message_carries_the_decoded_subject(self) -> None:
+        parsed = _parse_email_message(_msg(ENCODED), "Inbox")
+        assert parsed["subject"] == "Urgent: wire transfer"
+        assert "José Silva" in str(parsed["sender"])
+
+    def test_a_keyword_search_now_reaches_an_encoded_subject(self) -> None:
+        parsed = _parse_email_message(_msg(ENCODED), "Inbox")
+        assert _matches_search(str(parsed["subject"]), "", None, [], "wire transfer")
+
+
+class TestRecipientParsing:
+    RAW = '"Doe, John" <john@example.com>, jane@example.com, "Smith, A" <a@x.com>'
+
+    def test_a_comma_in_a_display_name_does_not_split_the_recipient(self) -> None:
+        assert len(_parse_recipients(self.RAW)) == 3
+
+    def test_the_old_split_produced_five_fragments(self) -> None:
+        assert len([r.strip() for r in self.RAW.split(",") if r.strip()]) == 5
+
+    def test_every_address_survives(self) -> None:
+        joined = " ".join(_parse_recipients(self.RAW))
+        for addr in ("john@example.com", "jane@example.com", "a@x.com"):
+            assert addr in joined
+
+    def test_a_bare_address_is_kept_bare(self) -> None:
+        assert _parse_recipients("jane@example.com") == ["jane@example.com"]
+
+    def test_empty(self) -> None:
+        assert _parse_recipients("") == []
+
+    def test_an_encoded_display_name_is_decoded(self) -> None:
+        out = _parse_recipients("=?utf-8?Q?Jos=C3=A9?= <jose@example.com>")
+        assert out == ["José <jose@example.com>"]
+
+
+class TestBodyExtraction:
+    def test_a_plain_body_is_read(self) -> None:
+        assert "numbers are attached" in (_get_searchable_body(_msg(PLAIN)) or "")
+
+    def test_an_html_only_message_has_a_searchable_body(self) -> None:
+        """Most phishing is HTML-only; it previously had no body at all."""
+        body = _get_searchable_body(_msg(HTML_ONLY)) or ""
+        assert "reset your password" in body
+        assert "<b>" not in body
+
+    def test_the_link_target_survives_tag_stripping(self) -> None:
+        parsed = _parse_email_message(_msg(HTML_ONLY), "Inbox")
+        assert _matches_search("", "", str(parsed["body_text"]), [], "reset your password")
+
+    def test_plain_is_preferred_over_html(self) -> None:
+        both = (
+            "Subject: s\r\n"
+            'Content-Type: multipart/alternative; boundary="B"\r\n'
+            "\r\n--B\r\nContent-Type: text/plain\r\n\r\nthe plain one\r\n"
+            "--B\r\nContent-Type: text/html\r\n\r\n<p>the html one</p>\r\n--B--\r\n"
+        )
+        assert "the plain one" in (_get_searchable_body(_msg(both)) or "")
+
+    def test_an_attachment_is_not_mistaken_for_the_body(self) -> None:
+        body = _get_searchable_body(_msg(INLINE_ATTACHMENT)) or ""
+        assert "see attached" in body
+        assert "MZ" not in body
+
+
+class TestAttachmentDetection:
+    def test_an_inline_payload_is_an_attachment(self) -> None:
+        parsed = _parse_email_message(_msg(INLINE_ATTACHMENT), "Inbox")
+        assert parsed["attachments"] == ["invoice.exe"]
+
+    def test_an_inline_payload_trips_the_suspicious_check(self) -> None:
+        """The point of the function: an .exe must be flagged however it arrives."""
+        parsed = _parse_email_message(_msg(INLINE_ATTACHMENT), "Inbox")
+        assert parsed["has_suspicious_attachment"] is True
+
+    def test_a_message_without_attachments_is_clean(self) -> None:
+        parsed = _parse_email_message(_msg(PLAIN), "Inbox")
+        assert parsed["attachments"] == []
+        assert parsed["has_suspicious_attachment"] is False
+
+    def test_an_attachment_name_is_searchable(self) -> None:
+        assert _matches_search("", "", None, [], "invoice.exe", ["invoice.exe"])
+
+
+class TestSearchCoversEveryRecipientField:
+    def test_a_cc_recipient_matches(self) -> None:
+        """Cc was parsed and then never searched."""
+        assert _matches_search("", "", None, ["carol@example.com"], "carol")
+
+    def test_the_parsed_message_carries_bcc_and_reply_to(self) -> None:
+        raw = PLAIN.replace(
+            "To: bob@example.com\r\n",
+            "To: bob@example.com\r\nBcc: hidden@example.com\r\nReply-To: spoof@evil.example\r\n",
+        )
+        parsed = _parse_email_message(_msg(raw), "Inbox")
+        assert parsed["recipients_bcc"] == ["hidden@example.com"]
+        assert parsed["reply_to"] == ["spoof@evil.example"]
+
+    def test_a_sortable_date_is_exposed(self) -> None:
+        parsed = _parse_email_message(_msg(PLAIN), "Inbox")
+        assert str(parsed["date_iso"]).startswith("2024-03-11T09:14:02")
+        # The header as sent is preserved alongside it.
+        assert parsed["date"] == "Mon, 11 Mar 2024 09:14:02 +0100"


### PR DESCRIPTION
## BLUF

- **Any date-bounded mailbox search returned zero messages.** The RFC 5322 `Date` header was compared to `YYYY-MM-DD` bounds **as a string**, and `"Mon, 11 Mar 2024 ..." > "2024-12-31"` is true for every message ever sent.
- **Encoded subjects were never decoded**, so a search for `wire transfer` could not match a subject that literally says "Urgent: wire transfer" — it was still base64 in memory and in the report.
- **Recipients were split on `","`**, which lives inside a quoted display name as often as between addresses: three recipients became five fragments, three of them not addresses.
- **HTML-only mail — most phishing — had no body at all**, so no keyword could match it and nothing was indexed.
- **`inline` attachments were invisible**, including to the suspicious-extension check that is the reason the function exists.
- **Risk:** Low, and one-directional: every change makes strictly more evidence visible.

## Priority

**high** — five separate ways for a mailbox search to report "nothing found" on a mailbox that contains the thing.

## 1. The date filter excluded the entire mailbox

```python
date_val = str(parsed.get("date") or "")     # "Mon, 11 Mar 2024 09:14:02 +0100"
if date_start and date_val and date_val < date_start:   # never true
    continue
if date_end and date_val and date_val > date_end:       # always true
    continue
```

Measured:

```
range 2024-01-01..2024-12-31: dropped_by_start=False dropped_by_end=True
range 2025-01-01..2025-12-31: dropped_by_start=False dropped_by_end=True
```

`M` (0x4D) sorts above every digit, so the end bound discards everything and the start bound discards nothing — regardless of what the dates actually are.

Now parsed with `parsedate_to_datetime` and compared as dates, honouring the offset. A message with a missing or malformed `Date` is **kept**, so a broken header cannot silently hide evidence. `date_iso` is exposed alongside the header as sent.

## 2. RFC 2047 headers

`Subject: =?utf-8?B?VXJnZW50OiB3aXJlIHRyYW5zZmVy?=` stayed exactly that. Decoded now, for subjects and for display names (`=?utf-8?Q?Jos=C3=A9_Silva?=`).

## 3. Recipient splitting

```
'"Doe, John" <john@example.com>, jane@example.com, "Smith, A" <a@x.com>'

split(","):     '"Doe' | 'John" <john@example.com>' | 'jane@example.com' | '"Smith' | 'A" <a@x.com>'
getaddresses:   ('Doe, John', john@example.com) | ('', jane@example.com) | ('Smith, A', a@x.com)
```

Recipient search and address IOC extraction both missed those addresses.

## 4. HTML-only bodies

`_get_body(msg, "text/plain")` returned `None` for an HTML-only message. `text/html` is now the fallback with tags stripped, and attachment parts are no longer mistaken for the body.

## 5. Attachment detection

`get_content_disposition() == "attachment"` misses `Content-Disposition: inline; filename="invoice.exe"` and parts carrying a filename with no disposition at all. Anything with a filename now counts — so the `.exe` is flagged however it arrives.

## Also

`Cc` was parsed and then never searched; `Bcc` and `Reply-To` were not captured at all. Search now covers every recipient field plus attachment names.

## Not in this PR

`parse_pst` discards `readpst`'s `CompletedProcess`, so a failed extraction reports an empty mailbox. That is the same root cause as #70 and belongs there, not here.

## Tests

New `tests/test_email_parsing.py` (35 tests), against real RFC-shaped fixtures built with the stdlib `email` module:

- the date range: inside, before, after, inclusive bounds, timezone offsets, and three malformed headers that must be kept — **plus a test that asserts the old string comparison really did drop the message**, so the premise is pinned rather than asserted;
- header decoding, including a round trip through `email.header.Header`;
- recipient parsing, **with a test asserting the old split produced five fragments**;
- HTML-only body extraction, plain preferred over HTML, attachment not mistaken for body;
- an `inline` `.exe` flagged as suspicious and searchable by name;
- Cc matching, and Bcc/Reply-To captured.

`make lint format typecheck test` — 777 passed (742 baseline, +35), mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
