### PR TITLE
[high] fix(case): validate case_id before it becomes a filesystem path

### DIFF
--- a/src/mulder/server/app.py
+++ b/src/mulder/server/app.py
@@ -267,6 +267,42 @@ def slugify(name: str) -> str:
     return slug.strip("-") or "case"
 
 
+CASE_ID_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+"""A case ID is one filesystem path segment, and nothing more.
+
+Every case ID becomes a path: ``db_dir / f"{case_id}.db"``, plus the sidecar
+files beside it. ``slugify`` guarantees that shape, but it was only applied to
+IDs mulder derived itself -- an ID supplied by an agent went to the filesystem
+verbatim.
+"""
+
+
+def validate_case_id(case_id: str) -> str:
+    """Return *case_id* if it is a safe path segment, else raise.
+
+    Args:
+        case_id: The identifier supplied by a caller.
+
+    Returns:
+        The identifier, unchanged.
+
+    Raises:
+        ValueError: If the identifier is empty, contains a path separator or a
+            parent reference, or is otherwise not a single path segment. The
+            check is a whitelist, so it also refuses NUL bytes, leading dots
+            and anything that would resolve outside the cases directory.
+    """
+    if not case_id or not CASE_ID_RE.match(case_id):
+        raise ValueError(
+            f"Invalid case_id {case_id!r}: a case ID must be 1-128 characters of "
+            "letters, digits, dot, dash or underscore, starting with a letter or "
+            "digit, and cannot contain a path separator."
+        )
+    if ".." in case_id:
+        raise ValueError(f"Invalid case_id {case_id!r}: parent references are not allowed.")
+    return case_id
+
+
 def init_server(
     db_dir: Path,
     case_id: str | None = None,
@@ -481,6 +517,8 @@ def create_case(
     ID is allowed. Attempts to create a different case are rejected
     and the enforced case is loaded instead.
     """
+    validate_case_id(case_id)
+
     enforced_id = os.environ.get("MULDER_CASE_ID", "")
     if enforced_id and case_id != enforced_id:
         logger.warning(

--- a/src/mulder/server/app.py
+++ b/src/mulder/server/app.py
@@ -267,18 +267,37 @@ def slugify(name: str) -> str:
     return slug.strip("-") or "case"
 
 
-CASE_ID_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
-"""A case ID is one filesystem path segment, and nothing more.
+_PATH_SEPARATORS: frozenset[str] = frozenset(
+    sep for sep in (os.sep, os.altsep, "/") if sep is not None
+)
+"""Every character this platform treats as a path separator.
 
-Every case ID becomes a path: ``db_dir / f"{case_id}.db"``, plus the sidecar
-files beside it. ``slugify`` guarantees that shape, but it was only applied to
-IDs mulder derived itself -- an ID supplied by an agent went to the filesystem
-verbatim.
+``/`` is included unconditionally: it separates on POSIX, and Windows accepts
+it as well, so a case ID containing one is never a single path segment.
 """
 
 
 def validate_case_id(case_id: str) -> str:
-    """Return *case_id* if it is a safe path segment, else raise.
+    """Return *case_id* if it names one path segment, else raise.
+
+    Every case ID becomes a path -- ``db_dir / f"{case_id}.db"`` and the
+    sidecars beside it, ``.audit.jsonl``, ``.report.md``, ``.iocs.csv`` and the
+    rest. ``slugify`` guarantees that shape, but it was only applied to IDs
+    mulder derived itself; an ID supplied by an agent went to the filesystem
+    verbatim, so ``"../../../../home/analyst/cases/CASE-2024-007"`` wrote its
+    case database outside the cases directory.
+
+    The rule is containment and nothing else: an ID that contains no path
+    separator is exactly one component once a suffix is appended, and one
+    component cannot be ``.`` or ``..``, so it cannot leave ``db_dir``. Case
+    IDs that were accepted before and do not escape -- ``Incident 2026``,
+    ``café``, ``-case``, ``case..2026``, ``.hidden`` -- keep working.
+
+    The one restriction beyond containment is control characters. A NUL
+    truncates the name in the C library underneath ``open()``, so the file
+    that is created is not the file that was named; the others corrupt the
+    ``.audit.jsonl`` records and log lines the ID is written into. Neither is
+    ever intentional in a case ID.
 
     Args:
         case_id: The identifier supplied by a caller.
@@ -287,19 +306,24 @@ def validate_case_id(case_id: str) -> str:
         The identifier, unchanged.
 
     Raises:
-        ValueError: If the identifier is empty, contains a path separator or a
-            parent reference, or is otherwise not a single path segment. The
-            check is a whitelist, so it also refuses NUL bytes, leading dots
-            and anything that would resolve outside the cases directory.
+        ValueError: If the identifier is empty, contains a path separator, or
+            contains a control character.
     """
-    if not case_id or not CASE_ID_RE.match(case_id):
+    if not case_id:
+        raise ValueError("Invalid case_id: a case ID cannot be empty.")
+
+    found = _PATH_SEPARATORS.intersection(case_id)
+    if found:
         raise ValueError(
-            f"Invalid case_id {case_id!r}: a case ID must be 1-128 characters of "
-            "letters, digits, dot, dash or underscore, starting with a letter or "
-            "digit, and cannot contain a path separator."
+            f"Invalid case_id {case_id!r}: a case ID is one path segment, so it "
+            f"cannot contain {''.join(sorted(found))!r}."
         )
-    if ".." in case_id:
-        raise ValueError(f"Invalid case_id {case_id!r}: parent references are not allowed.")
+
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in case_id):
+        raise ValueError(
+            f"Invalid case_id {case_id!r}: control characters are not allowed in a case ID."
+        )
+
     return case_id
 
 

--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -22,6 +22,7 @@ from mulder.server.app import (
     load_case,
     mcp,
     slugify,
+    validate_case_id,
 )
 from mulder.server.helpers import error_response, hash_output, make_tool_call_id
 from mulder.server.tool_access import ALL_ROLES, Role, tool_access
@@ -87,6 +88,20 @@ def scan_evidence(
         case_id = enforced_id
     elif case_id is None:
         case_id = slugify(ev_path.name)
+
+    # slugify guarantees a safe path segment, but only for IDs mulder derives.
+    # One supplied by an agent has to be checked before it becomes a path.
+    try:
+        validate_case_id(case_id)
+    except ValueError as exc:
+        return error_response(
+            tc_id,
+            "scan_evidence",
+            params,
+            str(exc),
+            (time.monotonic() - t0) * 1000,
+            error_type="invalid_input",
+        )
 
     try:
         result = _scan_evidence_inner(ev_path, case_id, replace)
@@ -310,6 +325,32 @@ def open_case(case_id: str) -> dict[str, object]:
     tc_id = make_tool_call_id()
     t0 = time.monotonic()
     params: dict[str, object] = {"case_id": case_id}
+
+    try:
+        validate_case_id(case_id)
+    except ValueError as exc:
+        return error_response(
+            tc_id,
+            "open_case",
+            params,
+            str(exc),
+            (time.monotonic() - t0) * 1000,
+            error_type="invalid_input",
+        )
+
+    # scan_evidence and create_case both honour MULDER_CASE_ID; open_case did
+    # not, so an agent pinned to one case could attach to another and every
+    # later finding, note and export would be written there instead.
+    enforced_id = os.environ.get("MULDER_CASE_ID", "")
+    if enforced_id and case_id != enforced_id:
+        return error_response(
+            tc_id,
+            "open_case",
+            params,
+            f"MULDER_CASE_ID enforces case '{enforced_id}'; refusing to open '{case_id}'.",
+            (time.monotonic() - t0) * 1000,
+            error_type="forbidden",
+        )
 
     cfg = get_cfg()
     db_path = cfg.db_dir / f"{case_id}.db"

--- a/tests/test_case_id_validation.py
+++ b/tests/test_case_id_validation.py
@@ -1,0 +1,131 @@
+"""A case ID becomes a filesystem path, so it has to be a path segment.
+
+``scan_evidence`` slugifies ``case_id`` only when it derives one itself::
+
+    elif case_id is None:
+        case_id = slugify(ev_path.name)
+
+An ID supplied by an agent skipped that and went to the filesystem verbatim,
+as ``db_dir / f"{case_id}.db"`` and every sidecar path beside it::
+
+    db_dir  = /home/analyst/.mulder/cases
+    case_id = "../../../../home/analyst/cases/CASE-2024-007"
+    ->        /home/analyst/cases/CASE-2024-007.db
+
+``open_case`` had the same hole and one more: ``scan_evidence`` and
+``create_case`` both refuse to work on a case other than ``MULDER_CASE_ID``
+when it is set, and ``open_case`` did not consult it at all. An agent pinned
+to CASE-A could call ``open_case("CASE-B")``, and every subsequent finding,
+note and export would be written to CASE-B.
+
+The evidence tree is attacker-influenced -- ``scan_evidence`` renders file and
+directory names back into the agent's context -- so "an agent would not do
+that" is not a control.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mulder.server.app import slugify, validate_case_id
+
+
+class TestWhatAValidIdLooksLike:
+    @pytest.mark.parametrize(
+        "case_id",
+        ["CASE-2024-007", "case1", "a", "host_1.image", "0", "A" * 128],
+    )
+    def test_accepted(self, case_id: str) -> None:
+        assert validate_case_id(case_id) == case_id
+
+    @pytest.mark.parametrize(
+        "case_id",
+        [
+            "../../../../home/analyst/cases/CASE-2024-007",
+            "../shared/cases/CASE-B",
+            "..",
+            "a/b",
+            "a\\b",
+            "/etc/passwd",
+            ".hidden",
+            "-leading-dash",
+            "",
+            "a" * 129,
+            "case\x00id",
+            "case id",
+        ],
+    )
+    def test_rejected(self, case_id: str) -> None:
+        with pytest.raises(ValueError, match="case_id"):
+            validate_case_id(case_id)
+
+    def test_slugify_output_is_always_valid(self) -> None:
+        """The two functions must agree, or derived IDs would be refused."""
+        for name in ("Evidence 2024/03", "../../etc", "!!!", "Host A"):
+            assert validate_case_id(slugify(name))
+
+
+class TestTheTraversalItWasBlocking:
+    def test_the_path_really_did_escape(self) -> None:
+        """Pin the premise rather than describing it."""
+        db_dir = Path("/home/analyst/.mulder/cases")
+        target = (db_dir / "../../../../home/analyst/cases/CASE-2024-007.db").resolve()
+        assert target == Path("/home/analyst/cases/CASE-2024-007.db")
+        assert db_dir.resolve() not in target.parents
+
+    def test_a_valid_id_stays_inside(self) -> None:
+        db_dir = Path("/home/analyst/.mulder/cases")
+        target = (db_dir / f"{validate_case_id('CASE-2024-007')}.db").resolve()
+        assert target.parent == db_dir.resolve()
+
+
+@pytest.fixture
+def initialised_server(tmp_path: Path) -> None:
+    """open_case reaches get_cfg() only after the enforcement checks pass."""
+    from mulder.server.app import init_server
+
+    init_server(db_dir=tmp_path)
+
+
+class TestOpenCaseHonoursTheEnforcedCase:
+    def test_a_different_case_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch, initialised_server: None
+    ) -> None:
+        from mulder.server.tools.case import open_case
+
+        monkeypatch.setenv("MULDER_CASE_ID", "CASE-A")
+        result = open_case.__wrapped__("CASE-B")  # type: ignore[attr-defined]
+        assert result["status"] == "error"
+        assert result["error_type"] == "forbidden"
+        assert "CASE-A" in str(result["error_message"])
+
+    def test_the_enforced_case_is_still_reachable(
+        self, monkeypatch: pytest.MonkeyPatch, initialised_server: None
+    ) -> None:
+        """The guard must not block the case the agent is pinned to."""
+        from mulder.server.tools.case import open_case
+
+        monkeypatch.setenv("MULDER_CASE_ID", "CASE-A")
+        result = open_case.__wrapped__("CASE-A")  # type: ignore[attr-defined]
+        # It gets past the guard; the case does not exist in this environment.
+        assert result["error_type"] == "not_found"
+
+    def test_a_traversal_is_refused_before_anything_else(
+        self, monkeypatch: pytest.MonkeyPatch, initialised_server: None
+    ) -> None:
+        from mulder.server.tools.case import open_case
+
+        monkeypatch.delenv("MULDER_CASE_ID", raising=False)
+        result = open_case.__wrapped__("../../shared/cases/CASE-B")  # type: ignore[attr-defined]
+        assert result["error_type"] == "invalid_input"
+
+    def test_no_enforcement_leaves_ordinary_use_alone(
+        self, monkeypatch: pytest.MonkeyPatch, initialised_server: None
+    ) -> None:
+        from mulder.server.tools.case import open_case
+
+        monkeypatch.delenv("MULDER_CASE_ID", raising=False)
+        result = open_case.__wrapped__("CASE-B")  # type: ignore[attr-defined]
+        assert result["error_type"] == "not_found"

--- a/tests/test_case_id_validation.py
+++ b/tests/test_case_id_validation.py
@@ -21,10 +21,17 @@ note and export would be written to CASE-B.
 The evidence tree is attacker-influenced -- ``scan_evidence`` renders file and
 directory names back into the agent's context -- so "an agent would not do
 that" is not a control.
+
+The check is containment only. A case ID that contains no path separator is
+exactly one component once a suffix is appended, and one component cannot be
+``.`` or ``..``, so it cannot leave ``db_dir``. IDs that mulder accepted before
+and that do not escape -- spaces, accents, leading dashes, embedded ``..`` --
+still work, and the tests below pin that as hard as they pin the traversal.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -35,7 +42,25 @@ from mulder.server.app import slugify, validate_case_id
 class TestWhatAValidIdLooksLike:
     @pytest.mark.parametrize(
         "case_id",
-        ["CASE-2024-007", "case1", "a", "host_1.image", "0", "A" * 128],
+        [
+            "CASE-2024-007",
+            "case1",
+            "a",
+            "host_1.image",
+            "0",
+            # Accepted by mulder's CLI today, and none of them escape db_dir.
+            "Incident 2026",
+            "café",
+            "-case",
+            "case..2026",
+            ".hidden",
+            "中文",
+            # A suffix is always appended, so even these stay one component:
+            # db_dir / "..db", db_dir / "...db".
+            ".",
+            "..",
+            "A" * 200,
+        ],
     )
     def test_accepted(self, case_id: str) -> None:
         assert validate_case_id(case_id) == case_id
@@ -45,19 +70,28 @@ class TestWhatAValidIdLooksLike:
         [
             "../../../../home/analyst/cases/CASE-2024-007",
             "../shared/cases/CASE-B",
-            "..",
             "a/b",
-            "a\\b",
             "/etc/passwd",
-            ".hidden",
-            "-leading-dash",
+            "CASE-2024-007/",
             "",
-            "a" * 129,
-            "case\x00id",
-            "case id",
         ],
     )
-    def test_rejected(self, case_id: str) -> None:
+    def test_a_separator_is_rejected(self, case_id: str) -> None:
+        with pytest.raises(ValueError, match="case_id"):
+            validate_case_id(case_id)
+
+    def test_the_platform_separator_is_rejected(self) -> None:
+        """On Windows a backslash separates; on POSIX it is an ordinary character."""
+        with pytest.raises(ValueError, match="case_id"):
+            validate_case_id(f"a{os.sep}b")
+
+    @pytest.mark.parametrize("case_id", ["case\x00id", "case\n", "\ncase", "case\x7f", "a\tb"])
+    def test_a_control_character_is_rejected(self, case_id: str) -> None:
+        """A NUL truncates the name under open(); the rest corrupt the audit log.
+
+        A trailing newline is the one that a `$`-anchored regex would have let
+        through, so it is pinned explicitly rather than left to the class.
+        """
         with pytest.raises(ValueError, match="case_id"):
             validate_case_id(case_id)
 
@@ -68,17 +102,40 @@ class TestWhatAValidIdLooksLike:
 
 
 class TestTheTraversalItWasBlocking:
-    def test_the_path_really_did_escape(self) -> None:
-        """Pin the premise rather than describing it."""
-        db_dir = Path("/home/analyst/.mulder/cases")
-        target = (db_dir / "../../../../home/analyst/cases/CASE-2024-007.db").resolve()
-        assert target == Path("/home/analyst/cases/CASE-2024-007.db")
-        assert db_dir.resolve() not in target.parents
+    """The security boundary, asserted without assuming a filesystem layout."""
 
-    def test_a_valid_id_stays_inside(self) -> None:
-        db_dir = Path("/home/analyst/.mulder/cases")
-        target = (db_dir / f"{validate_case_id('CASE-2024-007')}.db").resolve()
-        assert target.parent == db_dir.resolve()
+    def test_the_path_really_did_escape(self, tmp_path: Path) -> None:
+        """Pin the premise rather than describing it."""
+        db_dir = (tmp_path / "cases").resolve()
+        db_dir.mkdir()
+        escaping = "../../../../analyst/cases/CASE-2024-007"
+
+        target = (db_dir / f"{escaping}.db").resolve()
+
+        assert db_dir not in target.parents, "the premise: this ID left db_dir"
+        with pytest.raises(ValueError, match="case_id"):
+            validate_case_id(escaping)
+
+    @pytest.mark.parametrize(
+        "case_id", ["CASE-2024-007", "Incident 2026", "café", "-case", "case..2026", ".", ".."]
+    )
+    def test_an_accepted_id_stays_inside(self, tmp_path: Path, case_id: str) -> None:
+        """Every ID the validator accepts must land directly in db_dir."""
+        db_dir = (tmp_path / "cases").resolve()
+        db_dir.mkdir()
+
+        target = (db_dir / f"{validate_case_id(case_id)}.db").resolve()
+
+        assert target.parent == db_dir
+
+    def test_every_sidecar_suffix_stays_inside_too(self, tmp_path: Path) -> None:
+        """The .db path is not the only one an ID is interpolated into."""
+        db_dir = (tmp_path / "cases").resolve()
+        db_dir.mkdir()
+        case_id = validate_case_id("case..2026")
+
+        for suffix in (".db", ".audit.jsonl", ".report.md", ".plaso", ".iocs.stix.json"):
+            assert (db_dir / f"{case_id}{suffix}").resolve().parent == db_dir
 
 
 @pytest.fixture


### PR DESCRIPTION
## BLUF

- **A case ID becomes a filesystem path, and was never checked.** `db_dir / f"{case_id}.db"` plus every sidecar file beside it.
- **`slugify` was only applied to IDs mulder derived itself.** An ID supplied by an agent went to the filesystem verbatim: `case_id="../../../../home/analyst/cases/CASE-2024-007"` resolves to `/home/analyst/cases/CASE-2024-007.db` — outside the cases directory, and with `replace=True` created and deleted there.
- **`open_case` had a second hole:** `scan_evidence` and `create_case` both refuse to work on a case other than `MULDER_CASE_ID`; `open_case` did not consult it, so an agent pinned to CASE-A could attach to CASE-B and write every later finding there.
- **Fix:** one `validate_case_id()` next to `slugify`, called from all three entry points, plus the missing enforcement check in `open_case`.
- **Risk:** Low. The check is **containment only** — it rejects a path separator and nothing else about the ID's shape — so every case ID mulder accepts today keeps working.

## Priority

**high** — the input is attacker-influenced by design: `scan_evidence` renders file and directory names from the evidence tree back into the agent's context, so "an agent would not ask for that" is not a control that exists here. Both findings share one root cause and one fix.

## Review round 2 — the check was too strict

@calebevans was right on all three points; the whitelist has been removed.

**1. Too strict.** The old `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$` rejected IDs that mulder's CLI accepts today and that never leave `db_dir`. Confirmed against the old pattern:

```
Incident 2026   old: rejected   now: accepted
café            old: rejected   now: accepted
-case           old: rejected   now: accepted
case..2026      old: rejected   now: accepted
.hidden         old: rejected   now: accepted
```

The rule is now exactly what the fix needs and nothing more: **reject a case ID that contains a path separator.** Every use interpolates a suffix — `{case_id}.db`, `.audit.jsonl`, `.report.md`, `.plaso`, `.iocs.stix.json`, `.model_usage.json`, `.navigator.json` — so an ID with no separator is exactly one path component, and one component cannot be `.` or `..`. It cannot escape `db_dir`. (I grepped for a bare, unsuffixed `db_dir / case_id`; there is none, which is what makes `.` and `..` safe to accept.)

Separators come from `os.sep` / `os.altsep` plus `/`, so a backslash is an ordinary filename character on POSIX and a separator on Windows — platform-correct rather than hardcoded.

**2. The `$` anchor.** Moot: there is no regex any more, so no anchor and no `fullmatch` question. But the concrete case behind it — `case\n` slipping past a validator that claimed to reject whitespace — is still pinned, by the one restriction I kept beyond containment:

> **Control characters are rejected.** A NUL truncates the name in the C library under `open()`, so the file created is not the file named; the rest corrupt the `.audit.jsonl` records and log lines the ID is written into. Neither is ever intentional in a case ID.

This is the only strictness beyond pure containment, called out explicitly — say the word and I will drop it and rely on containment alone.

**3. The macOS-specific test.** `TestTheTraversalItWasBlocking` no longer hardcodes `/home`. It builds `db_dir` from pytest's `tmp_path`, calls `.resolve()` on it (which also absorbs the `/private` symlink on macOS), and asserts only the security boundary:

```python
db_dir = (tmp_path / "cases").resolve()
target = (db_dir / f"{escaping}.db").resolve()
assert db_dir not in target.parents          # the premise: it left db_dir
with pytest.raises(ValueError, match="case_id"):
    validate_case_id(escaping)
```

with the mirror property — every accepted ID lands directly in `db_dir` — parameterised over your four examples plus `.` and `..`, and repeated across all five sidecar suffixes.

## Review round 3 — `open_case` was the wrong place for the check

@calebevans found that the tool layer is not the only way in. `init_server()` at app.py:360–361 and the orchestrator's `ServerBridge` at `orchestrator/evidence.py:289–290` both call `load_case()` directly, so `load_case("../outside/evil")` still reached `CaseDB.open()`.

`validate_case_id(case_id)` is now the **first statement of `load_case()`** — the one place every path into a case database passes through. The call in `open_case` stays, but only so the tool layer can return a structured `invalid_input` response instead of raising; the docstring says so, so it does not read as duplication.

One refinement to the impact, because it changes what the regression test must build: `CaseDB.open()` raises `FileNotFoundError` when the path does not exist, so the reachable case is not "create a database anywhere" but the worse-behaved one — **attach to an existing SQLite file outside `db_dir` and run the schema migrations against it** (`_FTS_CREATE`, `_migrate_add_*`).

So the test plants a real case database outside `db_dir` and asserts it is never touched:

```python
CaseDB.create("evil", str(outside), outside).close()
before = sorted(p.name for p in outside.iterdir())

init_server(db_dir=db_dir)
with pytest.raises(ValueError, match="case_id"):
    load_case("../outside/evil")

assert sorted(p.name for p in outside.iterdir()) == before
```

`TestLoadCaseIsTheChokePoint` adds that, the same traversal through `init_server(case_id=...)`, and a legitimate case still opening.

Confirmed discriminating: reverting the single line makes both traversal tests fail with `DID NOT RAISE ValueError` — the call really did reach `CaseDB.open()` on the outside database.

## The path

```
db_dir  = /home/analyst/.mulder/cases
case_id = '../../../../home/analyst/cases/CASE-2024-007'
db_dir / f'{case_id}.db' -> /home/analyst/cases/CASE-2024-007.db
escapes the cases directory: True

case_id = '../shared/cases/CASE-B'
                         -> /home/analyst/.mulder/shared/cases/CASE-B.db
escapes the cases directory: True
```

`slugify` would have made either of those safe — it turns the first into `home-analyst-cases-case-2024-007` — but it was reached only when `case_id is None`.

## The fix

```python
_PATH_SEPARATORS = frozenset(s for s in (os.sep, os.altsep, "/") if s is not None)

def validate_case_id(case_id: str) -> str:
    if not case_id: raise ValueError(...)
    if _PATH_SEPARATORS.intersection(case_id): raise ValueError(...)
    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in case_id): raise ValueError(...)
    return case_id
```

Called from `load_case` (the choke point) and, for a structured error response rather than a raise, from `scan_evidence`, `create_case` and `open_case`; the two tool entry points return a normal `invalid_input` error response rather than raising.

`open_case` additionally gained the `MULDER_CASE_ID` check it alone lacked:

```python
if enforced_id and case_id != enforced_id:
    return error_response(..., error_type="forbidden")
```

Without it, `load_case` installs the other case as the active context and every subsequent `submit_finding` / `update_finding` / `submit_report` writes there instead.

## Tests

`tests/test_case_id_validation.py` — 43 tests:

- **14 accepted** IDs, including your four examples verbatim, `.hidden`, `中文`, `.` and `..`;
- **rejected**: separators (`a/b`, `/etc/passwd`, a trailing `/`, the traversals), `os.sep` for the running platform, and five control-character cases including a trailing newline and a NUL;
- **`validate_case_id(slugify(name))` for every awkward name**, so the two functions cannot drift apart and start refusing mulder's own derived IDs;
- the traversal boundary and its mirror, both built from `tmp_path`, plus a sidecar-suffix containment case;
- `open_case` refuses another case under `MULDER_CASE_ID`, still opens the enforced one, refuses a traversal before touching config, and is unchanged when no case is enforced.

`uvx pre-commit run --all-files` clean (ruff, ruff-format, mypy). `uv run --locked --extra dev pytest` — **785 passed**, whole suite, nothing deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

