### PR TITLE
[high] fix(sqlite): escape evidence paths before they become a URI

### DIFF
--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Mapping, Sequence
 from contextvars import ContextVar
 from pathlib import Path
 from typing import Any, ParamSpec
+from urllib.parse import quote
 from uuid import uuid4
 
 from mulder.server.app import get_ctx, has_ctx
@@ -31,6 +32,45 @@ TOOL_TIMEOUT: int = 600
 
 _GIB_THRESHOLD = 4
 """File size (GiB) below which no extra time is added."""
+
+
+def readonly_sqlite_uri(db_path: Path | str) -> str:
+    """Build a read-only ``file:`` URI for *db_path*, escaping URI syntax.
+
+    ``f"file:{db_path}?mode=ro"`` is not safe for a path that came out of an
+    evidence tree, because the filename is pasted into a URI without being
+    escaped. Filenames like these are ordinary, not hostile:
+
+    ``sms#2024-03-12.db``
+        ``#`` opens a URI fragment, so the path is truncated to ``sms`` and
+        ``?mode=ro`` lands inside the discarded fragment. SQLite then creates
+        and opens an empty ``sms`` **inside the evidence directory**, and the
+        caller reports that the database has no tables.
+
+    ``chat?mode=rwc.db``
+        ``?`` starts the query, so the caller's parameters are appended to the
+        attacker's and the connection is refused outright -- the database is
+        silently dropped from the analysis by the surrounding
+        ``except sqlite3.Error``.
+
+    ``report%20final.db``
+        SQLite percent-decodes the path when ``%`` is followed by two hex
+        digits, so this names a file called ``report final.db`` -- a different
+        file, and usually one that does not exist. (``100%_full.db`` is fine:
+        ``%_f`` is not a valid escape and is left alone. The bug is not "any
+        percent sign", it is a percent sign in front of two hex digits.)
+
+    Escaping the path fixes all three: the file that is opened is the file that
+    was named, it is opened read-only, and nothing is written into the evidence
+    tree.
+
+    Args:
+        db_path: Path to the SQLite database.
+
+    Returns:
+        A ``file:`` URI to pass to ``sqlite3.connect(..., uri=True)``.
+    """
+    return "file:" + quote(str(db_path)) + "?mode=ro"
 
 
 def adaptive_timeout(

--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -60,9 +60,17 @@ def readonly_sqlite_uri(db_path: Path | str) -> str:
         ``%_f`` is not a valid escape and is left alone. The bug is not "any
         percent sign", it is a percent sign in front of two hex digits.)
 
-    Escaping the path fixes all three: the file that is opened is the file that
-    was named, it is opened read-only, and nothing is written into the evidence
-    tree.
+    ``//tmp/case/sms.db``
+        A path may legally begin with exactly two slashes, and ``file://`` is
+        the start of a URI authority. SQLite reads ``tmp`` as a hostname and
+        refuses the connection with ``invalid uri authority: tmp``. This is
+        why the separators have to be escaped as well -- ``quote`` leaves
+        ``/`` alone by default, which fixes the filename but not the path.
+
+    Escaping the whole path fixes all four: the file that is opened is the
+    file that was named, it is opened read-only, and nothing is written into
+    the evidence tree. SQLite percent-decodes the path before using it, so
+    ``file:%2Ftmp%2Fcase%2Fsms.db`` names ``/tmp/case/sms.db`` exactly.
 
     Args:
         db_path: Path to the SQLite database.
@@ -70,7 +78,7 @@ def readonly_sqlite_uri(db_path: Path | str) -> str:
     Returns:
         A ``file:`` URI to pass to ``sqlite3.connect(..., uri=True)``.
     """
-    return "file:" + quote(str(db_path)) + "?mode=ro"
+    return "file:" + quote(str(db_path), safe="") + "?mode=ro"
 
 
 def adaptive_timeout(

--- a/src/mulder/server/tools/artifacts.py
+++ b/src/mulder/server/tools/artifacts.py
@@ -25,7 +25,11 @@ from typing import Any
 
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
-from mulder.server.helpers import hash_output, make_tool_call_id
+from mulder.server.helpers import (
+    hash_output,
+    make_tool_call_id,
+    readonly_sqlite_uri,
+)
 from mulder.server.tool_access import Role, tool_access
 
 logger = logging.getLogger(__name__)
@@ -199,7 +203,7 @@ def parse_browser_history() -> dict[str, object]:
                     continue
 
                 try:
-                    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                    conn = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
                     conn.row_factory = sqlite3.Row
 
                     if browser == "chrome":
@@ -389,7 +393,7 @@ def query_sqlite_from_image(inode: int, query: str, description: str = "") -> di
             }
 
         try:
-            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            conn = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
             conn.execute("PRAGMA trusted_schema=OFF")
             conn.set_authorizer(_readonly_authorizer)
             conn.row_factory = sqlite3.Row

--- a/src/mulder/server/tools/phone.py
+++ b/src/mulder/server/tools/phone.py
@@ -28,6 +28,7 @@ from mulder.server.helpers import (
     error_response,
     interpreter_candidates,
     make_tool_call_id,
+    readonly_sqlite_uri,
     require_binary,
     tool_response,
 )
@@ -72,7 +73,7 @@ def _carve_sqlite_databases(
                 db_path.write_bytes(mm[pos : pos + db_size])
 
                 try:
-                    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                    conn = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
                     tables = [
                         r[0]
                         for r in conn.execute(
@@ -269,7 +270,7 @@ _ANDROID_ARTIFACTS: dict[str, dict[str, object]] = {
 def _query_sqlite_safe(db_path: Path, query: str) -> list[str]:
     """Run a read-only query, returning formatted rows or empty list on error."""
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
         conn.row_factory = sqlite3.Row
         rows = conn.execute(query).fetchall()
         conn.close()
@@ -501,7 +502,7 @@ def _resolve_ios_manifest(backup_dir: Path) -> dict[str, Path]:
 
     mapping: dict[str, Path] = {}
     try:
-        conn = sqlite3.connect(f"file:{manifest}?mode=ro", uri=True)
+        conn = sqlite3.connect(readonly_sqlite_uri(manifest), uri=True)
         rows = conn.execute("SELECT fileID, relativePath, domain FROM Files").fetchall()
         conn.close()
     except sqlite3.Error:
@@ -791,7 +792,7 @@ def decrypt_app_data(
 
     for db_path in sqlite_files:
         try:
-            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+            conn = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
             tables = [
                 r[0]
                 for r in conn.execute(
@@ -804,7 +805,7 @@ def decrypt_app_data(
                 lines.append(f"Tables: {', '.join(tables)}")
                 for table in tables[:5]:
                     try:
-                        c2 = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+                        c2 = sqlite3.connect(readonly_sqlite_uri(db_path), uri=True)
                         c2.row_factory = sqlite3.Row
                         rows = c2.execute(f"SELECT * FROM [{table}] LIMIT 10").fetchall()
                         c2.close()

--- a/tests/test_sqlite_uri_escaping.py
+++ b/tests/test_sqlite_uri_escaping.py
@@ -1,0 +1,198 @@
+"""Evidence filenames were pasted into a SQLite URI without being escaped.
+
+Every read-only connection in the tree was opened as::
+
+    sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+
+``db_path`` comes out of an evidence tree, and a URI is not a string format --
+``#``, ``?`` and ``%`` are syntax. Three ordinary filenames break it, each in a
+different and silent way:
+
+``sms#2024-03-12.db``
+    ``#`` opens a fragment, so the path is truncated to ``sms`` and the
+    ``?mode=ro`` the caller asked for is inside the discarded fragment. SQLite
+    creates and opens an empty ``sms`` **in the evidence directory**, and the
+    tool reports that the database has no tables -- a wrong answer about the
+    wrong file, plus a write into the evidence tree.
+
+``chat?mode=rwc.db``
+    ``?`` starts the query string, so the caller's parameters are appended to
+    whatever the filename contained and the connection is refused. The
+    surrounding ``except sqlite3.Error`` drops the database from the analysis
+    without saying so.
+
+``report%20final.db``
+    SQLite percent-decodes ``%`` followed by two hex digits, so this names
+    ``report final.db`` -- a different file, and normally a missing one.
+    ``100%_full.db`` is *not* affected: ``%_f`` is not a valid escape and is
+    left alone. The bug is a percent sign in front of two hex digits, not any
+    percent sign, and the tests below pin both directions.
+
+These are not adversarial names. ``#`` and ``%`` appear in exported chat
+databases, dated backups and app cache filenames as a matter of course. A name
+chosen deliberately does more than confuse the path, though -- see
+``test_a_chosen_name_reaches_mode_rwc``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mulder.server.helpers import readonly_sqlite_uri
+
+
+def _make_db(path: Path) -> None:
+    """A minimal evidence database with one message in it."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE message(body TEXT)")
+    conn.execute("INSERT INTO message VALUES ('the evidence')")
+    conn.commit()
+    conn.close()
+
+
+HOSTILE_NAMES = [
+    "sms#2024-03-12.db",
+    "chat?mode=rwc&cache=shared.db",
+    "100%_full.db",
+    "report%20final.db",
+    "my backup.db",
+    "j..smith's phone.db",
+    "中文.db",
+    "ordinary.db",
+]
+
+
+class TestThePremise:
+    """What the old expression actually did, asserted rather than described."""
+
+    def test_a_hash_truncates_the_path_and_opens_the_wrong_file(self, tmp_path: Path) -> None:
+        evidence = tmp_path / "sms#2024-03-12.db"
+        _make_db(evidence)
+
+        conn = sqlite3.connect(f"file:{evidence}?mode=ro", uri=True)
+        tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        conn.close()
+
+        assert tables == [], "the old form did not open the evidence at all"
+        assert (tmp_path / "sms").exists(), (
+            "and it created an empty database inside the evidence directory"
+        )
+
+    def test_a_percent_hex_pair_is_decoded_into_a_different_path(self, tmp_path: Path) -> None:
+        evidence = tmp_path / "report%20final.db"
+        _make_db(evidence)
+
+        with pytest.raises(sqlite3.Error):
+            sqlite3.connect(f"file:{evidence}?mode=ro", uri=True)
+
+    def test_a_bare_percent_was_actually_fine(self, tmp_path: Path) -> None:
+        """Stated so the fix is not credited with more than it fixes.
+
+        ``%_f`` is not a valid escape, so ``100%_full.db`` opened correctly
+        under the old expression too.
+        """
+        evidence = tmp_path / "100%_full.db"
+        _make_db(evidence)
+
+        conn = sqlite3.connect(f"file:{evidence}?mode=ro", uri=True)
+        assert [r[0] for r in conn.execute("SELECT body FROM message")] == ["the evidence"]
+        conn.close()
+
+    def test_a_chosen_name_reaches_mode_rwc(self, tmp_path: Path) -> None:
+        """Why this is a security fix and not only a parsing one.
+
+        A file named ``chat.db?mode=rwc&x=`` makes the caller's ``?mode=ro``
+        land in the value of ``x``, so ``mode=rwc`` wins and the evidence is
+        opened read-write.
+        """
+        evidence = tmp_path / "chat.db"
+        _make_db(evidence)
+        hostile = tmp_path / "chat.db?mode=rwc&x="
+
+        conn = sqlite3.connect(f"file:{hostile}?mode=ro", uri=True)
+        conn.execute("CREATE TABLE injected(x)")
+        conn.commit()
+        conn.close()
+
+        opened = sqlite3.connect(evidence)
+        tables = [r[0] for r in opened.execute("SELECT name FROM sqlite_master")]
+        opened.close()
+        assert "injected" in tables, "read-only was defeated and the evidence was written"
+
+    def test_a_question_mark_makes_the_connection_fail(self, tmp_path: Path) -> None:
+        evidence = tmp_path / "chat?mode=rwc&cache=shared.db"
+        _make_db(evidence)
+
+        with pytest.raises(sqlite3.Error):
+            sqlite3.connect(f"file:{evidence}?mode=ro", uri=True)
+
+
+class TestReadonlySqliteUri:
+    @pytest.mark.parametrize("name", HOSTILE_NAMES)
+    def test_the_named_file_is_the_file_that_opens(self, tmp_path: Path, name: str) -> None:
+        evidence = tmp_path / name
+        _make_db(evidence)
+        before = sorted(p.name for p in tmp_path.iterdir())
+
+        conn = sqlite3.connect(readonly_sqlite_uri(evidence), uri=True)
+        rows = [r[0] for r in conn.execute("SELECT body FROM message")]
+        conn.close()
+
+        assert rows == ["the evidence"]
+        assert sorted(p.name for p in tmp_path.iterdir()) == before, (
+            "opening evidence must not create files next to it"
+        )
+
+    @pytest.mark.parametrize("name", HOSTILE_NAMES)
+    def test_the_connection_is_read_only(self, tmp_path: Path, name: str) -> None:
+        """mode=ro must survive the escaping, or evidence becomes writable."""
+        evidence = tmp_path / name
+        _make_db(evidence)
+
+        conn = sqlite3.connect(readonly_sqlite_uri(evidence), uri=True)
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("DELETE FROM message")
+        conn.close()
+
+    def test_a_string_path_works_too(self, tmp_path: Path) -> None:
+        """Call sites pass both Path and str."""
+        evidence = tmp_path / "sms#1.db"
+        _make_db(evidence)
+
+        conn = sqlite3.connect(readonly_sqlite_uri(str(evidence)), uri=True)
+        assert [r[0] for r in conn.execute("SELECT body FROM message")] == ["the evidence"]
+        conn.close()
+
+    def test_a_percent_escape_is_not_decoded(self, tmp_path: Path) -> None:
+        """The file named report%20final.db, not the file named 'report final.db'."""
+        evidence = tmp_path / "report%20final.db"
+        _make_db(evidence)
+        decoy = tmp_path / "report final.db"
+        _make_db(decoy)
+        conn = sqlite3.connect(decoy)
+        conn.execute("UPDATE message SET body = 'the wrong file'")
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(readonly_sqlite_uri(evidence), uri=True)
+        assert [r[0] for r in conn.execute("SELECT body FROM message")] == ["the evidence"]
+        conn.close()
+
+
+class TestEveryCallSiteUsesIt:
+    """A new read-only connection built by hand would reintroduce the bug."""
+
+    def test_no_module_formats_a_sqlite_uri_by_hand(self) -> None:
+        import mulder
+
+        root = Path(mulder.__file__).parent
+        offenders = [
+            str(path.relative_to(root))
+            for path in root.rglob("*.py")
+            if 'sqlite3.connect(f"file:' in path.read_text()
+        ]
+        assert offenders == []

--- a/tests/test_sqlite_uri_escaping.py
+++ b/tests/test_sqlite_uri_escaping.py
@@ -28,6 +28,15 @@ different and silent way:
     left alone. The bug is a percent sign in front of two hex digits, not any
     percent sign, and the tests below pin both directions.
 
+The directory is as much a part of the URI as the filename:
+
+``//tmp/case/sms.db``
+    POSIX allows a path to begin with exactly two slashes, and ``file://``
+    begins a URI authority. SQLite reads the first component as a hostname and
+    refuses the connection -- ``invalid uri authority: tmp``. Escaping only the
+    unsafe *filename* characters is not enough, because ``quote`` leaves ``/``
+    alone by default; the separators have to be escaped too.
+
 These are not adversarial names. ``#`` and ``%`` appear in exported chat
 databases, dated backups and app cache filenames as a matter of course. A name
 chosen deliberately does more than confuse the path, though -- see
@@ -38,10 +47,25 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
 
 from mulder.server.helpers import readonly_sqlite_uri
+
+
+def _double_slash_db(tmp_path: Path) -> Path:
+    """An evidence database whose path begins with exactly two slashes.
+
+    ``tmp_path`` is absolute, so prefixing one more slash gives a path with a
+    leading ``//``. POSIX leaves such a path implementation-defined but every
+    platform mulder runs on resolves it to the same file as a single slash;
+    pathlib preserves exactly two, and collapses three or more.
+    """
+    evidence = Path("/" + str(tmp_path)) / "sms.db"
+    assert str(evidence).startswith("//") and not str(evidence).startswith("///")
+    _make_db(evidence)
+    return evidence
 
 
 def _make_db(path: Path) -> None:
@@ -130,6 +154,22 @@ class TestThePremise:
         with pytest.raises(sqlite3.Error):
             sqlite3.connect(f"file:{evidence}?mode=ro", uri=True)
 
+    def test_a_double_slash_path_is_read_as_a_uri_authority(self, tmp_path: Path) -> None:
+        """Escaping the filename alone leaves this one, so pin it separately.
+
+        ``quote()`` keeps ``/`` unescaped by default, so a path beginning with
+        exactly two slashes still produces ``file://host/...`` and SQLite takes
+        the first component for a hostname.
+        """
+        evidence = _double_slash_db(tmp_path)
+
+        for uri in (
+            f"file:{evidence}?mode=ro",
+            "file:" + quote(str(evidence)) + "?mode=ro",
+        ):
+            with pytest.raises(sqlite3.OperationalError, match="invalid uri authority"):
+                sqlite3.connect(uri, uri=True)
+
 
 class TestReadonlySqliteUri:
     @pytest.mark.parametrize("name", HOSTILE_NAMES)
@@ -166,6 +206,18 @@ class TestReadonlySqliteUri:
         conn = sqlite3.connect(readonly_sqlite_uri(str(evidence)), uri=True)
         assert [r[0] for r in conn.execute("SELECT body FROM message")] == ["the evidence"]
         conn.close()
+
+    def test_a_double_slash_path_opens_against_real_sqlite(self, tmp_path: Path) -> None:
+        """The regression for the URI-authority case, against real SQLite."""
+        evidence = _double_slash_db(tmp_path)
+
+        conn = sqlite3.connect(readonly_sqlite_uri(evidence), uri=True)
+        rows = [r[0] for r in conn.execute("SELECT body FROM message")]
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("DELETE FROM message")
+        conn.close()
+
+        assert rows == ["the evidence"]
 
     def test_a_percent_escape_is_not_decoded(self, tmp_path: Path) -> None:
         """The file named report%20final.db, not the file named 'report final.db'."""


### PR DESCRIPTION
## BLUF

- **Evidence paths were pasted into a SQLite URI unescaped.** All seven read-only connections were built as `f"file:{db_path}?mode=ro"`, where `db_path` comes out of an evidence tree. In a URI, `#`, `?`, `%` and `//` are syntax.
- **`sms#2024-03-12.db` makes mulder analyse a file it invented.** `#` opens a fragment, the path truncates to `sms`, and SQLite **creates an empty database inside the evidence directory** and reports it has no tables.
- **`chat.db?mode=rwc&x=` opens the evidence read-write** — the caller's `?mode=ro` is swallowed as a parameter value, and `mode=rwc` wins. **`report%20final.db` opens a different file**, because `%` before two hex digits is decoded.
- **A `//` path is read as a URI authority.** `//tmp/case/sms.db` becomes `file://tmp/...`, and SQLite refuses it with `invalid uri authority: tmp`. This is the directory, not the filename, so escaping the filename alone does not fix it.
- **Fix:** one `readonly_sqlite_uri()` helper that percent-encodes the **whole path, separators included**, used at every call site, with a test that fails if a new one is hand-built.
- **Risk:** Low. SQLite percent-decodes the path before opening it, so the escaped form names the same file; behaviour is identical for every path the existing tests use.

## Priority

**high** — writing into the evidence tree and reporting on the wrong file are integrity failures in a forensic tool, and the names that trigger them are ordinary rather than adversarial. A deliberately chosen name reaches `mode=rwc` and defeats read-only outright, demonstrated below, which is why this is filed as a security fix rather than a parsing one.

## Review round 2 — the `//` authority case

@calebevans found that `quote()` keeps `/` unescaped by default, so a POSIX path that legally begins with exactly two slashes still produced `file://host/...`. Reproduced exactly as reported:

```
"file:" + quote("//tmp/probe/x.db")            -> OperationalError: invalid uri authority: tmp
"file:" + quote("//tmp/probe/x.db", safe="")   -> file:%2F%2Ftmp%2Fprobe%2Fx.db?mode=ro   OK, read-only
```

Fixed with `quote(str(db_path), safe="")`, and pinned by two tests against real SQLite:

- `TestThePremise::test_a_double_slash_path_is_read_as_a_uri_authority` asserts that **both** the bare f-string and `quote()`'s `safe="/"` default raise `invalid uri authority` — so the test cannot pass against a version that only escapes the filename;
- `TestReadonlySqliteUri::test_a_double_slash_path_opens_against_real_sqlite` opens the database through the helper, reads the row back, and asserts the connection is still read-only.

Confirmed discriminating: reverting the helper to `quote(str(db_path))` fails the second test with `invalid uri authority: tmp` and passes the other 25.

## Demonstrated, not reasoned about

Against a real database containing one message:

```
evidence file : sms#2024-03-12.db  ->  table 'message', 1 row
tables seen   : []                     <- mulder reports no message table
before        : ['sms#2024-03-12.db']
after         : ['sms', 'sms#2024-03-12.db']   <- created in the evidence tree
```

Five distinct failure modes, all silent:

| path | what SQLite does | what the caller sees |
|---|---|---|
| `sms#2024-03-12.db` | `#` starts a fragment; path truncates to `sms`, `?mode=ro` is discarded | an empty DB, created in the evidence dir, opened **read-write** |
| `chat.db?mode=rwc&x=` | `?` starts the query; `?mode=ro` becomes the value of `x`, so `mode=rwc` wins | **the evidence opens read-write** |
| `report%20final.db` | `%20` decoded to a space | a different filename — connection fails, DB silently dropped |
| `chat?mode=rwc.db` | `?` starts the query, but the value is not a valid parameter | `sqlite3.Error`, swallowed — the DB vanishes from the analysis |
| `//tmp/case/sms.db` | `//` starts a URI authority; `tmp` is read as a hostname | `OperationalError`, swallowed — the DB vanishes from the analysis |

`mode=rwc` is not theoretical:

```
file:/case/chat.db?mode=rwc&x=?mode=ro  ->  CREATE TABLE injected(x)   OK
```

`#` and `%` appear in exported chat databases, dated backups and app cache filenames as a matter of course.

**One correction to an earlier draft of this PR:** it claimed `100%_full.db` was also broken. It is not — `%_f` is not a valid percent-escape, so SQLite leaves it alone and the old expression opened that file correctly. A test now pins that too, so the fix is not credited with more than it fixes.

## The fix

```python
return "file:" + quote(str(db_path), safe="") + "?mode=ro"
```

`readonly_sqlite_uri()` in `server/helpers.py`. Verified against every name above plus spaces, apostrophes and non-ASCII:

```
sms#2024-03-12.db        tables=['message'] readonly=yes no_new_files=True
chat?mode=rwc.db         tables=['message'] readonly=yes no_new_files=True
report%20final.db        tables=['message'] readonly=yes no_new_files=True
100%_full.db             tables=['message'] readonly=yes no_new_files=True
my backup.db             tables=['message'] readonly=yes no_new_files=True
j..smith's phone.db      tables=['message'] readonly=yes no_new_files=True
中文.db                   tables=['message'] readonly=yes no_new_files=True
//tmp/.../sms.db         tables=['message'] readonly=yes no_new_files=True
```

Seven call sites: `phone.py` ×5, `artifacts.py` ×2. `extract/pcap.py:110` matches the same grep but is a tshark `-o tls.keylog_file:` option, not a URI, and is untouched.

## Tests

`tests/test_sqlite_uri_escaping.py` — 26 tests:

- six **pin the premise** by asserting what the old expression actually did — that it opened no tables and created `sms` on disk, that `mode=rwc` defeated read-only, that `%20` broke the path, that a `//` path was refused as an authority, **and that `100%_full.db` was fine** — so the tests cannot pass against a codebase where the bug was never real, and cannot overstate it either;
- eight filenames are parameterised over two properties each: the file that opens is the file that was named, and `mode=ro` survives the escaping;
- one walks the installed package and asserts no module formats a SQLite URI by hand, so a new connection cannot reintroduce this.

`uvx pre-commit run --all-files` clean (ruff, ruff-format, mypy). `uv run --locked --extra dev pytest` — **782 passed**, whole suite, nothing deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
