### PR TITLE
[high] fix(case): record that an extraction finished, and stop feeding gzip to tar

### DIFF
--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -412,14 +412,6 @@ MAX_EXTRACT_BYTES = 20 * 1024**3
 MAX_EXTRACT_MEMBERS = 200_000
 """Cap on member count, for an archive of millions of tiny files."""
 
-MAX_COMPRESSION_RATIO = 500
-"""Cap on a single member's expansion factor.
-
-42.zip expands roughly a millionfold. Ordinary evidence -- logs, registry
-hives, memory strings -- compresses well but not like that; 500 leaves ample
-headroom while still refusing a bomb.
-"""
-
 
 class ArchiveLimitError(Exception):
     """An archive exceeded a resource limit and was not fully extracted."""
@@ -481,7 +473,7 @@ def _extract_zip(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
     handle the compression method (e.g. deflate64, LZMA).
 
     Raises:
-        ArchiveLimitError: If the archive exceeds a member, size or ratio cap.
+        ArchiveLimitError: If the archive exceeds the member or size cap.
     """
     skipped: list[str] = []
     try:
@@ -505,16 +497,6 @@ def _extract_zip(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
                     raise ArchiveLimitError(
                         f"{archive.name} expands to more than {MAX_EXTRACT_BYTES // 1024**3} GiB"
                     )
-                if (
-                    info.compress_size > 0
-                    and info.file_size / info.compress_size > MAX_COMPRESSION_RATIO
-                ):
-                    raise ArchiveLimitError(
-                        f"{archive.name}: member {info.filename!r} expands "
-                        f"{info.file_size // max(info.compress_size, 1)}x, over the "
-                        f"ratio limit of {MAX_COMPRESSION_RATIO}"
-                    )
-
                 zf.extract(info, dest)
     except (NotImplementedError, zipfile.BadZipFile):
         if not shutil.which("7z"):
@@ -598,7 +580,7 @@ def _extract_7z(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
 
     7-Zip refuses absolute and traversing member paths itself, and the sizes
     inside the archive are not visible to us before extraction, so this path
-    is bounded by ``_EXTRACT_TIMEOUT`` rather than by the byte and ratio caps
+    is bounded by ``_EXTRACT_TIMEOUT`` rather than by the member and byte caps
     the zip and tar paths apply. Anything it wrote outside *dest* would not
     appear in the listing either way.
 

--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -5,6 +5,7 @@ Tier 1 tools: help the agent orient before running any extractions.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import shutil
@@ -120,7 +121,6 @@ def _hash_and_register_evidence(manifest: list[dict[str, object]]) -> list[str]:
     Returns:
         List of file paths that failed to hash.
     """
-    import hashlib as _hashlib
 
     from mulder.server.app import get_ctx, has_ctx
 
@@ -133,7 +133,7 @@ def _hash_and_register_evidence(manifest: list[dict[str, object]]) -> list[str]:
         if not fp.is_file():
             continue
         try:
-            h = _hashlib.sha256()
+            h = hashlib.sha256()
             size = 0
             with open(fp, "rb") as f:
                 while True:
@@ -406,50 +406,208 @@ def verify_evidence_integrity() -> dict[str, object]:
     return result
 
 
-def _extract_zip(archive: Path, dest: Path) -> list[str]:
-    """Extract a zip archive to *dest* and return paths relative to *dest*.
+MAX_EXTRACT_BYTES = 20 * 1024**3
+"""Cap on total uncompressed output: 20 GiB."""
+
+MAX_EXTRACT_MEMBERS = 200_000
+"""Cap on member count, for an archive of millions of tiny files."""
+
+MAX_COMPRESSION_RATIO = 500
+"""Cap on a single member's expansion factor.
+
+42.zip expands roughly a millionfold. Ordinary evidence -- logs, registry
+hives, memory strings -- compresses well but not like that; 500 leaves ample
+headroom while still refusing a bomb.
+"""
+
+
+class ArchiveLimitError(Exception):
+    """An archive exceeded a resource limit and was not fully extracted."""
+
+
+def _is_contained(dest: Path, member_name: str) -> bool:
+    """Whether *member_name* stays inside *dest* once joined and resolved.
+
+    The previous test was ``member.startswith("/") or ".." in member``. As a
+    security control it adds nothing over CPython's own sanitisation, and as a
+    filter it is wrong in both directions: it rejects ``invoice..pdf``,
+    ``svchost..exe`` and ``Users/j..smith/NTUSER.DAT`` -- ordinary names, and
+    ordinary evidence -- while a component-wise traversal expressed some other
+    way would not be recognised. Resolving the joined path and checking
+    containment is the check that actually answers the question.
+
+    Args:
+        dest: The extraction root.
+        member_name: The archive member's name.
+
+    Returns:
+        True if extracting the member writes inside *dest*.
+    """
+    if not member_name or member_name.startswith(("/", "\\")):
+        return False
+    if "\x00" in member_name:
+        return False
+    resolved_dest = dest.resolve()
+    try:
+        target = (resolved_dest / member_name).resolve()
+    except (OSError, ValueError):
+        return False
+    return target == resolved_dest or resolved_dest in target.parents
+
+
+def _archive_slot(archive: Path) -> str:
+    """A per-archive extraction directory name that cannot collide.
+
+    ``<stem>`` alone collides whenever two hosts contribute an archive of the
+    same name, which in a triage case is the normal shape of the evidence
+    rather than an edge case. The parent path is hashed in so the name stays
+    readable and bounded.
+
+    Args:
+        archive: The resolved path of the archive.
+
+    Returns:
+        A single directory-name component.
+    """
+    digest = hashlib.sha256(str(archive.parent).encode()).hexdigest()[:12]
+    stem = slugify(archive.stem)
+    return f"{stem}-{digest}"
+
+
+def _extract_zip(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
+    """Extract a zip archive to *dest*; return (relative paths, skipped members).
 
     Falls back to the ``7z`` binary when Python's zipfile module cannot
     handle the compression method (e.g. deflate64, LZMA).
+
+    Raises:
+        ArchiveLimitError: If the archive exceeds a member, size or ratio cap.
     """
+    skipped: list[str] = []
     try:
         with zipfile.ZipFile(archive, "r") as zf:
-            for member in zf.namelist():
-                if member.startswith("/") or ".." in member:
-                    logger.warning("Skipping unsafe zip entry: %r", member)
+            infos = zf.infolist()
+            if len(infos) > MAX_EXTRACT_MEMBERS:
+                raise ArchiveLimitError(
+                    f"{archive.name} declares {len(infos)} members, over the "
+                    f"limit of {MAX_EXTRACT_MEMBERS}"
+                )
+
+            total = 0
+            for info in infos:
+                if not _is_contained(dest, info.filename):
+                    skipped.append(info.filename)
+                    logger.warning("Skipping zip entry outside dest: %r", info.filename)
                     continue
-                zf.extract(member, dest)
+
+                total += info.file_size
+                if total > MAX_EXTRACT_BYTES:
+                    raise ArchiveLimitError(
+                        f"{archive.name} expands to more than {MAX_EXTRACT_BYTES // 1024**3} GiB"
+                    )
+                if (
+                    info.compress_size > 0
+                    and info.file_size / info.compress_size > MAX_COMPRESSION_RATIO
+                ):
+                    raise ArchiveLimitError(
+                        f"{archive.name}: member {info.filename!r} expands "
+                        f"{info.file_size // max(info.compress_size, 1)}x, over the "
+                        f"ratio limit of {MAX_COMPRESSION_RATIO}"
+                    )
+
+                zf.extract(info, dest)
     except (NotImplementedError, zipfile.BadZipFile):
         if not shutil.which("7z"):
             raise
         return _extract_7z(archive, dest)
+    return _listing(dest), skipped
+
+
+def _listing(dest: Path) -> list[str]:
+    """Files under *dest*, as paths relative to it."""
     return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
 
 
 def _safe_tar_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
-    """Allow extraction but neutralize absolute symlinks and path traversal."""
-    if member.name.startswith("/") or ".." in member.name:
+    """Drop a tar member that would write outside *path*, else allow it.
+
+    The previous test was ``member.name.startswith("/") or ".." in member.name``.
+    As a filter that is wrong in both directions: it rejects ordinary evidence
+    names such as ``Users/j..smith/NTUSER.DAT``, and it answers a question
+    about substrings rather than about where the member actually lands.
+    Containment is now decided by resolving the joined path.
+
+    Args:
+        member: The tar member under consideration.
+        path: The extraction root.
+
+    Returns:
+        The member, possibly with an absolute link target made relative, or
+        None to skip it.
+    """
+    dest = Path(path)
+    if not _is_contained(dest, member.name):
         return None
     if member.issym() or member.islnk():
-        if ".." in member.linkname:
+        if not _is_contained(dest, member.linkname.lstrip("/")):
             return None
-        if member.linkname.startswith("/"):
-            member.linkname = member.linkname.lstrip("/")
+        member.linkname = member.linkname.lstrip("/")
     return member
 
 
-def _extract_tar(archive: Path, dest: Path) -> list[str]:
-    """Extract a tar/tar-compressed archive to *dest*; return relative file paths."""
+def _extract_tar(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
+    """Extract a tar/tar-compressed archive to *dest*.
+
+    Returns:
+        (relative file paths, skipped member names).
+
+    Raises:
+        ArchiveLimitError: If the archive exceeds a member or size cap.
+    """
+    skipped: list[str] = []
+    total = 0
+    count = 0
+
     with tarfile.open(archive, "r:*") as tf:
-        tf.extractall(dest, filter=_safe_tar_filter)
-    return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
+        for member in tf:
+            count += 1
+            if count > MAX_EXTRACT_MEMBERS:
+                raise ArchiveLimitError(
+                    f"{archive.name} holds more than {MAX_EXTRACT_MEMBERS} members"
+                )
+
+            checked = _safe_tar_filter(member, str(dest))
+            if checked is None:
+                skipped.append(member.name)
+                logger.warning("Skipping tar entry outside dest: %r", member.name)
+                continue
+
+            total += checked.size
+            if total > MAX_EXTRACT_BYTES:
+                raise ArchiveLimitError(
+                    f"{archive.name} expands to more than {MAX_EXTRACT_BYTES // 1024**3} GiB"
+                )
+
+            tf.extract(checked, dest, filter="tar")
+
+    return _listing(dest), skipped
 
 
-def _extract_7z(archive: Path, dest: Path) -> list[str]:
-    """Extract via the ``7z`` CLI to *dest*; return paths relative to *dest*."""
+def _extract_7z(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
+    """Extract via the ``7z`` CLI to *dest*.
+
+    7-Zip refuses absolute and traversing member paths itself, and the sizes
+    inside the archive are not visible to us before extraction, so this path
+    is bounded by ``_EXTRACT_TIMEOUT`` rather than by the byte and ratio caps
+    the zip and tar paths apply. Anything it wrote outside *dest* would not
+    appear in the listing either way.
+
+    Returns:
+        (relative file paths, skipped member names -- always empty here).
+    """
     cmd = ["7z", "x", f"-o{dest}", "-y", str(archive)]
     subprocess.run(cmd, capture_output=True, timeout=_EXTRACT_TIMEOUT, check=True)
-    return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
+    return _listing(dest), []
 
 
 @mcp.tool()
@@ -489,11 +647,30 @@ def extract_archive(
             error_type="file_not_found",
         )
 
+    cfg = get_cfg()
+    extract_root = (cfg.db_dir / "extracted").resolve()
+
     if extract_to:
         dest = Path(extract_to).expanduser().resolve()
+        # The docstring says output goes under the mulder cases directory.
+        # Honouring an arbitrary destination turns "extract this evidence"
+        # into "write these attacker-supplied files wherever you can reach",
+        # and the archive and the steer can both come from the evidence tree.
+        if dest != extract_root and extract_root not in dest.parents:
+            return error_response(
+                tc_id,
+                "extract_archive",
+                params,
+                f"extract_to must be inside {extract_root}; got {dest}",
+                (time.monotonic() - t0) * 1000,
+                error_type="invalid_input",
+            )
     else:
-        cfg = get_cfg()
-        dest = cfg.db_dir / "extracted" / archive.stem
+        # Keyed by the archive's location, not just its name: a case routinely
+        # holds /evidence/host1/logs.zip and /evidence/host2/logs.zip, and a
+        # bare stem gives both the same directory -- so the second call sees a
+        # populated directory and hands back the first host's files.
+        dest = extract_root / _archive_slot(archive)
 
     # Idempotent: if already extracted, return the existing files
     if dest.exists() and any(dest.iterdir()):
@@ -532,13 +709,13 @@ def extract_archive(
 
     try:
         if ext == ".zip":
-            files = _extract_zip(archive, dest)
+            files, skipped = _extract_zip(archive, dest)
         elif (
             ext in (".tar", ".tgz")
             or name_lower.endswith((".tar.gz", ".tar.bz2"))
             or (ext in (".gz", ".bz2") and ".tar" not in name_lower)
         ):
-            files = _extract_tar(archive, dest)
+            files, skipped = _extract_tar(archive, dest)
         elif ext in (".7z", ".rar") or ".7z." in name_lower:
             if not shutil.which("7z"):
                 return error_response(
@@ -549,7 +726,7 @@ def extract_archive(
                     (time.monotonic() - t0) * 1000,
                     error_type="binary_missing",
                 )
-            files = _extract_7z(archive, dest)
+            files, skipped = _extract_7z(archive, dest)
         else:
             return error_response(
                 tc_id,
@@ -559,6 +736,20 @@ def extract_archive(
                 (time.monotonic() - t0) * 1000,
                 error_type="unsupported_format",
             )
+    except ArchiveLimitError as exc:
+        # Whatever landed before the limit was hit stays on disk; saying how
+        # much is the difference between "this archive is hostile" and "the
+        # tool broke".
+        partial = _listing(dest)
+        return error_response(
+            tc_id,
+            "extract_archive",
+            params,
+            f"Refusing to extract {archive.name}: {exc}. "
+            f"{len(partial)} file(s) were written to {dest} before the limit was reached.",
+            (time.monotonic() - t0) * 1000,
+            error_type="resource_limit",
+        )
     except Exception as exc:
         logger.error("Archive extraction failed for %r: %s", archive, exc)
         return error_response(
@@ -602,10 +793,16 @@ def extract_archive(
         "total_files_extracted": len(files),
         "type_summary": type_counts,
         "total_evidence_items": len(manifest),
+        # A dropped member was previously visible only in the log, while the
+        # response still said "success" with a file list that had never
+        # contained it. An analyst cannot chase evidence they are not told is
+        # missing.
+        "skipped_members": skipped,
         "message": (
             f"Extracted {len(files)} file(s) to {dest}. "
             f"Found {len(manifest)} evidence item(s). "
-            "Use scan_evidence on the extracted directory to create a case, "
+            + (f"{len(skipped)} member(s) were skipped as unsafe to extract. " if skipped else "")
+            + "Use scan_evidence on the extracted directory to create a case, "
             "or run extraction tools directly on the evidence files."
         ),
     }

--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -5,14 +5,19 @@ Tier 1 tools: help the agent orient before running any extractions.
 
 from __future__ import annotations
 
+import bz2
+import gzip
 import hashlib
+import json
 import logging
+import lzma
 import os
 import shutil
 import subprocess
 import tarfile
 import time
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mulder.server.app import (
@@ -447,6 +452,53 @@ def _is_contained(dest: Path, member_name: str) -> bool:
     return target == resolved_dest or resolved_dest in target.parents
 
 
+_COMPLETION_MARKER = ".mulder-extraction-complete.json"
+"""Written only after an extraction finishes, and read to decide idempotency."""
+
+
+def _extraction_is_complete(dest: Path, archive: Path) -> bool:
+    """Whether *dest* holds a finished extraction of *archive*.
+
+    Args:
+        dest: The extraction directory.
+        archive: The archive it should contain.
+
+    Returns:
+        True only if a completion marker is present and names this archive at
+        its current size. A directory that merely has files in it is a
+        previous attempt that may have failed part-way.
+    """
+    marker = dest / _COMPLETION_MARKER
+    if not marker.is_file():
+        return False
+    try:
+        recorded = json.loads(marker.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    try:
+        size = archive.stat().st_size
+    except OSError:
+        return False
+    return bool(recorded.get("archive") == str(archive) and recorded.get("archive_size") == size)
+
+
+def _mark_extraction_complete(dest: Path, archive: Path, file_count: int) -> None:
+    """Record that *archive* was fully extracted into *dest*."""
+    try:
+        (dest / _COMPLETION_MARKER).write_text(
+            json.dumps(
+                {
+                    "archive": str(archive),
+                    "archive_size": archive.stat().st_size,
+                    "files": file_count,
+                    "completed_utc": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+    except OSError as exc:  # pragma: no cover - a full disk, already reported
+        logger.warning("Could not write extraction marker in %s: %s", dest, exc)
+
+
 def _archive_slot(archive: Path) -> str:
     """A per-archive extraction directory name that cannot collide.
 
@@ -506,8 +558,16 @@ def _extract_zip(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
 
 
 def _listing(dest: Path) -> list[str]:
-    """Files under *dest*, as paths relative to it."""
-    return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
+    """Files under *dest*, as paths relative to it.
+
+    The completion marker is mulder's own bookkeeping, not extracted evidence,
+    so it never appears in a file list handed to an analyst or an agent.
+    """
+    return [
+        str(f.relative_to(dest))
+        for f in dest.rglob("*")
+        if f.is_file() and f.name != _COMPLETION_MARKER
+    ]
 
 
 def _safe_tar_filter(member: tarfile.TarInfo, path: str) -> tarfile.TarInfo | None:
@@ -573,6 +633,48 @@ def _extract_tar(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
             tf.extract(checked, dest, filter="tar")
 
     return _listing(dest), skipped
+
+
+_SINGLE_FILE_DECOMPRESSORS: dict[str, object] = {
+    ".gz": gzip.open,
+    ".bz2": bz2.open,
+    ".xz": lzma.open,
+    ".lzma": lzma.open,
+}
+"""Compressors that wrap one file rather than an archive."""
+
+
+def _extract_single_file(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
+    """Decompress a plain .gz/.bz2/.xz stream into *dest*.
+
+    ``auth.log.gz`` is a gzip stream, not a tar. Handing it to
+    ``tarfile.open(..., "r:*")`` raises ``ReadError: file could not be opened
+    successfully``, so compressed single-file evidence -- which is most of the
+    Linux logs in a triage collection -- always failed to extract.
+
+    Returns:
+        (relative file paths, skipped member names -- always empty here).
+
+    Raises:
+        ArchiveLimitError: If the stream expands past the size cap.
+    """
+    opener = _SINGLE_FILE_DECOMPRESSORS[archive.suffix.lower()]
+    out_name = archive.stem or archive.name
+    out_path = dest / out_name
+
+    written = 0
+    with opener(archive, "rb") as src, out_path.open("wb") as dst:  # type: ignore[operator]
+        while chunk := src.read(1024 * 1024):
+            written += len(chunk)
+            if written > MAX_EXTRACT_BYTES:
+                dst.close()
+                out_path.unlink(missing_ok=True)
+                raise ArchiveLimitError(
+                    f"{archive.name} expands to more than {MAX_EXTRACT_BYTES // 1024**3} GiB"
+                )
+            dst.write(chunk)
+
+    return _listing(dest), []
 
 
 def _extract_7z(archive: Path, dest: Path) -> tuple[list[str], list[str]]:
@@ -654,9 +756,13 @@ def extract_archive(
         # populated directory and hands back the first host's files.
         dest = extract_root / _archive_slot(archive)
 
-    # Idempotent: if already extracted, return the existing files
-    if dest.exists() and any(dest.iterdir()):
-        existing_files = [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
+    # Idempotent, but only for an extraction that actually finished. A
+    # non-empty directory is not evidence of completion: a run that timed out
+    # after 40 of 900 files leaves one behind, and treating that as done
+    # returned those 40 with a message to proceed, losing the other 860
+    # silently. Completion is recorded explicitly instead.
+    if _extraction_is_complete(dest, archive):
+        existing_files = _listing(dest)
         result: dict[str, object] = {
             "tool_call_id": tc_id,
             "status": "already_extracted",
@@ -692,12 +798,14 @@ def extract_archive(
     try:
         if ext == ".zip":
             files, skipped = _extract_zip(archive, dest)
-        elif (
-            ext in (".tar", ".tgz")
-            or name_lower.endswith((".tar.gz", ".tar.bz2"))
-            or (ext in (".gz", ".bz2") and ".tar" not in name_lower)
+        elif ext in (".tar", ".tgz", ".tbz2", ".txz") or name_lower.endswith(
+            (".tar.gz", ".tar.bz2", ".tar.xz")
         ):
             files, skipped = _extract_tar(archive, dest)
+        elif ext in _SINGLE_FILE_DECOMPRESSORS:
+            # A plain .gz/.bz2/.xz wraps one file, not an archive; tarfile
+            # cannot read it.
+            files, skipped = _extract_single_file(archive, dest)
         elif ext in (".7z", ".rar") or ".7z." in name_lower:
             if not shutil.which("7z"):
                 return error_response(
@@ -766,6 +874,8 @@ def extract_archive(
     for mi in manifest:
         t = str(mi["artifact_type"])
         type_counts[t] = type_counts.get(t, 0) + 1
+
+    _mark_extraction_complete(dest, archive, len(files))
 
     result = {
         "tool_call_id": tc_id,

--- a/tests/test_archive_completion.py
+++ b/tests/test_archive_completion.py
@@ -1,0 +1,185 @@
+"""Two ways ``extract_archive`` reported the wrong files.
+
+**A partial extraction read as a finished one.** The idempotency check was
+``dest.exists() and any(dest.iterdir())``. A run that hit the 600 s timeout
+after writing 40 of 900 files leaves a non-empty directory behind; the retry
+saw it, returned ``status: already_extracted`` with those 40 files and a
+message telling the agent to proceed with analysis, and the other 860 were
+never mentioned again. Completion is now recorded explicitly and read back.
+
+**Plain compressed files were routed to tarfile.** The dispatch sent any
+``.gz``/``.bz2`` whose name did not contain ``.tar`` to ``_extract_tar``::
+
+    or (ext in (".gz", ".bz2") and ".tar" not in name_lower)
+
+``auth.log.gz`` is a gzip stream, not a tar, so ``tarfile.open(..., "r:*")``
+raises ``ReadError: file could not be opened successfully`` and the log --
+which ``scan_evidence`` had classified as evidence and told the agent to
+extract -- never reached the case. Compressed single-file logs are most of the
+Linux evidence in a triage collection.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import lzma
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from mulder.server.tools.case import (
+    _COMPLETION_MARKER,
+    ArchiveLimitError,
+    _extract_single_file,
+    _extract_tar,
+    _extraction_is_complete,
+    _listing,
+    _mark_extraction_complete,
+)
+
+
+@pytest.fixture
+def archive(tmp_path: Path) -> Path:
+    path = tmp_path / "triage.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("a.txt", "one")
+    return path
+
+
+class TestCompletionIsRecordedNotInferred:
+    def test_a_fresh_directory_is_not_complete(self, tmp_path: Path, archive: Path) -> None:
+        dest = tmp_path / "out"
+        dest.mkdir()
+        assert _extraction_is_complete(dest, archive) is False
+
+    def test_a_partial_extraction_is_not_complete(self, tmp_path: Path, archive: Path) -> None:
+        """The bug: files on disk from a run that never finished."""
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "partial-1.evtx").write_text("x")
+        (dest / "partial-2.evtx").write_text("x")
+
+        assert any(dest.iterdir()), "the old check would have said yes here"
+        assert _extraction_is_complete(dest, archive) is False
+
+    def test_a_finished_extraction_is_complete(self, tmp_path: Path, archive: Path) -> None:
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "a.txt").write_text("one")
+        _mark_extraction_complete(dest, archive, 1)
+
+        assert _extraction_is_complete(dest, archive) is True
+
+    def test_a_marker_for_a_different_archive_does_not_count(
+        self, tmp_path: Path, archive: Path
+    ) -> None:
+        other = tmp_path / "other.zip"
+        with zipfile.ZipFile(other, "w") as z:
+            z.writestr("b.txt", "two")
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        _mark_extraction_complete(dest, other, 1)
+
+        assert _extraction_is_complete(dest, archive) is False
+
+    def test_a_changed_archive_invalidates_the_marker(self, tmp_path: Path, archive: Path) -> None:
+        """Re-collected evidence under the same name must not be skipped."""
+        dest = tmp_path / "out"
+        dest.mkdir()
+        _mark_extraction_complete(dest, archive, 1)
+
+        with zipfile.ZipFile(archive, "w") as z:
+            z.writestr("a.txt", "one")
+            z.writestr("b.txt", "a second file, so the size differs")
+
+        assert _extraction_is_complete(dest, archive) is False
+
+    def test_a_corrupt_marker_is_not_trusted(self, tmp_path: Path, archive: Path) -> None:
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / _COMPLETION_MARKER).write_text("{not json")
+
+        assert _extraction_is_complete(dest, archive) is False
+
+    def test_the_marker_is_not_reported_as_evidence(self, tmp_path: Path, archive: Path) -> None:
+        """It is mulder's bookkeeping, not a file that came out of the archive."""
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "a.txt").write_text("one")
+        _mark_extraction_complete(dest, archive, 1)
+
+        assert _listing(dest) == ["a.txt"]
+
+
+class TestSingleFileDecompression:
+    def test_a_plain_gzip_log_is_extracted(self, tmp_path: Path) -> None:
+        content = "Failed password for root from 10.0.0.1\n" * 100
+        path = tmp_path / "auth.log.gz"
+        with gzip.open(path, "wt") as fh:
+            fh.write(content)
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files, skipped = _extract_single_file(path, dest)
+
+        assert files == ["auth.log"]
+        assert skipped == []
+        assert (dest / "auth.log").read_text() == content
+
+    def test_tarfile_really_cannot_read_it(self, tmp_path: Path) -> None:
+        """Pin the premise: this is what the old dispatch did with it."""
+        path = tmp_path / "auth.log.gz"
+        with gzip.open(path, "wt") as fh:
+            fh.write("some log line\n")
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(tarfile.ReadError):
+            _extract_tar(path, dest)
+
+    def test_bzip2_and_xz_are_handled(self, tmp_path: Path) -> None:
+        for name, opener in (("a.log.bz2", bz2.open), ("b.log.xz", lzma.open)):
+            path = tmp_path / name
+            with opener(path, "wt") as fh:  # type: ignore[operator]
+                fh.write("line\n")
+            dest = tmp_path / f"out-{name}"
+            dest.mkdir()
+            files, _ = _extract_single_file(path, dest)
+            assert files == [name.rsplit(".", 1)[0]]
+
+    def test_a_decompression_bomb_is_refused(self, tmp_path: Path) -> None:
+        """A .gz of zeroes expands without limit; the cap must still apply."""
+        from mulder.server.tools import case as case_module
+
+        path = tmp_path / "bomb.log.gz"
+        with gzip.open(path, "wb") as fh:
+            fh.write(b"\0" * (8 * 1024 * 1024))
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        original = case_module.MAX_EXTRACT_BYTES
+        case_module.MAX_EXTRACT_BYTES = 1024
+        try:
+            with pytest.raises(ArchiveLimitError):
+                _extract_single_file(path, dest)
+        finally:
+            case_module.MAX_EXTRACT_BYTES = original
+
+        assert _listing(dest) == [], "the partial output must not be left behind"
+
+    def test_a_tar_gz_is_still_a_tar(self, tmp_path: Path) -> None:
+        """The dispatch must not send .tar.gz down the single-file path."""
+        member = tmp_path / "inside.txt"
+        member.write_text("evidence")
+        path = tmp_path / "bundle.tar.gz"
+        with tarfile.open(path, "w:gz") as tf:
+            tf.add(member, arcname="inside.txt")
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files, _ = _extract_tar(path, dest)
+        assert files == ["inside.txt"]

--- a/tests/test_archive_containment.py
+++ b/tests/test_archive_containment.py
@@ -1,0 +1,202 @@
+"""Archive extraction trusted both the archive and the caller.
+
+Four boundaries were missing or wrong.
+
+**The destination.** ``extract_archive`` accepted an arbitrary ``extract_to``,
+expanded it and used it verbatim, contradicting its own docstring ("creates a
+directory under the mulder cases dir"). A malicious archive plus a steered
+destination writes attacker-chosen files anywhere the process can reach --
+and both the archive and the steer can come from the evidence tree, which
+``scan_evidence`` renders back into the agent's context.
+
+**The default destination.** ``<db_dir>/extracted/<archive.stem>`` ignores
+where the archive came from. A case holding ``/evidence/host1/logs.zip`` and
+``/evidence/host2/logs.zip`` gives both the same directory, so the second call
+finds it populated and returns **host 1's files** as ``already_extracted``,
+with a message telling the agent to analyse them. In a triage case that is the
+normal shape of the evidence, not an edge case.
+
+**The member filter.** ``member.startswith("/") or ".." in member`` answers a
+question about substrings, not about where the member lands. It drops
+``logs/app..2024-03-01.log`` and ``Users/j..smith/NTUSER.DAT`` -- ordinary
+evidence -- and reports success with a file list that never contained them, so
+the caller cannot tell anything was lost.
+
+**Resource limits.** There were none: no cap on uncompressed size, member
+count or compression ratio, and no timeout at all on the Python paths. The
+tool's own ``scan_evidence`` message tells the agent to extract any archive it
+finds, so a 42.zip in the evidence fills the filesystem holding the live case
+database.
+"""
+
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from mulder.server.tools.case import (
+    MAX_COMPRESSION_RATIO,
+    ArchiveLimitError,
+    _archive_slot,
+    _extract_tar,
+    _extract_zip,
+    _is_contained,
+    _safe_tar_filter,
+)
+
+
+class TestContainment:
+    @pytest.mark.parametrize(
+        "name",
+        ["../../etc/passwd", "a/../../b", "/etc/passwd", "\\\\windows\\\\system32", "", "a\x00b"],
+    )
+    def test_rejected(self, tmp_path: Path, name: str) -> None:
+        assert _is_contained(tmp_path, name) is False
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "normal.txt",
+            "sub/dir/file.txt",
+            "invoice..pdf",
+            "logs/app..2024-03-01.log",
+            "Users/j..smith/NTUSER.DAT",
+            "v1..2/config",
+        ],
+    )
+    def test_accepted(self, tmp_path: Path, name: str) -> None:
+        """Every one of these was dropped by the substring check."""
+        assert _is_contained(tmp_path, name) is True
+
+
+class TestZipExtraction:
+    @staticmethod
+    def _archive(tmp_path: Path, names: dict[str, str]) -> Path:
+        path = tmp_path / "a.zip"
+        with zipfile.ZipFile(path, "w") as z:
+            for name, content in names.items():
+                z.writestr(name, content)
+        return path
+
+    def test_a_traversing_member_is_not_written(self, tmp_path: Path) -> None:
+        archive = self._archive(tmp_path, {"../../escaped.txt": "pwned", "normal.txt": "ok"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+
+        files, skipped = _extract_zip(archive, dest)
+
+        assert files == ["normal.txt"]
+        assert skipped == ["../../escaped.txt"]
+        assert not (tmp_path.parent / "escaped.txt").exists()
+
+    def test_legitimately_named_evidence_is_kept(self, tmp_path: Path) -> None:
+        """The names the old filter silently discarded."""
+        archive = self._archive(
+            tmp_path,
+            {
+                "logs/app..2024-03-01.log": "evidence",
+                "Users/j..smith/NTUSER.DAT": "evidence",
+            },
+        )
+        dest = tmp_path / "out"
+        dest.mkdir()
+
+        files, skipped = _extract_zip(archive, dest)
+
+        assert sorted(files) == [
+            "Users/j..smith/NTUSER.DAT",
+            "logs/app..2024-03-01.log",
+        ]
+        assert skipped == []
+
+    def test_a_bomb_is_refused(self, tmp_path: Path) -> None:
+        path = tmp_path / "bomb.zip"
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+            z.writestr("big", b"\0" * (50 * 1024 * 1024))
+
+        info = zipfile.ZipFile(path).infolist()[0]
+        ratio = info.file_size / info.compress_size
+        assert ratio > MAX_COMPRESSION_RATIO, "the fixture must actually be a bomb"
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(ArchiveLimitError, match="ratio limit"):
+            _extract_zip(path, dest)
+
+    def test_ordinary_compression_is_not_refused(self, tmp_path: Path) -> None:
+        """Logs compress well; the limit must leave room for real evidence."""
+        path = tmp_path / "logs.zip"
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+            z.writestr("auth.log", "Failed password for root from 10.0.0.1\n" * 20_000)
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files, _ = _extract_zip(path, dest)
+        assert files == ["auth.log"]
+
+
+class TestTarExtraction:
+    def test_a_traversing_member_is_skipped(self, tmp_path: Path) -> None:
+        payload = tmp_path / "payload"
+        payload.write_text("pwned")
+        archive = tmp_path / "a.tar"
+        with tarfile.open(archive, "w") as tf:
+            tf.add(payload, arcname="../../escaped.txt")
+            tf.add(payload, arcname="normal.txt")
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files, skipped = _extract_tar(archive, dest)
+
+        assert files == ["normal.txt"]
+        assert skipped == ["../../escaped.txt"]
+
+    def test_a_symlink_out_of_the_tree_is_skipped(self, tmp_path: Path) -> None:
+        archive = tmp_path / "a.tar"
+        with tarfile.open(archive, "w") as tf:
+            member = tarfile.TarInfo("link")
+            member.type = tarfile.SYMTYPE
+            member.linkname = "../../../../etc/shadow"
+            tf.addfile(member)
+
+        dest = tmp_path / "out"
+        dest.mkdir()
+        files, skipped = _extract_tar(archive, dest)
+
+        assert files == []
+        assert skipped == ["link"]
+
+    def test_the_filter_still_relativises_an_absolute_link(self, tmp_path: Path) -> None:
+        member = tarfile.TarInfo("link.txt")
+        member.type = tarfile.SYMTYPE
+        member.linkname = "/usr/lib/libfoo.so"
+
+        result = _safe_tar_filter(member, str(tmp_path))
+
+        assert result is not None
+        assert result.linkname == "usr/lib/libfoo.so"
+
+
+class TestTheDestinationName:
+    def test_two_hosts_do_not_collide(self) -> None:
+        """The whole reason the idempotency check returned the wrong host."""
+        one = _archive_slot(Path("/evidence/host1/logs.zip"))
+        two = _archive_slot(Path("/evidence/host2/logs.zip"))
+        assert one != two
+
+    def test_it_is_a_single_path_segment(self) -> None:
+        slot = _archive_slot(Path("/evidence/host 1/My Logs (final).zip"))
+        assert "/" not in slot
+        assert ".." not in slot
+
+    def test_it_is_stable(self) -> None:
+        """Idempotency depends on the same archive producing the same slot."""
+        assert _archive_slot(Path("/evidence/host1/logs.zip")) == _archive_slot(
+            Path("/evidence/host1/logs.zip")
+        )
+
+    def test_the_archive_name_is_still_readable_in_it(self) -> None:
+        assert _archive_slot(Path("/evidence/host1/logs.zip")).startswith("logs-")

--- a/tests/test_archive_containment.py
+++ b/tests/test_archive_containment.py
@@ -23,7 +23,7 @@ evidence -- and reports success with a file list that never contained them, so
 the caller cannot tell anything was lost.
 
 **Resource limits.** There were none: no cap on uncompressed size, member
-count or compression ratio, and no timeout at all on the Python paths. The
+count, and no timeout at all on the Python paths. The
 tool's own ``scan_evidence`` message tells the agent to extract any archive it
 finds, so a 42.zip in the evidence fills the filesystem holding the live case
 database.
@@ -38,7 +38,6 @@ from pathlib import Path
 import pytest
 
 from mulder.server.tools.case import (
-    MAX_COMPRESSION_RATIO,
     ArchiveLimitError,
     _archive_slot,
     _extract_tar,
@@ -113,18 +112,49 @@ class TestZipExtraction:
         assert skipped == []
 
     def test_a_bomb_is_refused(self, tmp_path: Path) -> None:
+        """The declared output size is what stops it, not how well it packed."""
+        from mulder.server.tools import case as case_module
+
         path = tmp_path / "bomb.zip"
         with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
             z.writestr("big", b"\0" * (50 * 1024 * 1024))
 
+        dest = tmp_path / "out"
+        dest.mkdir()
+        original = case_module.MAX_EXTRACT_BYTES
+        case_module.MAX_EXTRACT_BYTES = 1024 * 1024
+        try:
+            with pytest.raises(ArchiveLimitError, match="expands to more than"):
+                _extract_zip(path, dest)
+        finally:
+            case_module.MAX_EXTRACT_BYTES = original
+
+    def test_a_zeroed_memory_region_is_not_a_bomb(self, tmp_path: Path) -> None:
+        """Evidence full of zeroes is ordinary, and must still extract.
+
+        Unallocated regions of a ``dd`` image and a freshly booted VM's memory
+        dump are mostly zeroes, so they hit deflate's ~1032x ceiling -- the
+        same figure as a hostile archive. A per-member expansion-ratio cap
+        cannot tell the two apart, which is why this code does not have one:
+        the total-output cap already bounds the damage, and it bounds it by
+        the number that actually matters, bytes written to disk.
+        """
+        path = tmp_path / "mem.zip"
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+            z.writestr("mem.raw", b"\0" * (64 * 1024 * 1024))
+
         info = zipfile.ZipFile(path).infolist()[0]
-        ratio = info.file_size / info.compress_size
-        assert ratio > MAX_COMPRESSION_RATIO, "the fixture must actually be a bomb"
+        assert info.file_size / info.compress_size > 1000, (
+            "the fixture must compress like a bomb for this test to mean anything"
+        )
 
         dest = tmp_path / "out"
         dest.mkdir()
-        with pytest.raises(ArchiveLimitError, match="ratio limit"):
-            _extract_zip(path, dest)
+        files, skipped = _extract_zip(path, dest)
+
+        assert files == ["mem.raw"]
+        assert skipped == []
+        assert (dest / "mem.raw").stat().st_size == 64 * 1024 * 1024
 
     def test_ordinary_compression_is_not_refused(self, tmp_path: Path) -> None:
         """Logs compress well; the limit must leave room for real evidence."""


### PR DESCRIPTION
## BLUF

- **A partial extraction was reported as a complete one.** The idempotency check was `dest.exists() and any(dest.iterdir())`. A run that timed out after 40 of 900 files leaves a non-empty directory; the retry returned those 40 as `already_extracted` and told the agent to proceed. The other 860 were never mentioned again.
- **Plain `.gz`/`.bz2` evidence was handed to tarfile.** `auth.log.gz` is a gzip stream, not a tar — `tarfile.open(..., "r:*")` raises `ReadError`, so compressed single-file logs never reached the case.
- **Fix:** record completion explicitly in a marker naming the archive and its size, and give single-file compressors their own path.
- **Risk:** Low. Both changes make the tool do what its callers already assume; existing tar and zip handling is unchanged and tested in both directions.

## Priority

**high** — an incomplete evidence set presented as a complete one is the failure that matters most in a forensic tool: nothing downstream can tell that 860 files are missing, and the message actively directs the agent to analyse what is there.

## Stacked on #84

Based on `fix/archive-containment`, which rewrites the same extractors. Review #84 first.

Rebased after #84 dropped its compression-ratio cap (it would have refused a zeroed memory dump). `_extract_single_file` here is bounded by the total-output cap only, for the same reason.

## Completion is recorded, not inferred

A non-empty directory is not evidence that an extraction finished. It is now written down:

```json
{"archive": "/evidence/host1/triage.zip", "archive_size": 84213760,
 "files": 900, "completed_utc": "..."}
```

and read back before the idempotent branch is taken. Consequences, each tested:

- a directory with files but no marker is a previous attempt, so the archive is extracted again;
- **re-collected evidence under the same name invalidates the marker**, because its size differs — otherwise a second acquisition would silently return the first one's contents;
- a marker naming a different archive does not count, and a corrupt marker is not trusted;
- the marker never appears in a file list handed to an analyst or an agent.

## `.gz` is not a tar

```python
or (ext in (".gz", ".bz2") and ".tar" not in name_lower)   # -> _extract_tar
```

`scan_evidence` classifies `auth.log.gz` as evidence and tells the agent to extract it; `extract_archive` then returns `Extraction failed: file could not be opened successfully`. Compressed single-file logs are most of the Linux evidence in a triage collection.

`.gz`, `.bz2`, `.xz` and `.lzma` now go to a single-file decompressor that streams to disk under the same size cap #84 introduced (with the partial output removed if the cap trips). `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tgz`, `.tbz2` and `.txz` still go to tar.

A test pins the premise rather than describing it — `pytest.raises(tarfile.ReadError)` on a real gzip file — and another asserts a real `.tar.gz` still takes the tar path, so the dispatch cannot drift the other way.

## Tests

New `tests/test_archive_completion.py` (12 tests), all against real archives and real gzip/bzip2/xz streams written by the test.

`make lint format typecheck test` — 777 passed, mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
