### PR TITLE
[high] fix(zircolite): report a failed Zircolite run instead of a clean scan

### DIFF
--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -30,6 +30,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 _ZIRCOLITE_TIMEOUT = 600
+_STDERR_PREVIEW_CHARS = 500
 _ZIRCOLITE_DIRNAME = "zircolite"
 
 
@@ -74,7 +75,7 @@ def _run_zircolite_process(
     log_format: str,
     ruleset_path: Path,
     output_dir: Path,
-) -> Path:
+) -> tuple[Path, subprocess.CompletedProcess[str]]:
     """Execute Zircolite against event logs.
 
     Args:
@@ -85,7 +86,9 @@ def _run_zircolite_process(
         output_dir: Output directory for results.
 
     Returns:
-        Path to the JSON results file.
+        Tuple of (path to the JSON results file, the completed process). The
+        caller needs the process to tell a genuinely empty ruleset match from a
+        Zircolite run that never produced results.
 
     Raises:
         subprocess.TimeoutExpired: If Zircolite exceeds the timeout.
@@ -106,14 +109,14 @@ def _run_zircolite_process(
         *format_flags,
     ]
 
-    subprocess.run(
+    proc = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
         timeout=_ZIRCOLITE_TIMEOUT,
         check=False,
     )
-    return output_file
+    return output_file, proc
 
 
 def _build_detection_timeline(
@@ -361,7 +364,7 @@ def run_zircolite(
     with tempfile.TemporaryDirectory(prefix="mulder_zircolite_") as tmpdir:
         output_dir = Path(tmpdir)
         try:
-            results_path = _run_zircolite_process(
+            results_path, proc = _run_zircolite_process(
                 str(script),
                 Path(events_path),
                 log_format,
@@ -385,6 +388,19 @@ def run_zircolite(
                 f"Failed to execute Zircolite: {exc}",
                 (time.monotonic() - t0) * 1000,
                 error_type="os_error",
+            )
+
+        if proc.returncode != 0 and not results_path.exists():
+            detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[
+                :_STDERR_PREVIEW_CHARS
+            ]
+            return error_response(
+                tc_id,
+                "run_zircolite",
+                params,
+                f"Zircolite exited {proc.returncode} and wrote no results file: {detail}",
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
             )
 
         result = _parse_zircolite_output(results_path, events_path, log_format, sigma_level_filter)

--- a/tests/test_zircolite_exit_code.py
+++ b/tests/test_zircolite_exit_code.py
@@ -1,0 +1,153 @@
+"""Zircolite failures must not be reported as a clean, zero-detection scan.
+
+``_run_zircolite_process`` discarded the ``CompletedProcess`` entirely, so a
+Zircolite invocation that argparse rejected -- or that died on a malformed
+ruleset -- left no results file, and ``_parse_zircolite_output`` answered that
+with ``total_detections: 0``. The MCP client saw ``status: success`` and no
+detections: indistinguishable from a log that genuinely matched no Sigma rule.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.tools.zircolite import run_zircolite
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> dict[str, Path]:
+    """A resolvable script, ruleset and events file, so the run reaches Zircolite."""
+    script = tmp_path / "zircolite.py"
+    script.write_text("")
+    events = tmp_path / "audit.log"
+    events.write_text("type=EXECVE msg=audit(1700000000.000:1): argc=1\n")
+    ruleset = tmp_path / "rules"
+    ruleset.mkdir()
+    return {"script": script, "events": events, "ruleset": ruleset}
+
+
+def _invoke(evidence: dict[str, Path], proc: subprocess.CompletedProcess[str]) -> Any:
+    """Run ``run_zircolite`` with Zircolite itself replaced by *proc*."""
+    with (
+        patch("mulder.server.tools.zircolite.sources_already_indexed", return_value=[]),
+        patch(
+            "mulder.server.tools.zircolite.importlib.util.find_spec",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "mulder.server.tools.zircolite._zircolite_script",
+            return_value=evidence["script"],
+        ),
+        patch("mulder.server.tools.zircolite.subprocess.run", return_value=proc),
+        patch("mulder.server.tools.zircolite.extract_and_index", return_value={}),
+    ):
+        return run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence["events"]),
+            ruleset_path=str(evidence["ruleset"]),
+        )
+
+
+def test_a_rejected_invocation_is_an_error_not_an_empty_scan(
+    evidence: dict[str, Path],
+) -> None:
+    """The exact shape that made this silent: argparse rejects the flags.
+
+    Zircolite exits non-zero before opening a log and writes no results file.
+    Before this fix the caller was told the scan succeeded with 0 detections.
+    """
+    proc = subprocess.CompletedProcess(
+        args=["zircolite.py"],
+        returncode=2,
+        stdout="",
+        stderr="zircolite.py: error: unrecognized arguments: --json",
+    )
+
+    result = _invoke(evidence, proc)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert "exited 2" in message
+    assert "unrecognized arguments" in message
+    # The failure must not be dressed up as a result.
+    assert "total_detections" not in result
+    assert "detections" not in result
+
+
+def test_the_report_carries_stdout_when_zircolite_is_silent_on_stderr(
+    evidence: dict[str, Path],
+) -> None:
+    """Some Zircolite failures print only to stdout; the detail must survive."""
+    proc = subprocess.CompletedProcess(
+        args=["zircolite.py"],
+        returncode=1,
+        stdout="[-] Ruleset is empty or malformed",
+        stderr="",
+    )
+
+    result = _invoke(evidence, proc)
+
+    assert result["status"] == "error"
+    assert "Ruleset is empty or malformed" in str(result["error_message"])
+
+
+def test_a_genuinely_quiet_log_is_still_a_successful_scan(
+    evidence: dict[str, Path],
+) -> None:
+    """Pins the fix's narrowness: exit 0 and no detections stays a success.
+
+    Zircolite exits 0 and writes no results file when nothing matched. That is
+    a real answer, not a failure, and must keep reporting as one -- otherwise
+    the fix trades silent failures for false alarms.
+    """
+    proc = subprocess.CompletedProcess(args=["zircolite.py"], returncode=0, stdout="", stderr="")
+
+    result = _invoke(evidence, proc)
+
+    assert result["status"] == "success"
+
+
+def test_partial_results_are_kept_when_zircolite_exits_non_zero(
+    evidence: dict[str, Path],
+) -> None:
+    """A non-zero exit that still wrote detections must not discard them.
+
+    Zircolite exits non-zero on a single unreadable input while having already
+    written matches for the rest, so the guard is deliberately conjunctive:
+    non-zero *and* no results file.
+    """
+    written: list[Path] = []
+
+    def _write_results(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        outfile = Path(cmd[cmd.index("--outfile") + 1])
+        outfile.write_text('[{"rule_level": "high", "title": "T", "matches": []}]')
+        written.append(outfile)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr="one input was unreadable"
+        )
+
+    with (
+        patch("mulder.server.tools.zircolite.sources_already_indexed", return_value=[]),
+        patch(
+            "mulder.server.tools.zircolite.importlib.util.find_spec",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "mulder.server.tools.zircolite._zircolite_script",
+            return_value=evidence["script"],
+        ),
+        patch("mulder.server.tools.zircolite.subprocess.run", side_effect=_write_results),
+        patch("mulder.server.tools.zircolite.extract_and_index", return_value={}),
+    ):
+        result = run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence["events"]),
+            ruleset_path=str(evidence["ruleset"]),
+        )
+
+    assert written, "the fake Zircolite never ran"
+    assert result["status"] == "success"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_zircolite` returns `status: success` with `total_detections: 0` when Zircolite **failed to run at all** — a Sigma sweep that never happened is reported to the agent as a clean log.
- Root cause: `_run_zircolite_process` calls `subprocess.run(...)` and **discards the result**. The exit code is never read. Zircolite writes no results file on failure, and `_parse_zircolite_output` answers a missing file with an empty, authoritative-looking zero-detection dict.
- Fix: return the `CompletedProcess` alongside the output path; when Zircolite exited non-zero **and** wrote no results file, return `error_response(..., error_type="tool_failed")` with the exit code and a stderr/stdout preview.
- Scope: `src/mulder/server/tools/zircolite.py` only. No shared helper, no new abstraction, no change to any other tool.

## The bug

```python
    subprocess.run(cmd, capture_output=True, text=True,
                   timeout=_ZIRCOLITE_TIMEOUT, check=False)
    return output_file          # <- the process, and its exit code, are dropped
```

and then:

```python
    if not results_path.exists():
        return {... "detections": [], "total_detections": 0, ...}
```

Any Zircolite failure — argparse rejecting the invocation, an unreadable ruleset, a Python traceback — takes the missing-file branch and is presented as a completed scan that found nothing.

## The fix

`_run_zircolite_process` now returns `tuple[Path, subprocess.CompletedProcess[str]]`, and `run_zircolite` checks:

```python
        if proc.returncode != 0 and not results_path.exists():
            detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[
                :_STDERR_PREVIEW_CHARS
            ]
            return error_response(
                tc_id, "run_zircolite", params,
                f"Zircolite exited {proc.returncode} and wrote no results file: {detail}",
                (time.monotonic() - t0) * 1000,
                error_type="tool_failed",
            )
```

The guard is **conjunctive on purpose**. Zircolite exits non-zero when a single input is unreadable while having already written matches for the rest; those detections must not be thrown away. Two of the four tests pin that narrowness:

- exit 0 with no results file → still `success` (a quiet log is a real answer, not a failure);
- exit 1 with a results file present → still `success`, detections preserved.

## Deliberately out of scope

- **Partial-result surfacing.** Attaching a `warning` to a successful response would not reach the caller: when `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.
- **The `--json` flag.** On current `main` `_run_zircolite_process` passes `--json`, which Zircolite 2.20.0's argparse rejects. With this PR that stops being silent and starts returning an error — which is the correct behaviour and the clearest demonstration of the bug, but it is a **visible change**: runs that previously reported "0 detections" will now report the failure. The flag itself is a separate defect in a separate module concern and is not fixed here.

## Verification

- `uvx pre-commit run --all-files` → ruff, ruff-format, mypy all pass.
- `pytest tests/ -q` → **757 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check:** with `src/mulder/server/tools/zircolite.py` restored to `origin/main` and the new tests kept, the two bug tests fail with `assert 'success' == 'error'`, while the two narrowness tests pass. The tests cannot pass against a codebase where the bug never existed.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one module, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
