### PR TITLE
[low] fix(db): close a CaseDB whose queries raised

### DIFF
--- a/src/mulder/server/app.py
+++ b/src/mulder/server/app.py
@@ -400,11 +400,17 @@ def _try_open_existing(
     when the caller should proceed to create a fresh database (only
     possible for empty, corrupt DBs with ``replace=True``).
     """
+    # ``existing`` is handed to _build_context on the success paths, which
+    # takes ownership of it. It is only orphaned when the open succeeded and a
+    # query on it then raised, so that is the case this pre-binding covers.
+    existing = None
     try:
         existing = CaseDB.open(case_id, db_dir)
         meta = existing.get_case_metadata()
         source_count = existing.get_source_count()
     except Exception as exc:
+        if existing is not None:
+            existing.close()
         if not replace:
             logger.exception("Failed to open existing case '%s'", case_id)
             from mulder.server.helpers import error_response, make_tool_call_id

--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -256,9 +256,14 @@ def list_cases() -> dict[str, object]:
         try:
             from mulder.db import CaseDB
 
-            db = CaseDB.open(cid, cfg.db_dir)
-            meta = db.get_case_metadata()
-            count = db.get_source_count()
+            # ``with``, not a trailing close(): CaseDB.open starts a writer
+            # thread and holds an engine, and if get_case_metadata() raises --
+            # a corrupt file, a schema older than the migrations -- the close()
+            # below it never runs. Listing a directory of such cases leaked one
+            # thread per case, and list_cases is called repeatedly.
+            with CaseDB.open(cid, cfg.db_dir) as db:
+                meta = db.get_case_metadata()
+                count = db.get_source_count()
             cases.append(
                 {
                     "case_id": cid,
@@ -267,7 +272,6 @@ def list_cases() -> dict[str, object]:
                     "ingested_at": meta.ingested_at,
                 }
             )
-            db.close()
         except Exception as exc:
             logger.warning("Failed to read case '%s': %s", cid, exc)
             cases.append({"case_id": cid, "error": str(exc)})

--- a/tests/test_casedb_leaks.py
+++ b/tests/test_casedb_leaks.py
@@ -1,0 +1,124 @@
+"""A ``CaseDB`` that was opened, then failed a query, was never closed.
+
+``CaseDB.open`` starts a daemon writer thread (``db-writer``) and holds a
+SQLAlchemy engine. Two call sites released it with a trailing ``close()``
+*inside* the same ``try`` as the queries::
+
+    db = CaseDB.open(cid, cfg.db_dir)
+    meta = db.get_case_metadata()      # <- raises
+    count = db.get_source_count()
+    ...
+    db.close()                          # <- never reached
+
+The failure the ``except`` was written for -- a corrupt database, a schema
+older than the migrations -- is exactly the path that skips the close. Because
+the exception is caught and turned into a per-case ``error`` entry, the tool
+reports ``status: success`` and the caller has no reason to stop calling it, so
+the leak accumulates: one thread and one engine per unreadable case, per call.
+
+Measured before the fix, with three cases on disk and metadata reads raising:
+
+    writer threads before: 0
+    writer threads after : 3
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mulder.db import CaseDB
+
+
+def _writer_threads() -> list[threading.Thread]:
+    return [t for t in threading.enumerate() if t.name == "db-writer"]
+
+
+@pytest.fixture
+def case_dir(tmp_path: Path) -> Path:
+    """Three real case databases, closed again."""
+    db_dir = tmp_path / "cases"
+    db_dir.mkdir()
+    for cid in ("case-a", "case-b", "case-c"):
+        CaseDB.create(cid, str(tmp_path / "evidence"), db_dir).close()
+    return db_dir
+
+
+@pytest.fixture
+def initialised(case_dir: Path) -> Path:
+    from mulder.server.app import init_server
+
+    init_server(db_dir=case_dir)
+    return case_dir
+
+
+def _boom(self: CaseDB) -> None:
+    raise RuntimeError("schema drift: no such column: ingested_at")
+
+
+class TestListCases:
+    def test_a_failing_case_does_not_leak_a_writer_thread(self, initialised: Path) -> None:
+        from mulder.server.tools.case import list_cases
+
+        before = len(_writer_threads())
+        with patch.object(CaseDB, "get_case_metadata", _boom):
+            result = list_cases.__wrapped__()  # type: ignore[attr-defined]
+
+        assert len(_writer_threads()) == before
+
+        # The premise: the failure path really was taken for every case.
+        cases = result["results"]
+        assert isinstance(cases, list)
+        assert [c.get("case_id") for c in cases] == ["case-a", "case-b", "case-c"]
+        assert all("error" in c for c in cases)
+
+    def test_the_healthy_path_still_reports_the_cases(self, initialised: Path) -> None:
+        from mulder.server.tools.case import list_cases
+
+        before = len(_writer_threads())
+        result = list_cases.__wrapped__()  # type: ignore[attr-defined]
+
+        assert len(_writer_threads()) == before
+        cases = result["results"]
+        assert isinstance(cases, list)
+        assert result["result_count"] == 3
+        assert all("error" not in c for c in cases)
+
+    def test_the_leak_scales_with_the_number_of_cases(self, initialised: Path) -> None:
+        """Two calls over three cases would have leaked six threads."""
+        from mulder.server.tools.case import list_cases
+
+        before = len(_writer_threads())
+        with patch.object(CaseDB, "get_case_metadata", _boom):
+            list_cases.__wrapped__()  # type: ignore[attr-defined]
+            list_cases.__wrapped__()  # type: ignore[attr-defined]
+
+        assert len(_writer_threads()) == before
+
+
+class TestOpenExistingCase:
+    def test_a_failing_query_does_not_leak(self, case_dir: Path) -> None:
+        """app.py had the same shape: opened, queried, closed in one try."""
+        from mulder.server.app import _try_open_existing
+
+        before = len(_writer_threads())
+        with patch.object(CaseDB, "get_case_metadata", _boom):
+            result = _try_open_existing("case-a", str(case_dir / "ev"), False, case_dir)
+
+        assert len(_writer_threads()) == before
+        assert isinstance(result, dict)
+        assert result["error_type"] == "database_error"
+
+    def test_a_missing_database_is_unaffected(self, case_dir: Path) -> None:
+        """CaseDB.open itself raised, so there is nothing to close."""
+        from mulder.server.app import _try_open_existing
+
+        before = len(_writer_threads())
+        result = _try_open_existing("no-such-case", str(case_dir / "ev"), False, case_dir)
+
+        assert len(_writer_threads()) == before
+        assert isinstance(result, dict)
+        assert result["error_type"] == "database_error"


### PR DESCRIPTION
## BLUF

- **A `CaseDB` that opened and then failed a query was never closed.** `close()` sat inside the same `try` as the queries, so the corrupt-database path the `except` exists for is exactly the path that skips it.
- **`CaseDB.open` is not free** — it starts a daemon `db-writer` thread and holds a SQLAlchemy engine.
- **`list_cases` accumulates the leak**, because it catches per case, still returns `status: success`, and gets called repeatedly. Three unreadable cases leaked **3 threads per call**; 9 after three calls.
- **`_try_open_existing` in `app.py` had the same shape** and is fixed with it.
- **Fix:** `with CaseDB.open(...)` — a context manager `CaseDB` already supported.
- **Risk:** Low. Nothing changes on the healthy path; the tests pin that.

## Priority

**low** — daemon threads die with the process and a short-lived server never notices. It matters for a long-running MCP server against a case directory with one bad database in it, which is exactly when `list_cases` is called on a loop.

## Measured

Three real case databases on disk, metadata reads raising:

```
writer threads before: 0
writer threads after : 3      <- one per unreadable case
```

The listing still reports `status: success` with a per-case `error` entry, so nothing upstream signals that the tool should not be called again.

## The two sites

```python
db = CaseDB.open(cid, cfg.db_dir)
meta = db.get_case_metadata()      # raises
count = db.get_source_count()
...
db.close()                          # never reached
```

`list_cases` now uses `with CaseDB.open(...) as db:`.

`_try_open_existing` needed more care rather than the same wrapper: on its success paths the database is handed to `_build_context`, which takes ownership of it. Only the *opened, then a query raised* case is closed there, and pre-binding `existing = None` keeps `CaseDB.open`'s own failure — a missing file, where there is nothing to close — from being confused with it.

## Tests

New `tests/test_casedb_leaks.py` (5 tests), counting live `db-writer` threads around real `CaseDB` instances:

- three **fail against unfixed code** with `assert 3 == 0`, `assert 9 == 3` and `assert 10 == 9`;
- the leak test also asserts the premise — that all three cases really did take the failure path — so it cannot pass by never reaching the bug;
- two pin the unchanged behaviour: a healthy listing still reports three cases, and a missing database still returns `database_error` without leaking.

`make lint format typecheck test` — 746 passed, mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
