### PR TITLE
Fix audit hashes for large outputs

### DIFF
--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -175,7 +175,6 @@ _HINT_CHAR_LIMIT = 200
 _DEFAULT_SEARCH_LIMIT = 50
 _FILE_LIST_CAP = 500
 
-_HASH_SIZE_THRESHOLD = 10000
 _HASH_PREFIX = "blake2b:"
 _HASH_DIGEST_SIZE = 32
 
@@ -185,25 +184,8 @@ def _blake2b_hex(data: bytes) -> str:
 
 
 def hash_output(output: object) -> str:
-    """Return a BLAKE2b fingerprint of *output* for audit purposes.
-
-    For small payloads, hashes the full JSON.  For large payloads
-    (>10KB serialized), hashes a compact summary to avoid expensive
-    serialization of data that's about to be serialized again for the
-    MCP response.
-    """
-    if isinstance(output, list | dict):
-        if isinstance(output, list) and len(output) > 200:
-            return _blake2b_hex(f"list:len={len(output)}".encode())
-        if isinstance(output, dict) and len(output) > 100:
-            return _blake2b_hex(f"dict:keys={sorted(output.keys())}".encode())
-        probe = json.dumps(output, sort_keys=True, default=str)
-        if len(probe) > _HASH_SIZE_THRESHOLD:
-            return _blake2b_hex(f"large:{len(probe)}:{probe[:256]}".encode())
-        return _blake2b_hex(probe.encode())
+    """Return a BLAKE2b commitment to the complete JSON form of *output*."""
     raw = json.dumps(output, sort_keys=True, default=str)
-    if len(raw) > _HASH_SIZE_THRESHOLD:
-        return _blake2b_hex(f"large:{len(raw)}:{raw[:256]}".encode())
     return _blake2b_hex(raw.encode())
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -32,21 +32,19 @@ class TestHashOutput:
         expected = "blake2b:" + hashlib.blake2b(expected_json.encode(), digest_size=32).hexdigest()
         assert result == expected
 
-    def test_large_dict_summary_hash(self) -> None:
+    def test_large_dict_full_hash(self) -> None:
         data = {f"k{i}": "x" * 100 for i in range(150)}
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
-    def test_large_list_summary_hash(self) -> None:
+    def test_large_list_full_hash(self) -> None:
         data = ["x" * 50 for _ in range(250)]
         result = hash_output(data)
         full_json = json.dumps(data, sort_keys=True, default=str)
         full_hash = "blake2b:" + hashlib.blake2b(full_json.encode(), digest_size=32).hexdigest()
-        assert result != full_hash
-        assert result.startswith("blake2b:")
+        assert result == full_hash
 
     def test_scalar_input(self) -> None:
         result = hash_output("hello world")
@@ -123,24 +121,26 @@ class TestSlimWindow:
         assert result["event_time"] == "2025-01-01"
 
 
-class TestHashOutputHeuristic:
-    """Test the heuristic size-check that skips full JSON serialization."""
+class TestHashOutputContent:
+    """Large output hashes commit to the complete serialized content."""
 
-    def test_large_list_uses_length_hash(self) -> None:
-        """Lists with >200 items use a length summary, not full serialization."""
+    def test_large_lists_with_the_same_length_differ(self) -> None:
         data = list(range(250))
         h1 = hash_output(data)
         data_different_content = list(range(250, 500))
         h2 = hash_output(data_different_content)
-        assert h1 == h2
+        assert h1 != h2
 
-    def test_large_dict_uses_keys_hash(self) -> None:
-        """Dicts with >100 keys use a keys summary, not full serialization."""
+    def test_large_dicts_with_the_same_keys_differ(self) -> None:
         data = {f"k{i}": "value_a" for i in range(150)}
         h1 = hash_output(data)
         data_different_values = {f"k{i}": "value_b" for i in range(150)}
         h2 = hash_output(data_different_values)
-        assert h1 == h2
+        assert h1 != h2
+
+    def test_large_strings_with_the_same_length_and_prefix_differ(self) -> None:
+        prefix = "x" * 300
+        assert hash_output(prefix + "a" * 10_000) != hash_output(prefix + "b" * 10_000)
 
 
 class TestExtractPid:


### PR DESCRIPTION
Large tool outputs currently use lossy audit hashes: lists hash only their length, dictionaries hash only their keys, and long values hash only a length and prefix. Different forensic results can therefore produce the same recorded digest.

This change hashes the complete deterministic JSON representation for every output. It keeps the existing BLAKE2b format and small-value behavior while adding collision regressions for large lists, dictionaries, and strings.

This PR contains only the output-hashing correction; it does not introduce a new audit-chain format.

Validation:
- `pytest -q tests/test_helpers.py` (23 passed)
- `ruff format --check src/mulder/server/helpers.py tests/test_helpers.py`
- `ruff check src/mulder/server/helpers.py tests/test_helpers.py`
- `mypy src/mulder/server/helpers.py`
- `git diff --check origin/main..HEAD`
