### PR TITLE
[high] fix(photorec): stop indexing a failed carve as "recovered 0 file(s)"

### DIFF
--- a/src/mulder/server/tools/extract/carving.py
+++ b/src/mulder/server/tools/extract/carving.py
@@ -36,6 +36,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+_STDERR_PREVIEW_CHARS = 500
 _BULK_TIMEOUT = 1800
 _SCALPEL_TIMEOUT = 1800
 _PHOTOREC_TIMEOUT = 3600
@@ -639,7 +640,7 @@ def run_photorec(image_path: str) -> dict[str, object]:
             f"search,{tmpdir}/",
         ]
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -656,6 +657,20 @@ def run_photorec(image_path: str) -> dict[str, object]:
             )
 
         report_path = Path(tmpdir) / "report.xml"
+        recovered_anything = report_path.exists() or any(
+            f.is_file() for f in Path(tmpdir).rglob("*")
+        )
+        if proc.returncode != 0 and not recovered_anything:
+            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
+            return error_response(
+                tc_id,
+                "run_photorec",
+                params,
+                f"photorec exited {proc.returncode} and carved nothing: {detail}",
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+            )
+
         report_text = ""
         if report_path.exists():
             report_text = report_path.read_text(errors="replace")

--- a/tests/test_photorec_exit_code.py
+++ b/tests/test_photorec_exit_code.py
@@ -1,0 +1,117 @@
+"""A failed PhotoRec run must not be indexed as an authoritative empty carve.
+
+``run_photorec`` discarded PhotoRec's ``CompletedProcess`` entirely -- return
+code and stderr were never examined. When PhotoRec failed it wrote neither
+``report.xml`` nor any carved file, and the wrapper synthesised the string
+``"PhotoRec recovered 0 file(s):"`` and indexed *that* into the case DB as the
+result. An analyst searching the case later reads a confident statement that
+the disk image contained nothing recoverable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.extract.carving import run_photorec
+
+
+@pytest.fixture
+def image(tmp_path: Path) -> Path:
+    """A disk image that exists, so the run reaches PhotoRec itself."""
+    path = tmp_path / "evidence.dd"
+    path.write_bytes(b"\x00" * 4096)
+    return path
+
+
+def _invoke(image: Path, proc_or_fn: Any) -> tuple[Any, list[str]]:
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    kwargs = {"side_effect": proc_or_fn} if callable(proc_or_fn) else {"return_value": proc_or_fn}
+    with (
+        patch("mulder.server.tools.extract.carving.require_binary", return_value=True),
+        patch(
+            "mulder.server.tools.extract.carving.sources_already_indexed",
+            return_value=[],
+        ),
+        patch("mulder.server.tools.extract.carving._check_disk_space", return_value=None),
+        patch("mulder.server.tools.extract.carving.subprocess.run", **kwargs),
+        patch("mulder.server.tools.extract.carving.extract_and_index", side_effect=_record),
+    ):
+        result = run_photorec.__wrapped__(str(image))  # type: ignore[attr-defined]
+    return result, indexed
+
+
+def test_a_failed_carve_is_an_error_not_an_empty_result(image: Path) -> None:
+    proc = subprocess.CompletedProcess(
+        args=["photorec"],
+        returncode=1,
+        stdout="",
+        stderr="photorec: cannot open evidence.dd: Permission denied",
+    )
+
+    result, _indexed = _invoke(image, proc)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert "exited 1" in message
+    assert "Permission denied" in message
+
+
+def test_the_zero_files_claim_is_never_written_to_the_case(image: Path) -> None:
+    """The sharpest edge: 'PhotoRec recovered 0 file(s)' entering the case DB.
+
+    That sentence is a forensic assertion about the evidence. It must not be
+    manufactured from a run that never read the image.
+    """
+    proc = subprocess.CompletedProcess(
+        args=["photorec"], returncode=1, stdout="", stderr="cannot open device"
+    )
+
+    _result, indexed = _invoke(image, proc)
+
+    assert indexed == [], f"a failed carve was indexed as a result: {indexed}"
+
+
+def test_a_genuinely_empty_image_is_still_a_success(image: Path) -> None:
+    """Pins the fix's narrowness: PhotoRec exiting 0 having carved nothing.
+
+    A wiped or genuinely empty image is a real answer and must keep reporting
+    as a success -- otherwise the fix trades silent failures for false alarms.
+    """
+    proc = subprocess.CompletedProcess(args=["photorec"], returncode=0, stdout="", stderr="")
+
+    result, indexed = _invoke(image, proc)
+
+    assert result["status"] == "success"
+    assert indexed and "recovered 0 file(s)" in indexed[0]
+
+
+def test_files_carved_before_a_non_zero_exit_are_kept(image: Path) -> None:
+    """PhotoRec can hit a bad sector after recovering real files.
+
+    The guard is conjunctive -- non-zero *and* nothing carved -- so recovered
+    evidence is never discarded because of a late failure.
+    """
+
+    def _carve(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        outdir = Path(cmd[-1].split(",", 1)[1])
+        outdir.mkdir(parents=True, exist_ok=True)
+        (outdir / "f0000001.jpg").write_bytes(b"\xff\xd8\xff")
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr="read error at sector 99"
+        )
+
+    result, indexed = _invoke(image, _carve)
+
+    assert result["status"] == "success"
+    assert indexed and "recovered 1 file(s)" in indexed[0]


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_photorec` returns `status: success` when PhotoRec **failed to run**, and writes the sentence **`"PhotoRec recovered 0 file(s):"` into the case DB** as the result.
- That sentence is a forensic assertion about the evidence. It was being manufactured from a run that never opened the image — an analyst searching the case reads a confident "nothing recoverable" that no tool ever established.
- Root cause: `run_photorec` calls `subprocess.run(...)` and **discards the result**. Return code and stderr are never examined, so the missing-report path is indistinguishable from a genuinely empty image.
- Fix: capture the `CompletedProcess`; when PhotoRec exited non-zero **and** neither `report.xml` nor any carved file exists, return `error_response(..., error_type="tool_failed")` with the exit code and a stderr/stdout preview.
- Scope: `src/mulder/server/tools/extract/carving.py`, `run_photorec` only. No shared helper, no new abstraction, no change to the other carvers in the module.

## The bug

```python
        try:
            subprocess.run(cmd, capture_output=True, text=True,
                           timeout=timeout, check=False)      # <- result dropped
        except subprocess.TimeoutExpired:
            ...
        report_path = Path(tmpdir) / "report.xml"
        ...
        if not report_text.strip():
            recovered = list(Path(tmpdir).rglob("*"))
            file_list = [...]
            report_text = f"PhotoRec recovered {len(file_list)} file(s):\n" + ...
        summary = extract_and_index(report_text, "photorec.report", image_path, "photorec")
```

Permission denied on the image, an unsupported container, a missing `/cmd` subcommand — all land in the same branch and are indexed as `recovered 0 file(s)`.

## The fix

```python
        recovered_anything = report_path.exists() or any(
            f.is_file() for f in Path(tmpdir).rglob("*")
        )
        if proc.returncode != 0 and not recovered_anything:
            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
            return error_response(
                tc_id, "run_photorec", params,
                f"photorec exited {proc.returncode} and carved nothing: {detail}",
                (time.monotonic() - t0) * 1000,
                error_type="tool_failed",
            )
```

The guard is **conjunctive on purpose** — PhotoRec can hit a bad sector after recovering real files, and that evidence must survive. Two of the four tests pin that narrowness:

- exit 0 having carved nothing → still `success`, `recovered 0 file(s)` indexed (a wiped image is a real answer);
- exit 1 with one carved file → still `success`, `recovered 1 file(s)` indexed.

## Deliberately out of scope

**Partial-result surfacing.** Attaching a `warning` to the successful response would not reach the caller: when `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.

## Verification

- `uvx pre-commit run --all-files` → ruff, ruff-format, mypy all pass.
- `pytest tests/ -q` → **757 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check:** with `src/mulder/server/tools/extract/carving.py` restored to `origin/main` and the new tests kept, the two bug tests fail — `assert 'success' == 'error'` and `a failed carve was indexed as a result: ['PhotoRec recovered 0 file(s):']` — while the two narrowness tests pass. The tests cannot pass against a codebase where the bug never existed.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one function, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
