### PR TITLE
[low] fix(binary): use the shared IP and path patterns, not local copies

### DIFF
--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from mulder.patterns import IP_RE, UNIX_PATH_RE, WIN_PATH_RE
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -97,10 +98,13 @@ SUSPICIOUS_API_CATEGORIES: dict[str, list[str]] = {
     ],
 }
 
+# _URL_RE and _REGISTRY_RE have no counterpart in mulder.patterns and no other
+# caller, so they stay local. IP and filesystem paths do have one, and the
+# copies here had drifted: the local Unix pattern knew only /usr, /etc, /tmp
+# and /var, so strings like /root/.bash_history and /home/victim/.ssh/id_rsa
+# were classified as "not a path" and dropped from the categorised output.
 _URL_RE = re.compile(r"https?://[^\s\"']+")
-_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 _REGISTRY_RE = re.compile(r"HKLM\\|HKCU\\|HKCR\\|SOFTWARE\\", re.IGNORECASE)
-_FILEPATH_RE = re.compile(r"[A-Z]:\\[^\s\"]+|/(?:usr|etc|tmp|var)/[^\s\"]+")
 _BASE64_RE = re.compile(r"^[A-Za-z0-9+/]{20,}={0,2}$")
 _HEX_KEY_RE = re.compile(r"^[0-9a-fA-F]{16,}$")
 _RAHASH_RE = re.compile(r"(\w+):\s+([0-9a-fA-F]+)")
@@ -254,11 +258,11 @@ def _categorize_string(value: str) -> str | None:
     """
     if _URL_RE.search(value):
         return "url"
-    if _IPV4_RE.search(value):
+    if IP_RE.search(value):
         return "ip"
     if _REGISTRY_RE.search(value):
         return "registry"
-    if _FILEPATH_RE.search(value):
+    if WIN_PATH_RE.search(value) or UNIX_PATH_RE.search(value):
         return "filepath"
     return None
 

--- a/tests/test_binary_string_patterns.py
+++ b/tests/test_binary_string_patterns.py
@@ -1,0 +1,104 @@
+"""``binary.py`` re-declared IP and path regexes instead of using the shared ones.
+
+``mulder.patterns`` exists so one parser is fixed once -- the same reason the
+``mmls`` and ``fls`` parsers were consolidated. ``binary.py`` kept private
+copies, and they had drifted:
+
+===================  ==========================================
+shared               ``/(?:usr|var|etc|home|tmp|opt|root|proc|sys|run|mnt|media)``
+local (was)          ``/(?:usr|etc|tmp|var)/``
+===================  ==========================================
+
+So ``_categorize_string`` returned ``None`` for exactly the paths a malware
+triage cares about -- ``/root/.bash_history``, ``/home/victim/.ssh/id_rsa``,
+``/opt/...``, ``/proc/self/maps``, ``/run/...``, ``/mnt/...`` -- and those
+strings were dropped from the categorised output rather than surfaced as
+``filepath``.
+
+The IP copy was byte-identical to ``patterns.IP_RE``, so nothing changes there;
+it is removed because the next drift is the problem.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mulder.patterns import IP_RE, UNIX_PATH_RE, WIN_PATH_RE
+from mulder.server.tools.binary import _categorize_string
+
+
+class TestPathsTheLocalCopyMissed:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/root/.bash_history",
+            "/home/victim/.ssh/id_rsa",
+            "/opt/implant/payload",
+            "/proc/self/maps",
+            "/run/user/1000/keyring",
+            "/mnt/exfil/staging.tar",
+            "/media/usb0/dump.bin",
+            "/sys/class/net/eth0/address",
+        ],
+    )
+    def test_it_is_now_a_filepath(self, value: str) -> None:
+        assert _categorize_string(value) == "filepath"
+
+    def test_the_old_pattern_really_did_miss_them(self) -> None:
+        """Pin the premise rather than describing it."""
+        import re
+
+        old = re.compile(r"[A-Z]:\\[^\s\"]+|/(?:usr|etc|tmp|var)/[^\s\"]+")
+
+        assert old.search("/root/.bash_history") is None
+        assert old.search("/home/victim/.ssh/id_rsa") is None
+
+
+class TestUnchangedBehaviour:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (r"C:\Windows\System32\svchost.exe", "filepath"),
+            (r"C:\Users\victim\AppData\Roaming\update.exe", "filepath"),
+            ("/usr/bin/curl", "filepath"),
+            ("/etc/passwd", "filepath"),
+            ("/tmp/.X11-unix/x0", "filepath"),
+            ("/var/log/auth.log", "filepath"),
+            ("http://evil.example/payload", "url"),
+            ("192.168.1.50", "ip"),
+            (r"HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run", "registry"),
+        ],
+    )
+    def test_still_classified_the_same(self, value: str, expected: str) -> None:
+        assert _categorize_string(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "GET /index.html HTTP/1.1",
+            "Mozilla/5.0 compatible",
+            "/dev/null",
+            "just some text",
+        ],
+    )
+    def test_still_uncategorised(self, value: str) -> None:
+        assert _categorize_string(value) is None
+
+
+class TestTheSharedPatternsAreTheOnesUsed:
+    def test_no_private_copies_remain(self) -> None:
+        """A re-declared copy here is what drifted last time."""
+        from mulder.server.tools import binary
+
+        assert not hasattr(binary, "_IPV4_RE")
+        assert not hasattr(binary, "_FILEPATH_RE")
+
+    def test_the_module_imports_the_shared_ones(self) -> None:
+        """vars(), not attribute access: these are re-exports, and mypy
+        --strict forbids reading a name a module did not declare itself."""
+        from mulder.server.tools import binary
+
+        namespace = vars(binary)
+        assert namespace["IP_RE"] is IP_RE
+        assert namespace["WIN_PATH_RE"] is WIN_PATH_RE
+        assert namespace["UNIX_PATH_RE"] is UNIX_PATH_RE


### PR DESCRIPTION
## BLUF

- **`binary.py` kept private copies of the IP and path regexes** instead of using `mulder.patterns`, which exists so one parser is fixed once — the same reason the `mmls` and `fls` parsers were consolidated in #68 and #77.
- **The copies had drifted.** The local Unix pattern knew only `/usr`, `/etc`, `/tmp`, `/var`.
- **So `_categorize_string` returned `None` for the paths that matter in malware triage** — `/root/.bash_history`, `/home/victim/.ssh/id_rsa`, `/proc/self/maps` — and those strings were dropped from the categorised output rather than surfaced as `filepath`.
- **The IP copy was byte-identical**, so nothing changes there; it goes anyway, because the *next* drift is the problem.
- **Risk:** Low. Six string classifications change, all from "uncategorised" to "filepath"; nothing that was categorised becomes something else.

## Review round 2 — the shared pattern's root boundary

@calebevans found that adopting `UNIX_PATH_RE` imported a false-positive class with it: the pattern matched the root name as a bare **prefix**, so any word merely starting with one was classified as a file path. The local pattern this PR deletes required a `/` after the root and rejected all four:

| string | shared (was) | local (deleted) | shared (now) |
|---|---|---|---|
| `GET /home.html HTTP/1.1` | match | no match | no match |
| `/rootkit` | match | no match | no match |
| `/mediawiki/index.php` | match | no match | no match |
| `/etcetera` | match | no match | no match |
| `/root/.bash_history` | match | no match | **match** |
| `/home/victim/.ssh/id_rsa` | match | no match | **match** |

The last two are why the switch is worth making at all, so the fix had to keep them. `patterns.UNIX_PATH_RE` now requires the `/`:

```python
r"/(?:usr|var|etc|home|tmp|opt|root|proc|sys|run|mnt|media)/[^\s,\"']+"
```

An explicit `/` rather than `\b`, deliberately — `\b` does not help, since `/home.html` would still match as `/home`.

One behaviour change beyond the false positives: a bare `/tmp` with no child no longer matches. That reads right to me — a directory name is not a file path worth extracting — but it is easy to reverse if you'd rather keep it.

This is a shared pattern, so `review.py:475` gets the same tightening when it collects file paths for review.

## Priority

**low** — it loses detail in an analyst-facing string list rather than producing a wrong answer, and only for a subset of Unix paths. Filed separately from #68/#77 because it is the same root cause reaching a third module.

## The drift

| | Unix roots recognised |
|---|---|
| `mulder.patterns.UNIX_PATH_RE` | `usr var etc home tmp opt root proc sys run mnt media` |
| local copy (removed) | `usr etc tmp var` |

Measured against `_categorize_string`:

```
/root/.bash_history          was: None   now: filepath
/home/victim/.ssh/id_rsa     was: None   now: filepath
/opt/implant/payload         was: None   now: filepath
/proc/self/maps              was: None   now: filepath
/run/user/1000/keyring       was: None   now: filepath
/mnt/exfil/staging.tar       was: None   now: filepath
```

Six of fifteen probe strings change, all in that direction. `GET /index.html HTTP/1.1`, `Mozilla/5.0 compatible` and `/dev/null` stay uncategorised.

Because these patterns are only ever used with `.search()` to classify — never to extract a substring — the shared patterns' extra exclusions (`,` and `'`) cannot change any outcome. Only the root coverage does.

## What is deliberately left alone

- **`_URL_RE` and `_REGISTRY_RE` stay local.** `mulder.patterns` has no counterpart and nothing else in the tree defines them; promoting them would be generality nobody asked for.
- **The two other IP-shaped regexes in the tree are not duplicates.** `enrichment.py:30` anchors with `^...$` to validate a single value, and `renderer.py:50` captures a port. Both are correct as they are.

## Tests

New `tests/test_binary_string_patterns.py` (24 tests):

- eight paths the local copy missed, now classified as `filepath`;
- one **pins the premise** by compiling the old pattern inline and asserting it really did miss `/root/.bash_history`, so the test cannot pass against a codebase where the drift never existed;
- nine assert unchanged classification (Windows paths, the four old Unix roots, URL, IP, registry) and four assert strings that must stay uncategorised;
- two assert the private copies are gone and the module now binds the shared objects, so a re-declaration fails the suite.

`uvx pre-commit run --all-files` clean; `uv run --locked --extra dev pytest` — 765 passed, mypy clean, ruff clean.

**One pre-existing test is failing in my environment for an unrelated reason:** `test_disk_pcap.py::test_size_filtering_skips_large_pcaps` writes a real 200 MB file and hits a filesystem quota here. It fails identically on unmodified `main`, so it is not caused by this change; I deselected it rather than report a clean run I did not get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

