### PR TITLE
[high] fix(binary): stop asserting that every valid PE timestamp is impossible

### DIFF
--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -343,7 +343,52 @@ def _detect_packing(
     return indicators
 
 
-def _assess_timestamp(raw_ts: str | None) -> dict[str, object]:
+_RABIN2_CTIME_FORMAT = "%a %b %d %H:%M:%S %Y"
+"""How rabin2 renders a PE TimeDateStamp: ``Wed Mar 12 09:41:03 2025``."""
+
+_TIMESTAMP_BEARING_FORMATS: frozenset[str] = frozenset({"pe", "coff", "te"})
+"""Formats whose header carries a compilation timestamp.
+
+ELF and Mach-O do not have one. rabin2 reports ``compiled: ""`` for them, and
+treating that absence as an anomaly scored every Linux and macOS binary as
+suspicious for a field the format never had.
+"""
+
+
+def _parse_rabin2_timestamp(raw_ts: str) -> datetime | None:
+    """Parse the compilation timestamp as rabin2 actually emits it.
+
+    rabin2 formats the PE TimeDateStamp with ctime before putting it in JSON::
+
+        "compiled": "Wed Mar 12 09:41:03 2025"
+
+    ``int()`` on that raises, which the caller used to report as an impossible
+    timestamp. A bare epoch integer is still accepted, since that is what a
+    caller passing the raw header field would supply.
+
+    Args:
+        raw_ts: The ``compiled`` value from ``rabin2 -Ij``.
+
+    Returns:
+        The parsed UTC datetime, or None if the value is in neither form.
+    """
+    text = raw_ts.strip()
+    if not text:
+        return None
+
+    if text.lstrip("-").isdigit():
+        try:
+            return datetime.fromtimestamp(int(text), tz=timezone.utc)
+        except (ValueError, OSError, OverflowError):
+            return None
+
+    try:
+        return datetime.strptime(text, _RABIN2_CTIME_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _assess_timestamp(raw_ts: str | None, bintype: str = "") -> dict[str, object]:
     """Validate a PE compilation timestamp.
 
     Checks whether the timestamp falls within a plausible range.
@@ -352,11 +397,21 @@ def _assess_timestamp(raw_ts: str | None) -> dict[str, object]:
 
     Args:
         raw_ts: Raw timestamp string from rabin2 output.
+        bintype: rabin2's ``bintype`` for the file (``pe``, ``elf``, ...).
+            Formats that carry no compilation timestamp are not penalised for
+            not having one.
 
     Returns:
         Dict with raw_timestamp, parsed_utc, validity, and reason.
     """
     if not raw_ts:
+        if bintype and bintype.lower() not in _TIMESTAMP_BEARING_FORMATS:
+            return {
+                "raw_timestamp": None,
+                "parsed_utc": None,
+                "validity": "not_applicable",
+                "reason": f"{bintype} binaries carry no compilation timestamp",
+            }
         return {
             "raw_timestamp": None,
             "parsed_utc": None,
@@ -364,9 +419,8 @@ def _assess_timestamp(raw_ts: str | None) -> dict[str, object]:
             "reason": "No compilation timestamp present",
         }
 
-    try:
-        parsed = datetime.fromtimestamp(int(raw_ts), tz=timezone.utc)
-    except (ValueError, OSError, OverflowError):
+    parsed = _parse_rabin2_timestamp(raw_ts)
+    if parsed is None:
         return {
             "raw_timestamp": raw_ts,
             "parsed_utc": None,
@@ -795,9 +849,9 @@ def triage_binary(
     info_dict: dict[str, Any] = info_raw.get("info", info_raw.get("bin", {}))
     raw_ts_val = info_dict.get("compiled")
     raw_ts = str(raw_ts_val) if raw_ts_val is not None else None
-    if raw_ts in ("None", "0", ""):
+    if raw_ts is not None and raw_ts.strip() in ("None", ""):
         raw_ts = None
-    timestamp = _assess_timestamp(raw_ts)
+    timestamp = _assess_timestamp(raw_ts, str(info_dict.get("bintype", "")))
 
     verdict = _compute_verdict(packing_indicators, suspicious_imports, timestamp, sections)
 

--- a/tests/test_pe_timestamp_assessment.py
+++ b/tests/test_pe_timestamp_assessment.py
@@ -1,0 +1,108 @@
+"""A valid PE compilation timestamp was asserted to be forensically impossible.
+
+``_assess_timestamp`` did ``int(raw_ts)`` and, on ValueError, returned
+``validity: "impossible"``, which ``_compute_verdict`` scores **+5** -- past
+the threshold of 4 on its own, so a clean binary with no other signal was
+classified ``suspicious_indicators``.
+
+rabin2 does not emit an epoch integer. It formats the PE TimeDateStamp with
+ctime first. Running radare2 6.0.7 against a PE built with a known
+``TimeDateStamp`` of ``1741772463``::
+
+    "compiled": "Wed Mar 12 09:41:03 2025"
+    "bintype":  "pe"
+
+The complementary half hits every non-Windows binary: ELF and Mach-O carry no
+compilation timestamp at all, rabin2 reports ``compiled: ""`` for them, and the
+missing-timestamp branch scored **+2** for a field the format never had.
+``rabin2 -Ij /bin/ls`` confirms ``compiled: ''``.
+
+The zeroed timestamp -- an actual malware evasion -- was reported as
+impossible before this change and still is, but now because it parses to 1970
+rather than because it failed to parse at all.
+"""
+
+from __future__ import annotations
+
+from mulder.server.tools.binary import _assess_timestamp, _compute_verdict
+
+
+class TestRabin2FormatsTheTimestamp:
+    def test_the_real_rabin2_value_is_valid(self) -> None:
+        """Verbatim `compiled` from radare2 6.0.7 on TimeDateStamp 1741772463."""
+        result = _assess_timestamp("Wed Mar 12 09:41:03 2025", "pe")
+        assert result["validity"] == "valid"
+        assert result["parsed_utc"] == "2025-03-12T09:41:03+00:00"
+
+    def test_int_really_does_reject_that_value(self) -> None:
+        """Pin the premise rather than trusting the description of the bug."""
+        import pytest
+
+        with pytest.raises(ValueError):
+            int("Wed Mar 12 09:41:03 2025")
+
+    def test_a_single_digit_day_is_parsed(self) -> None:
+        """ctime pads with a second space: `Jan  1`, not `Jan 01`."""
+        result = _assess_timestamp("Thu Jan  1 00:00:00 1970", "pe")
+        assert result["parsed_utc"] == "1970-01-01T00:00:00+00:00"
+
+    def test_a_bare_epoch_integer_is_still_accepted(self) -> None:
+        result = _assess_timestamp("1741772463", "pe")
+        assert result["validity"] == "valid"
+        assert result["parsed_utc"] == "2025-03-12T09:41:03+00:00"
+
+    def test_genuine_garbage_is_still_impossible(self) -> None:
+        result = _assess_timestamp("not a date at all", "pe")
+        assert result["validity"] == "impossible"
+
+
+class TestTheVerdictNoLongerPunishesACleanBinary:
+    def test_a_clean_pe_scores_nothing(self) -> None:
+        ts = _assess_timestamp("Wed Mar 12 09:41:03 2025", "pe")
+        verdict = _compute_verdict([], {}, ts, [])
+        assert verdict["classification"] == "benign_indicators"
+        assert verdict["reasons"] == []
+
+    def test_the_old_behaviour_would_have_crossed_the_threshold(self) -> None:
+        """+5 for an impossible timestamp, against a threshold of 4."""
+        impossible: dict[str, object] = {
+            "validity": "impossible",
+            "reason": "Cannot parse timestamp value",
+        }
+        verdict = _compute_verdict([], {}, impossible, [])
+        assert verdict["classification"] == "suspicious_indicators"
+
+
+class TestFormatsWithoutATimestamp:
+    def test_an_elf_is_not_penalised(self) -> None:
+        """rabin2 reports compiled: '' for ELF; the format has no such field."""
+        result = _assess_timestamp(None, "elf")
+        assert result["validity"] == "not_applicable"
+        assert _compute_verdict([], {}, result, [])["reasons"] == []
+
+    def test_a_macho_is_not_penalised(self) -> None:
+        assert _assess_timestamp(None, "mach0")["validity"] == "not_applicable"
+
+    def test_a_pe_with_no_timestamp_is_still_suspicious(self) -> None:
+        """A PE header always has the field, so a missing value is an anomaly."""
+        result = _assess_timestamp(None, "pe")
+        assert result["validity"] == "suspicious"
+        assert _compute_verdict([], {}, result, [])["reasons"] == [
+            "Missing or suspicious timestamp"
+        ]
+
+    def test_an_unknown_format_keeps_the_old_conservative_reading(self) -> None:
+        assert _assess_timestamp(None, "")["validity"] == "suspicious"
+
+
+class TestTheEvasionIsStillCaught:
+    def test_a_zeroed_timestamp_is_impossible(self) -> None:
+        """The real signal this check exists for, preserved."""
+        result = _assess_timestamp("Thu Jan  1 00:00:00 1970", "pe")
+        assert result["validity"] == "impossible"
+        assert "predates" in str(result["reason"])
+
+    def test_a_future_timestamp_is_impossible(self) -> None:
+        result = _assess_timestamp("Sat Jan  1 00:00:00 2400", "pe")
+        assert result["validity"] == "impossible"
+        assert "future" in str(result["reason"])


### PR DESCRIPTION
## BLUF

- **Every PE with an ordinary compilation date was asserted to be forensically impossible.** `_assess_timestamp` did `int(raw_ts)`; rabin2 emits `"compiled": "Wed Mar 12 09:41:03 2025"`, a ctime string. `int()` raises, and the ValueError branch returns `validity: "impossible"`.
- **That verdict is worth +5**, against a `suspicious_indicators` threshold of 4 — so a clean binary with no other signal was misclassified on the strength of a parse failure alone.
- **The other half hits every Linux and macOS binary.** ELF and Mach-O have no compilation timestamp; rabin2 reports `compiled: ""`, and the missing-timestamp branch scored **+2** for a field the format never had.
- **The evasion is still caught.** A zeroed TimeDateStamp renders as `"Thu Jan  1 00:00:00 1970"` and is still `impossible` — now because it parses to 1970, not because parsing failed.
- **Verified by running radare2 6.0.7** against a PE I built with a known `TimeDateStamp`, not by reading documentation.
- **Risk:** Low. Strictly fewer false positives; the true positives this check exists for are preserved and tested.

## Priority

**high** — this fires on *every* binary. Windows samples get a spurious +5, non-Windows samples a spurious +2, so `triage_binary`'s classification is skewed for the entire corpus and analyst attention is drawn to the wrong files.

## What rabin2 actually emits

I built a minimal PE32+ with `TimeDateStamp = 1741772463` and ran `rabin2 -Ij` from radare2 6.0.7:

```json
"bintype":  "pe",
"compiled": "Wed Mar 12 09:41:03 2025",
```

`int("Wed Mar 12 09:41:03 2025")` raises `ValueError` → `{"validity": "impossible", "reason": "Cannot parse timestamp value: …"}` → `+5` in `_compute_verdict`.

And for ELF:

```
$ rabin2 -Ij /bin/ls
"bintype": "elf",  "compiled": ""
```

The value is empty, so `raw_ts` becomes `None` and the missing-timestamp branch adds `+2` — for a header field ELF does not define.

## After the fix, through the real tool

```
PE, TimeDateStamp 1741772463
   compiled  : 'Wed Mar 12 09:41:03 2025'  bintype=pe
   validity  : valid            -> benign_indicators, no reasons

PE, zeroed TimeDateStamp
   compiled  : 'Thu Jan  1 00:00:00 1970'  bintype=pe
   validity  : impossible (predates reasonable compilation)
                            -> suspicious_indicators

ELF /bin/ls
   compiled  : ''  bintype=elf
   validity  : not_applicable  -> benign_indicators, no reasons
```

The timestamp is parsed in the form rabin2 emits, with a bare epoch integer still accepted for any caller that supplies the raw header field. A format that cannot carry the timestamp reports `not_applicable` and scores nothing; a PE without one is still `suspicious`, because a PE header always has it.

**One behaviour change worth flagging:** the caller previously blanked `compiled` when it was the literal string `"0"`, turning a zeroed stamp into "missing" (+2). It now parses to 1970 and is scored as impossible (+5), which is the stronger and more accurate signal — zeroing the field is a deliberate act.

## Tests

New `tests/test_pe_timestamp_assessment.py` (13 tests):

- the verbatim rabin2 value parses, including the ctime double space in `Jan  1`;
- a test asserting `int("Wed Mar 12 09:41:03 2025")` really does raise, so the premise is pinned rather than described;
- `_compute_verdict` on the old "impossible" dict still crosses the threshold, which is what made this severe;
- ELF and Mach-O score nothing, a PE with no timestamp is still suspicious, and an unknown format keeps the conservative reading;
- the zeroed and future-dated stamps are still `impossible`.

`make lint format typecheck test` — 754 passed, mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
