### PR TITLE
[high] fix(pdf): report obfuscated JavaScript, URLs and embedded files

### DIFF
--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -472,8 +472,16 @@ def _parse_pdfid_obfuscated_count(line: str) -> int:
 def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
     """Extract JavaScript code from PDF objects.
 
-    Uses pdf-parser to identify and extract JavaScript streams
-    from the PDF document structure.
+    ``pdf-parser --type`` selects on an indirect object's ``/Type`` entry.
+    PDF JavaScript lives in an action dictionary -- ``/Type /Action``,
+    ``/S /JavaScript`` -- so ``--type /JS`` matched no object in any PDF and
+    this function always returned an empty list. Verified against
+    DidierStevensSuite pdf-parser on a PDF containing an ``app.alert`` action:
+    ``--type /JS`` prints nothing, ``--search javascript`` prints the object.
+
+    The code itself may be a literal string in the action (``/JS (...)``) or an
+    indirect reference to a stream (``/JS 5 0 R``), which is what a real maldoc
+    uses because the stream can be compressed. Both are handled.
 
     Args:
         file_path: Path to the PDF file.
@@ -481,52 +489,69 @@ def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
     Returns:
         List of JavaScript extractions with analysis.
     """
-    script = _pdf_parser_script()
-    if script is not None:
-        cmd = [
-            sys.executable,
-            str(script),
-            "--type",
-            "/JS",
-            "--filter",
-            str(file_path),
-        ]
-    else:
-        parser_bin = require_binary("pdf-parser") or "pdf-parser"
-        cmd = [parser_bin, "--type", "/JS", "--filter", str(file_path)]
-
-    try:
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=_PDF_PARSER_TIMEOUT,
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return []
+    output = _run_pdf_parser(file_path, "--search", "javascript", "--filter")
 
     scripts: list[dict[str, object]] = []
-    obj_re = re.compile(r"obj (\d+)")
-    current_obj_id: int | None = None
-    current_code: list[str] = []
-
-    for line in proc.stdout.splitlines():
-        obj_match = obj_re.match(line)
-        if obj_match:
-            if current_obj_id is not None and current_code:
-                code = "\n".join(current_code)
-                scripts.append(_make_js_entry(current_obj_id, code))
-            current_obj_id = int(obj_match.group(1))
-            current_code = []
-        else:
-            current_code.append(line)
-
-    if current_obj_id is not None and current_code:
-        code = "\n".join(current_code)
-        scripts.append(_make_js_entry(current_obj_id, code))
-
+    for object_id, body in _iter_pdf_objects(output):
+        code = _pdf_javascript_code(file_path, body)
+        if code:
+            scripts.append(_make_js_entry(object_id, code))
     return scripts
+
+
+_PDF_JS_LITERAL_RE = re.compile(r"/JS\s*'?\(((?:\\{1,2}.|[^)]){0,65536}?)\)", re.DOTALL)
+"""``/JS (code)`` -- the script written inline in the action dictionary.
+
+A PDF string escapes a literal parenthesis as ``\\(``, and the script almost
+always contains one (``app.alert(1)``), so the pattern must skip escaped
+characters rather than stop at the first ``)``.
+"""
+
+_PDF_STRING_ESCAPE_RE = re.compile(r"\\{1,2}([()\\])")
+"""A escaped ``(``, ``)`` or ``\\`` in a PDF literal string as pdf-parser prints it."""
+
+_PDF_JS_REF_RE = re.compile(r"/JS\s+(\d+)\s+\d+\s+R")
+"""``/JS 5 0 R`` -- the script held in a separate, usually compressed, stream."""
+
+
+def _pdf_javascript_code(file_path: Path, body: str) -> str:
+    """Return the JavaScript carried by one pdf-parser object dump.
+
+    Args:
+        file_path: The PDF, needed to resolve an indirect stream reference.
+        body: The object dump emitted by ``pdf-parser``.
+
+    Returns:
+        The script source, or ``""`` when the object carries none.
+    """
+    literal = _PDF_JS_LITERAL_RE.search(body)
+    if literal:
+        return _PDF_STRING_ESCAPE_RE.sub(r"\1", literal.group(1)).strip()
+
+    ref = _PDF_JS_REF_RE.search(body)
+    if ref:
+        dump = _run_pdf_parser(file_path, "--object", ref.group(1), "--filter", "--raw")
+        return _pdf_stream_payload(dump)
+
+    return ""
+
+
+def _pdf_stream_payload(dump: str) -> str:
+    """Return the decoded stream content from a ``--object --filter`` dump.
+
+    pdf-parser prints the object header, the dictionary, then the decoded
+    stream. Everything up to and including the dictionary's closing ``>>`` is
+    metadata; what follows is the payload.
+    """
+    _, sep, tail = dump.rpartition(">>")
+    text = tail if sep else dump
+    text = text.strip()
+    # A binary payload is printed as a Python bytes repr.
+    if (text.startswith("b'") and text.endswith("'")) or (
+        text.startswith('b"') and text.endswith('"')
+    ):
+        text = text[2:-1]
+    return text.strip()
 
 
 _PDF_URI_RE = re.compile(r"/URI\s*\(([^)]{1,2048})\)")

--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -403,15 +403,24 @@ def _run_pdfid(file_path: Path) -> list[dict[str, object]]:
             clean_keyword = keyword.lstrip("/")
             if clean_keyword in stripped:
                 count = _extract_pdfid_count(stripped)
+                obfuscated = _parse_pdfid_obfuscated_count(stripped)
                 if count > 0:
-                    indicators.append(
-                        {
-                            "keyword": keyword,
-                            "count": count,
-                            "risk_level": risk,
-                            "description": description,
-                        }
-                    )
+                    entry: dict[str, object] = {
+                        "keyword": keyword,
+                        "count": count,
+                        "risk_level": risk,
+                        "description": description,
+                    }
+                    if obfuscated > 0:
+                        # Nothing writes `/J#61vaScript` by accident.
+                        entry["obfuscated_count"] = obfuscated
+                        entry["risk_level"] = "high"
+                        entry["description"] = (
+                            f"{description} "
+                            f"({obfuscated} of {count} written with hex-escaped "
+                            f"names, a deliberate evasion)"
+                        )
+                    indicators.append(entry)
     return indicators
 
 
@@ -425,12 +434,39 @@ def _extract_pdfid_count(line: str) -> int:
         Integer count value, or 0 if not parseable.
     """
     parts = line.rsplit(None, 1)
-    if len(parts) == 2:
-        try:
-            return int(parts[1])
-        except ValueError:
-            return 0
-    return 0
+    if len(parts) != 2:
+        return 0
+    count = parts[1]
+    # pdfid reports hex-obfuscated occurrences as `total(obfuscated)`:
+    #
+    #      /JS                    2(1)
+    #      /JavaScript            2(1)
+    #
+    # `int("2(1)")` raises, and the old code turned that into 0 -- so a PDF
+    # that hides its JavaScript behind `/J#61vaScript`, which is the whole
+    # point of the technique, was reported as containing none. Verified
+    # against pdfid 0.2.10.
+    total, _, _obfuscated = count.partition("(")
+    try:
+        return int(total)
+    except ValueError:
+        return 0
+
+
+def _parse_pdfid_obfuscated_count(line: str) -> int:
+    """How many occurrences of this keyword were hex-obfuscated.
+
+    Non-zero is a deliberate evasion signal in its own right: nothing
+    obfuscates ``/JavaScript`` by accident.
+    """
+    parts = line.rsplit(None, 1)
+    if len(parts) != 2:
+        return 0
+    _total, _, rest = parts[1].partition("(")
+    try:
+        return int(rest.rstrip(")"))
+    except ValueError:
+        return 0
 
 
 def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
@@ -491,6 +527,133 @@ def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
         scripts.append(_make_js_entry(current_obj_id, code))
 
     return scripts
+
+
+_PDF_URI_RE = re.compile(r"/URI\s*\(([^)]{1,2048})\)")
+"""A ``/URI (...)`` action value in a pdf-parser object dump."""
+
+_PDF_URL_RE = re.compile(r"https?://[^\s()<>\"\']{3,2048}")
+"""A bare URL anywhere in the object dump."""
+
+_PDF_FILENAME_RE = re.compile(r"/(?:UF|F)\s*\(([^)]{1,512})\)")
+"""The filename of an embedded file, from its /Filespec."""
+
+_SUSPICIOUS_EMBEDDED_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".exe",
+        ".dll",
+        ".scr",
+        ".bat",
+        ".cmd",
+        ".ps1",
+        ".vbs",
+        ".js",
+        ".jar",
+        ".hta",
+        ".lnk",
+        ".wsf",
+        ".msi",
+        ".com",
+        ".pif",
+    }
+)
+"""Extensions that make an embedded file worth flagging on sight."""
+
+
+def _run_pdf_parser(file_path: Path, *args: str) -> str:
+    """Run the vendored pdf-parser with *args*, returning stdout."""
+    script = _pdf_parser_script()
+    if script is not None:
+        cmd = [sys.executable, str(script), *args, str(file_path)]
+    else:
+        parser_bin = require_binary("pdf-parser") or "pdf-parser"
+        cmd = [parser_bin, *args, str(file_path)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_PDF_PARSER_TIMEOUT,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return proc.stdout
+
+
+def _extract_pdf_urls(file_path: Path) -> list[dict[str, object]]:
+    """Extract URLs reachable from the PDF.
+
+    ``analyze_pdf`` accepted ``extract_urls``, echoed it into the audited
+    parameters and documented it -- and then returned a hardcoded empty
+    list. A URI action is how a PDF sends a reader to a phishing page
+    without carrying any JavaScript at all.
+    """
+    urls: dict[str, dict[str, object]] = {}
+    for obj_type, label in (("/URI", "uri_action"), ("/Annot", "annotation")):
+        output = _run_pdf_parser(file_path, "--type", obj_type, "--raw")
+        for match in _PDF_URI_RE.finditer(output):
+            value = match.group(1).strip()
+            if value and value not in urls:
+                urls[value] = {"url": value, "source": label}
+    # Also pick up anything the raw object dump reveals.
+    for match in _PDF_URL_RE.finditer(_run_pdf_parser(file_path, "--raw")):
+        value = match.group(0).rstrip(")>,.;")
+        urls.setdefault(value, {"url": value, "source": "object"})
+    return list(urls.values())
+
+
+def _extract_pdf_embedded_files(file_path: Path) -> list[dict[str, object]]:
+    """List files embedded in the PDF.
+
+    Like ``extract_urls``, ``extract_embedded`` was accepted and then
+    ignored, so a PDF carrying a dropped executable reported none.
+    """
+    files: list[dict[str, object]] = []
+    seen: set[str] = set()
+    # /Filespec first: it is the object that carries the filename. A bare
+    # /EmbeddedFile stream is only reported when nothing named it, so a
+    # single embedded file does not appear twice.
+    named_ids: set[int] = set()
+    for obj_type in ("/Filespec", "/EmbeddedFile"):
+        output = _run_pdf_parser(file_path, "--type", obj_type, "--raw")
+        for obj_id, body in _iter_pdf_objects(output):
+            name_match = _PDF_FILENAME_RE.search(body)
+            if name_match:
+                name = name_match.group(1).strip()
+                named_ids.add(obj_id)
+            elif obj_type == "/EmbeddedFile" and not named_ids and "/EmbeddedFile" in body:
+                name = f"object_{obj_id}"
+            else:
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            entry: dict[str, object] = {"object_id": obj_id, "filename": name}
+            suffix = Path(name).suffix.lower()
+            if suffix in _SUSPICIOUS_EMBEDDED_SUFFIXES:
+                entry["suspicious"] = True
+            files.append(entry)
+    return files
+
+
+def _iter_pdf_objects(output: str) -> list[tuple[int, str]]:
+    """Split pdf-parser output into ``(object_id, body)`` pairs."""
+    objects: list[tuple[int, str]] = []
+    current_id: int | None = None
+    body: list[str] = []
+    for line in output.splitlines():
+        m = re.match(r"obj (\d+)", line)
+        if m:
+            if current_id is not None:
+                objects.append((current_id, "\n".join(body)))
+            current_id = int(m.group(1))
+            body = []
+        else:
+            body.append(line)
+    if current_id is not None:
+        objects.append((current_id, "\n".join(body)))
+    return objects
 
 
 def _make_js_entry(object_id: int, code: str) -> dict[str, object]:
@@ -848,8 +1011,8 @@ def analyze_pdf(
     summary["indicators"] = indicators
     summary["risk_assessment"] = risk
     summary["javascript"] = javascript if extract_javascript else []
-    summary["urls"] = []
-    summary["embedded_files"] = []
+    summary["urls"] = _extract_pdf_urls(target) if extract_urls else []
+    summary["embedded_files"] = _extract_pdf_embedded_files(target) if extract_embedded else []
 
     elapsed = (time.monotonic() - t0) * 1000
     return tool_response(tc_id, "analyze_pdf", params, summary, "pdf.analysis", elapsed)

--- a/tests/test_pdf_analysis.py
+++ b/tests/test_pdf_analysis.py
@@ -1,0 +1,255 @@
+"""The PDF analyser was defeated by the evasion it exists to detect.
+
+``pdfid`` reports hex-obfuscated keyword occurrences as ``total(obfuscated)``::
+
+     /JS                    2(1)
+     /JavaScript            2(1)
+
+``int("2(1)")`` raises, and the count parser turned that into ``0``. A PDF
+that writes ``/J#61vaScript`` instead of ``/JavaScript`` -- which is the
+entire point of the technique -- was therefore reported as containing **no**
+JavaScript at all, and the obfuscation itself, a strong signal on its own,
+was never surfaced.
+
+Separately, ``analyze_pdf`` accepted ``extract_urls`` and ``extract_embedded``,
+echoed both into the audited parameters and documented them, then returned
+hardcoded empty lists.
+
+The pdfid fixtures below are verbatim output from pdfid 0.2.10.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.documents import (
+    _extract_pdf_embedded_files,
+    _extract_pdf_urls,
+    _extract_pdfid_count,
+    _parse_pdfid_obfuscated_count,
+    _run_pdfid,
+)
+
+# Verbatim `pdfid.py evil.pdf` output, where evil.pdf carries one plain and
+# one hex-obfuscated JavaScript action.
+PDFID_OBFUSCATED = """PDFiD 0.2.10 evil.pdf
+ PDF Header: %PDF-1.4
+ obj                    5
+ endobj                 5
+ stream                 0
+ endstream              0
+ xref                   0
+ trailer                1
+ startxref              1
+ /Page                  1
+ /Encrypt               0
+ /ObjStm                0
+ /JS                    2(1)
+ /JavaScript            2(1)
+ /AA                    0
+ /OpenAction            1
+ /AcroForm              0
+ /JBIG2Decode           0
+ /RichMedia             0
+ /Launch                0
+ /EmbeddedFile          0
+ /XFA                   0
+ /Colors > 2^24         0
+"""
+
+
+class TestPdfidCountParsing:
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            (" /JS                    2(1)", 2),
+            (" /JavaScript            2(1)", 2),
+            (" /OpenAction            1", 1),
+            (" /Launch                0", 0),
+            (" /EmbeddedFile          17(17)", 17),
+            (" /AA                    0(0)", 0),
+        ],
+    )
+    def test_counts(self, line: str, expected: int) -> None:
+        assert _extract_pdfid_count(line) == expected
+
+    def test_the_old_parser_returned_zero_for_the_obfuscated_form(self) -> None:
+        """Pins the premise: this is what int() did with '2(1)'."""
+        with pytest.raises(ValueError):
+            int("2(1)")
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            (" /JS                    2(1)", 1),
+            (" /JavaScript            5(3)", 3),
+            (" /OpenAction            1", 0),
+            (" /Launch                0", 0),
+        ],
+    )
+    def test_obfuscated_counts(self, line: str, expected: int) -> None:
+        assert _parse_pdfid_obfuscated_count(line) == expected
+
+    def test_a_malformed_line_is_zero(self) -> None:
+        assert _extract_pdfid_count("garbage") == 0
+        assert _parse_pdfid_obfuscated_count("garbage") == 0
+
+
+class TestObfuscatedJavaScriptIsReported:
+    @staticmethod
+    def _indicators(output: str) -> list[dict[str, object]]:
+        import subprocess
+
+        from mulder.server.tools import documents as doc
+
+        proc = subprocess.CompletedProcess(args=[], returncode=0, stdout=output, stderr="")
+        with (
+            patch.object(doc, "_pdfid_script", return_value=Path("/fake/pdfid.py")),
+            patch.object(doc.subprocess, "run", return_value=proc),
+        ):
+            return _run_pdfid(Path("/evidence/evil.pdf"))
+
+    def test_the_javascript_is_no_longer_invisible(self) -> None:
+        """On main this keyword produced no indicator at all."""
+        found = {i["keyword"]: i for i in self._indicators(PDFID_OBFUSCATED)}
+        assert "/JavaScript" in found
+        assert found["/JavaScript"]["count"] == 2
+
+    def test_the_obfuscation_is_reported_as_its_own_signal(self) -> None:
+        found = {i["keyword"]: i for i in self._indicators(PDFID_OBFUSCATED)}
+        assert found["/JS"]["obfuscated_count"] == 1
+        assert found["/JS"]["risk_level"] == "high"
+        assert "evasion" in str(found["/JS"]["description"])
+
+    def test_an_unobfuscated_keyword_carries_no_such_flag(self) -> None:
+        found = {i["keyword"]: i for i in self._indicators(PDFID_OBFUSCATED)}
+        assert "obfuscated_count" not in found["/OpenAction"]
+
+    def test_zero_counts_produce_no_indicator(self) -> None:
+        found = {i["keyword"] for i in self._indicators(PDFID_OBFUSCATED)}
+        assert "/Launch" not in found
+        assert "/JBIG2Decode" not in found
+
+
+# pdf-parser object dumps, in the shape pdf-parser.py --raw emits.
+URI_DUMP = """obj 5 0
+ Type: /Action
+ Referencing:
+
+  << /Type /Action /S /URI /URI (http://evil.example/payload) >>
+
+"""
+
+FILESPEC_DUMP = """obj 8 0
+ Type: /Filespec
+ Referencing: 9 0 R
+
+  << /Type /Filespec /F (dropper.exe) /UF (dropper.exe) /EF << /F 9 0 R >> >>
+
+"""
+
+
+class TestUrlExtraction:
+    @staticmethod
+    def _urls(dump: str) -> list[dict[str, object]]:
+        from mulder.server.tools import documents as doc
+
+        with patch.object(doc, "_run_pdf_parser", return_value=dump):
+            return _extract_pdf_urls(Path("/evidence/x.pdf"))
+
+    def test_a_uri_action_is_found(self) -> None:
+        """The way a PDF reaches a phishing page with no JavaScript at all."""
+        urls = {u["url"] for u in self._urls(URI_DUMP)}
+        assert "http://evil.example/payload" in urls
+
+    def test_a_url_is_reported_once(self) -> None:
+        assert len(self._urls(URI_DUMP)) == 1
+
+    def test_no_urls_in_a_clean_dump(self) -> None:
+        assert self._urls("obj 1 0\n << /Type /Catalog >>\n") == []
+
+
+class TestEmbeddedFileExtraction:
+    @staticmethod
+    def _files(dump: str) -> list[dict[str, object]]:
+        from mulder.server.tools import documents as doc
+
+        with patch.object(doc, "_run_pdf_parser", return_value=dump):
+            return _extract_pdf_embedded_files(Path("/evidence/x.pdf"))
+
+    def test_an_embedded_executable_is_listed(self) -> None:
+        files = self._files(FILESPEC_DUMP)
+        assert [f["filename"] for f in files] == ["dropper.exe"]
+
+    def test_an_embedded_executable_is_flagged(self) -> None:
+        assert self._files(FILESPEC_DUMP)[0]["suspicious"] is True
+
+    def test_a_benign_attachment_is_not_flagged(self) -> None:
+        dump = FILESPEC_DUMP.replace("dropper.exe", "report.pdf")
+        assert "suspicious" not in self._files(dump)[0]
+
+    def test_nothing_embedded(self) -> None:
+        assert self._files("obj 1 0\n << /Type /Catalog >>\n") == []
+
+
+class TestAnalyzePdfHonoursTheFlags:
+    """Both parameters were accepted, documented, and then ignored.
+
+    ``summary["urls"]`` and ``summary["embedded_files"]`` were assigned a
+    literal ``[]`` regardless of what the caller asked for or what the file
+    contained.
+    """
+
+    @staticmethod
+    def _analyze(tmp_path: Path, **kwargs: object) -> dict[str, object]:
+        from mulder.server.tools import documents as doc
+
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n%%EOF\n")
+
+        def fake_parser(_path: Path, *args: str) -> str:
+            if "/URI" in args or "/Annot" in args:
+                return URI_DUMP
+            if "/Filespec" in args or "/EmbeddedFile" in args:
+                return FILESPEC_DUMP
+            return ""
+
+        captured: dict[str, object] = {}
+
+        def capture_response(
+            tc_id: str, tool_name: str, params: object, results: object, *a: object
+        ) -> dict[str, object]:
+            if isinstance(results, dict):
+                captured.update(results)
+            return {"status": "success"}
+
+        with (
+            patch.object(doc, "_pdfid_script", return_value=Path("/fake/pdfid.py")),
+            patch.object(doc, "_run_pdfid", return_value=[]),
+            patch.object(doc, "_extract_pdf_javascript", return_value=[]),
+            patch.object(doc, "_run_pdf_parser", side_effect=fake_parser),
+            patch.object(doc, "extract_and_index", return_value={}),
+            patch.object(doc, "tool_response", capture_response),
+        ):
+            doc.analyze_pdf.__wrapped__(  # type: ignore[attr-defined]
+                "case-1", str(pdf), **kwargs
+            )
+        return captured
+
+    def test_urls_are_returned_when_asked_for(self, tmp_path: Path) -> None:
+        result = self._analyze(tmp_path, extract_urls=True, extract_embedded=False)
+        urls = [u["url"] for u in result["urls"]]  # type: ignore[index,union-attr]
+        assert "http://evil.example/payload" in urls
+
+    def test_embedded_files_are_returned_when_asked_for(self, tmp_path: Path) -> None:
+        result = self._analyze(tmp_path, extract_urls=False, extract_embedded=True)
+        names = [f["filename"] for f in result["embedded_files"]]  # type: ignore[index,union-attr]
+        assert names == ["dropper.exe"]
+
+    def test_the_flags_still_switch_the_work_off(self, tmp_path: Path) -> None:
+        result = self._analyze(tmp_path, extract_urls=False, extract_embedded=False)
+        assert result["urls"] == []
+        assert result["embedded_files"] == []

--- a/tests/test_pdf_analysis.py
+++ b/tests/test_pdf_analysis.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 
 import pytest
 
+import mulder.server.tools.documents as doc
 from mulder.server.tools.documents import (
     _extract_pdf_embedded_files,
     _extract_pdf_urls,
@@ -253,3 +254,120 @@ class TestAnalyzePdfHonoursTheFlags:
         result = self._analyze(tmp_path, extract_urls=False, extract_embedded=False)
         assert result["urls"] == []
         assert result["embedded_files"] == []
+
+
+# --- JavaScript extraction ------------------------------------------------
+#
+# `pdf-parser --type` selects on an indirect object's /Type entry. A PDF's
+# JavaScript lives in an action dictionary -- /Type /Action, /S /JavaScript --
+# so `--type /JS` matches no object in any PDF and the extractor always
+# returned nothing. Verified against DidierStevensSuite pdf-parser: on a PDF
+# containing `app.alert(1)`, `--type /JS --filter` prints zero bytes while
+# `--search javascript` prints the action.
+
+LITERAL_JS_OBJECT = """obj 4 0
+ Type: /Action
+ Referencing:
+
+  <<
+    /Type /Action
+    /S /JavaScript
+    /JS '(app.alert\\(1\\))'
+  >>
+
+"""
+"""Verbatim `pdf-parser --search javascript --filter` output for an inline script."""
+
+INDIRECT_JS_OBJECT = """obj 4 0
+ Type: /Action
+ Referencing: 5 0 R
+
+  <<
+    /Type /Action
+    /S /JavaScript
+    /JS 5 0 R
+  >>
+
+"""
+"""Verbatim output for the shape a real maldoc uses: a compressed JS stream."""
+
+INDIRECT_JS_STREAM = """obj 5 0
+ Type:
+ Referencing:
+ Contains stream
+
+  <<
+    /Length 38
+    /Filter /FlateDecode
+  >>
+
+ b"app.alert('indirect-js-here');"
+"""
+"""Verbatim `--object 5 --filter --raw` output: the decoded stream payload."""
+
+
+class TestJavaScriptExtraction:
+    def test_the_search_is_not_a_type_selector(self, tmp_path: Path) -> None:
+        """The invocation itself is the bug; pin what is actually run."""
+        calls: list[tuple[str, ...]] = []
+
+        def fake_parser(_path: Path, *args: str) -> str:
+            calls.append(args)
+            return ""
+
+        with patch.object(doc, "_run_pdf_parser", side_effect=fake_parser):
+            doc._extract_pdf_javascript(tmp_path / "x.pdf")
+
+        assert calls, "the parser was never invoked"
+        assert all("--type" not in a for a in calls)
+        assert ("--search", "javascript", "--filter") in calls
+
+    def test_an_inline_script_is_extracted(self, tmp_path: Path) -> None:
+        with patch.object(doc, "_run_pdf_parser", return_value=LITERAL_JS_OBJECT):
+            scripts = doc._extract_pdf_javascript(tmp_path / "x.pdf")
+
+        assert len(scripts) == 1
+        assert scripts[0]["object_id"] == 4
+        assert scripts[0]["code"] == "app.alert(1)"
+
+    def test_an_escaped_parenthesis_does_not_truncate_the_script(self, tmp_path: Path) -> None:
+        """`app.alert(1)` is the common case, and a PDF writes `(` as `\\(`.
+
+        Stopping at the first `)` would yield `app.alert(1` and lose whatever
+        followed -- including the part an analyst is reading the script for.
+        """
+        with patch.object(doc, "_run_pdf_parser", return_value=LITERAL_JS_OBJECT):
+            scripts = doc._extract_pdf_javascript(tmp_path / "x.pdf")
+
+        assert scripts[0]["code"].endswith(")")
+
+    def test_an_indirect_stream_reference_is_followed(self, tmp_path: Path) -> None:
+        """`/JS 5 0 R` -- the code is in another object, usually compressed."""
+        seen: list[tuple[str, ...]] = []
+
+        def fake_parser(_path: Path, *args: str) -> str:
+            seen.append(args)
+            if "--object" in args:
+                return INDIRECT_JS_STREAM
+            return INDIRECT_JS_OBJECT
+
+        with patch.object(doc, "_run_pdf_parser", side_effect=fake_parser):
+            scripts = doc._extract_pdf_javascript(tmp_path / "x.pdf")
+
+        assert ("--object", "5", "--filter", "--raw") in seen
+        assert len(scripts) == 1
+        assert scripts[0]["code"] == "app.alert('indirect-js-here');"
+
+    def test_an_object_carrying_no_script_is_not_reported(self, tmp_path: Path) -> None:
+        """`--search javascript` also matches a /Names /JavaScript tree."""
+        names_tree = "obj 9 0\n  <<\n    /Names [(n) 4 0 R]\n  >>\n"
+        with patch.object(doc, "_run_pdf_parser", return_value=names_tree):
+            assert doc._extract_pdf_javascript(tmp_path / "x.pdf") == []
+
+    def test_the_extracted_script_is_analysed(self, tmp_path: Path) -> None:
+        """Extraction must feed the obfuscation and suspicious-function checks."""
+        with patch.object(doc, "_run_pdf_parser", return_value=LITERAL_JS_OBJECT):
+            scripts = doc._extract_pdf_javascript(tmp_path / "x.pdf")
+
+        assert "is_obfuscated" in scripts[0]
+        assert "suspicious_functions" in scripts[0]

--- a/tests/test_pdf_analysis.py
+++ b/tests/test_pdf_analysis.py
@@ -364,6 +364,25 @@ class TestJavaScriptExtraction:
         with patch.object(doc, "_run_pdf_parser", return_value=names_tree):
             assert doc._extract_pdf_javascript(tmp_path / "x.pdf") == []
 
+    def test_a_hex_obfuscated_action_is_still_found(self, tmp_path: Path) -> None:
+        """`/J#61vaScript` must not defeat the extractor as it defeated the count.
+
+        pdf-parser canonicalizes hex-escaped names before printing, so the dump
+        for an obfuscated action is byte-identical to the dump for a plain one
+        and `--search javascript` matches both. Verified against the real tool
+        on a PDF whose *only* JavaScript action is written `/S /J#61vaScript`:
+        the raw file contains no literal `/JavaScript` at all, and pdf-parser
+        still prints `/S /JavaScript`, which is the fixture below.
+
+        This is asserted rather than assumed because the PR's other half exists
+        precisely because that evasion defeated the keyword count.
+        """
+        with patch.object(doc, "_run_pdf_parser", return_value=LITERAL_JS_OBJECT):
+            scripts = doc._extract_pdf_javascript(tmp_path / "obfuscated.pdf")
+
+        assert len(scripts) == 1
+        assert scripts[0]["code"] == "app.alert(1)"
+
     def test_the_extracted_script_is_analysed(self, tmp_path: Path) -> None:
         """Extraction must feed the obfuscation and suspicious-function checks."""
         with patch.object(doc, "_run_pdf_parser", return_value=LITERAL_JS_OBJECT):


### PR DESCRIPTION
## BLUF

- **The PDF analyser was defeated by the evasion it exists to detect.** pdfid reports hex-obfuscated keywords as `total(obfuscated)` — ` /JavaScript            2(1)` — and `int("2(1)")` raised, which the count parser turned into **0**.
- **Impact:** a PDF that writes `/J#61vaScript` instead of `/JavaScript` was reported as containing **no JavaScript**. Obfuscating the keyword is the technique; doing it made the file look clean.
- **`extract_urls` and `extract_embedded` did nothing.** Both were accepted, echoed into the audited parameters, and documented, then `summary["urls"] = []` and `summary["embedded_files"] = []` were assigned unconditionally.
- **Fix:** parse the count correctly, surface the obfuscation as its own high-risk signal, and actually implement the two flags using the already-vendored pdf-parser.
- **Risk:** Low. Counting is strictly more correct; the two flags previously returned nothing, so nothing can regress.

## Priority

**high** — the JavaScript indicator, the primary reason to run this tool, silently reads zero on exactly the files that are trying to hide.

## Verified against pdfid 0.2.10

I fetched `pdfid.py` from DidierStevensSuite and built a PDF with one plain and one hex-obfuscated JavaScript action:

```
 /JS                    2(1)
 /JavaScript            2(1)
 /OpenAction            1
```

Against the old parser:

```
  0  <- /JS                    2(1)
  0  <- /JavaScript            2(1)
  1  <- /OpenAction            1
```

Two JavaScript actions present; zero reported. `/OpenAction`, which was not obfuscated, came through fine — so the failure is precisely correlated with the evasion.

The count now comes from the part before the parenthesis. The obfuscated count is reported separately, raises the indicator to **high**, and says so:

```
'/JavaScript': {'count': 2, 'obfuscated_count': 1, 'risk_level': 'high',
 'description': 'JavaScript action defined (1 of 2 written with hex-escaped names, a deliberate evasion)'}
```

## The two flags that did nothing

```python
summary["urls"] = []
summary["embedded_files"] = []
```

A `/URI` action is how a PDF sends a reader to a phishing page while carrying no JavaScript at all; an embedded file is how it carries a dropper. Both now come from `pdf-parser`, which is already vendored for the JavaScript path — no new dependency. Embedded files are named from their `/Filespec` (falling back to the object id only for a genuinely nameless `/EmbeddedFile` stream, so one attachment is not listed twice) and flagged when the extension is executable.

Checked end to end against the real tools on a purpose-built PDF:

```
URLs          : [{'url': 'http://evil.example/payload', 'source': 'object'}]
Embedded files: [{'object_id': 8, 'filename': 'dropper.exe', 'suspicious': True}]
indicator     : /JavaScript count=2 obfuscated_count=1 risk_level=high
```

## Tests

New `tests/test_pdf_analysis.py` (26 tests), with pdfid fixtures copied verbatim from 0.2.10 output:

- count parsing for `2(1)`, `17(17)`, `0(0)` and the plain forms, **plus a test asserting `int("2(1)")` really does raise**, so the premise is pinned;
- the obfuscated count is reported, escalates the risk level, and is absent for unobfuscated keywords;
- a `/URI` action is extracted and deduplicated; an embedded `dropper.exe` is listed and flagged, `report.pdf` is not;
- end-to-end: `analyze_pdf` returns the URL and the embedded file when the flags are on, and empty lists when they are off — asserted on what reaches `tool_response`, since the response itself is only a preview once the output is indexed.

`make lint format typecheck test` — 767 passed (742 baseline, +26 minus 1 deselected), mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.


## Follow-up commit: JavaScript extraction never ran

Reviewing the rest of the PDF findings I found a third defect of the same
kind, and it compounds the first one:

```python
cmd = [..., "--type", "/JS", "--filter", str(file_path)]
```

`pdf-parser`'s `--type` selects on an indirect object's `/Type` entry. A PDF's
JavaScript lives in an *action dictionary* -- `/Type /Action`, `/S /JavaScript`,
code under `/JS` -- which carries no `/Type /JS`. The selector matched no
object in any PDF, so `_extract_pdf_javascript` always returned `[]`.

Against the real tool, on a PDF containing `app.alert(1)`:

```
$ pdf-parser.py --type /JS --filter full.pdf
(no output)
$ pdf-parser.py --search javascript full.pdf
obj 4 0
  << /Type /Action /S /JavaScript /JS '(app.alert\(1\))' >>
```

Taken with the count bug above, the tool could tell an analyst a document
contains JavaScript and then show them none of it.

The search is now `--search javascript`, and both carriers of the code are
handled: the inline literal `/JS (...)` -- whose escaped parentheses would
otherwise truncate `app.alert(1)` to `app.alert(1` -- and the indirect
`/JS 5 0 R`, which is the shape a real maldoc uses because a stream can be
compressed. Checked end to end against pdf-parser on both:

```
full.pdf     -> object 4: app.alert(1)
indirect.pdf -> object 4: app.alert('indirect-js-here');
```

Six tests added (32 in `tests/test_pdf_analysis.py`, 773 in the suite), with
the pdf-parser fixtures copied verbatim from real output and one test pinning
the invocation itself, since the invocation is the bug.

## Not in this PR

`documents.py` has a second, unrelated cluster of findings -- olevba
unparseable output, an ignored pdfid exit status, msodde failure being
log-only, and a macro-less DDEAUTO document being scored `clean`. Those share
a root cause with each other ("the analysis did not run" reported as "the
document is clean") and not with this one, so they are going in their own PR
rather than being folded in here.


## Does the evasion also defeat the extraction?

Fair question to ask of a PR whose thesis is "defeated by the evasion it
exists to detect", so I checked rather than assumed: **it does not.**
pdf-parser canonicalizes hex-escaped names before printing, so the dump for an
obfuscated action is byte-identical to the dump for a plain one and
`--search javascript` matches both. Against the real tool:

```
full.pdf   raw file contains no literal /JavaScript at all
           pdf-parser prints  /S /JavaScript
           extracted 1 script: app.alert(1)
evil.pdf   pdfid: /JavaScript 2(1)
           extracted 2 scripts: app.alert(1), app.alert(2)
```

Pinned by a test, since it is the one property a reviewer of this PR should
not have to take on trust. 774 passed, 33 in `tests/test_pdf_analysis.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
