### PR TITLE
[high] fix(mvt): report a failed MVT run instead of a clean spyware scan

### DIFF
--- a/src/mulder/server/tools/mvt.py
+++ b/src/mulder/server/tools/mvt.py
@@ -25,6 +25,7 @@ from mulder.server.tool_access import Role, tool_access
 logger = logging.getLogger(__name__)
 
 _MVT_TIMEOUT = 600
+_STDERR_PREVIEW_CHARS = 500
 
 
 def _collect_mvt_results(output_dir: str) -> tuple[str, dict[str, int]]:
@@ -122,6 +123,17 @@ def run_mvt_android(
             )
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
+
+        if proc.returncode != 0 and not raw_output.strip():
+            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                f"mvt-android exited {proc.returncode} and produced no results: {detail}",
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
 
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()
@@ -222,6 +234,17 @@ def run_mvt_ios(
             )
 
         raw_output, module_counts = _collect_mvt_results(tmpdir)
+
+        if proc.returncode != 0 and not raw_output.strip():
+            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
+            return error_response(
+                tc_id,
+                tool_name,
+                params,
+                f"mvt-ios exited {proc.returncode} and produced no results: {detail}",
+                elapsed_ms=(time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
 
         if not raw_output.strip():
             raw_output = proc.stdout.strip() or proc.stderr.strip()

--- a/tests/test_mvt_exit_code.py
+++ b/tests/test_mvt_exit_code.py
@@ -1,0 +1,127 @@
+"""A failed MVT run must not be reported as a clean spyware scan.
+
+``run_mvt_android`` / ``run_mvt_ios`` never read ``proc.returncode``. When MVT
+fails it writes no JSON into the output directory, so ``_collect_mvt_results``
+comes back empty -- and the wrapper then falls back to *indexing MVT's stderr
+as if it were evidence* and returns ``status: success`` with ``detections: 0``.
+A Pegasus check that never ran looked exactly like a clean phone.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.mvt import run_mvt_android, run_mvt_ios
+
+_FAILURE = "Error: unable to open backup: not a valid Android backup"
+
+
+@pytest.fixture
+def backup(tmp_path: Path) -> Path:
+    """An evidence path that exists, so the run reaches MVT itself."""
+    path = tmp_path / "backup.ab"
+    path.write_bytes(b"ANDROID BACKUP\n")
+    return path
+
+
+def _invoke(tool: Any, evidence: Path, proc: subprocess.CompletedProcess[str]) -> Any:
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    with (
+        patch("mulder.server.tools.mvt.shutil.which", return_value="/usr/bin/mvt"),
+        patch("mulder.server.tools.mvt.subprocess.run", return_value=proc),
+        patch("mulder.server.tools.mvt.extract_and_index", side_effect=_record),
+    ):
+        result = tool.__wrapped__(str(evidence))
+    return result, indexed
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_mvt_android, "mvt-android"), (run_mvt_ios, "mvt-ios")],
+)
+def test_a_failed_scan_is_an_error_not_a_clean_phone(tool: Any, binary: str, backup: Path) -> None:
+    proc = subprocess.CompletedProcess(args=[binary], returncode=1, stdout="", stderr=_FAILURE)
+
+    result, indexed = _invoke(tool, backup, proc)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert binary in message
+    assert "exited 1" in message
+    assert "not a valid Android backup" in message
+    # The scan never happened, so it must not claim a detection count.
+    assert "detections" not in result
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_mvt_android, "mvt-android"), (run_mvt_ios, "mvt-ios")],
+)
+def test_an_error_message_is_never_indexed_as_evidence(
+    tool: Any, binary: str, backup: Path
+) -> None:
+    """The sharpest edge of the bug: stderr was stored in the case DB.
+
+    A later ``search()`` over the case would return MVT's own crash text as if
+    it were device evidence.
+    """
+    proc = subprocess.CompletedProcess(args=[binary], returncode=1, stdout="", stderr=_FAILURE)
+
+    _result, indexed = _invoke(tool, backup, proc)
+
+    assert indexed == [], f"MVT's failure text was indexed as evidence: {indexed}"
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_mvt_android, "mvt-android"), (run_mvt_ios, "mvt-ios")],
+)
+def test_a_genuinely_clean_device_is_still_a_success(tool: Any, binary: str, backup: Path) -> None:
+    """Pins the fix's narrowness: MVT exiting 0 with nothing found is a result.
+
+    A clean phone is the common case and must keep reporting as a success.
+    """
+    proc = subprocess.CompletedProcess(
+        args=[binary], returncode=0, stdout="No traces detected", stderr=""
+    )
+
+    result, _indexed = _invoke(tool, backup, proc)
+
+    assert result["status"] == "success"
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_mvt_android, "mvt-android"), (run_mvt_ios, "mvt-ios")],
+)
+def test_results_written_before_a_non_zero_exit_are_kept(
+    tool: Any, binary: str, backup: Path
+) -> None:
+    """MVT can fail on one module after others already produced findings.
+
+    The guard is conjunctive -- non-zero *and* no collected results -- so those
+    findings are not thrown away.
+    """
+    proc = subprocess.CompletedProcess(
+        args=[binary], returncode=1, stdout="", stderr="one module failed"
+    )
+
+    with patch(
+        "mulder.server.tools.mvt._collect_mvt_results",
+        return_value=("sms_detected: 2 entries", {"sms_detected": 2}),
+    ):
+        result, indexed = _invoke(tool, backup, proc)
+
+    assert result["status"] == "success"
+    assert indexed == ["sms_detected: 2 entries"]


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_mvt_android` / `run_mvt_ios` return `status: success` with `detections: 0` when MVT **failed to run** — a spyware check that never happened is reported as a clean phone.
- Worse: on failure the wrapper **indexes MVT's own stderr into the case DB as evidence**, so a later `search()` returns the crash text as if it were device data.
- Root cause: neither function ever reads `proc.returncode`. MVT writes no JSON on failure, `_collect_mvt_results` returns empty, and the existing fallback substitutes `proc.stderr` for the results.
- Fix: when MVT exited non-zero **and** produced no collected results, return `error_response(..., error_type="tool_failed")` with the exit code and a stderr/stdout preview.
- Scope: `src/mulder/server/tools/mvt.py` only. No shared helper, no new abstraction, no change to any other tool.

## The bug

```python
        raw_output, module_counts = _collect_mvt_results(tmpdir)

        if not raw_output.strip():
            raw_output = proc.stdout.strip() or proc.stderr.strip()   # <- stderr becomes "evidence"

    index_result = extract_and_index(raw_output, "mvt.android", evidence_path, "mvt")
```

`detections` is then summed over an empty `module_counts` — always `0` — and returned as a success.

## The fix

```python
        if proc.returncode != 0 and not raw_output.strip():
            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
            return error_response(
                tc_id, tool_name, params,
                f"mvt-android exited {proc.returncode} and produced no results: {detail}",
                elapsed_ms=(time.monotonic() - t0) * 1000,
                error_type="tool_failed",
            )
```

Applied identically to both entry points (one tool, two subcommands).

The guard is **conjunctive on purpose** — MVT can fail on one module after earlier modules already produced findings. Two of the four tests pin that narrowness:

- exit 0 with nothing found → still `success` (a clean phone is the common case);
- exit 1 with results already collected → still `success`, findings indexed.

## Deliberately out of scope

**Partial-result surfacing.** Attaching a `warning` to the successful response would not reach the caller: when `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.

## Verification

- `uvx pre-commit run --all-files` → ruff, ruff-format, mypy all pass.
- `pytest tests/ -q` → **761 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check:** with `src/mulder/server/tools/mvt.py` restored to `origin/main` and the new tests kept, the four bug tests fail — two on `assert 'success' == 'error'` and two on `MVT's failure text was indexed as evidence: ['Error: unable to open backup...']` — while the four narrowness tests pass. The tests cannot pass against a codebase where the bug never existed.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one module, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
