### PR TITLE
[medium] build(make): make the local targets check what CI checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,42 @@ CONTAINER_ENGINE ?= $(shell \
 IMAGE_NAME ?= mulder
 IMAGE_TAG  ?= dev
 
-.PHONY: all install lint format typecheck test precommit build dist-check assets-lock container-build container-run clean
+.PHONY: all install hooks lint format typecheck test precommit build dist-check assets-lock container-build container-run clean
 
 install:
 	uv pip install -e ".[dev]"
 
+# Run once after cloning. The installed git hook checks the *staged* set at
+# commit time, which is the only local check a brand-new file cannot slip past
+# (see the note on `precommit` below).
+hooks:
+	pre-commit install
+
+# lint/format/typecheck are fast inner-loop targets, not the gate: they cover
+# less than CI does. `make precommit` is the gate. ruff's scope here matches
+# the pre-commit hooks, which pass no path restriction and so cover tests/ too.
 lint:
-	ruff check src/
+	ruff check src/ tests/
 
 format:
-	ruff format src/
+	ruff format src/ tests/
 
+# CI runs mypy --strict over src/ *and* tests/ inside pre-commit's own isolated
+# environment. This target is the narrower src-only pass; use `make precommit`
+# before pushing.
 typecheck:
 	mypy src/mulder
 
 test:
 	pytest tests/ -v
 
+# `pre-commit run --all-files` enumerates files with `git ls-files`, which lists
+# tracked files only -- a newly written file that has not been `git add`-ed is
+# invisible to every hook, so this target would report a clean pass and CI would
+# then fail on it. Passing the tracked *and* untracked-not-ignored set closes
+# that gap.
 precommit:
-	pre-commit run --all-files
+	pre-commit run --files $$(git ls-files -co --exclude-standard)
 
 # Maintainer chore, never CI: downloads every digest-pinnable asset and
 # rewrites src/mulder/assets/assets.lock. Re-run it in the same PR as any
@@ -56,4 +73,6 @@ clean:
 	rm -rf dist/ build/ *.egg-info .pytest_cache .mypy_cache
 	find . -type d -name __pycache__ -exec rm -rf {} +
 
-all: lint format typecheck test
+# The default goal is the gate CI actually enforces: the pre-commit hooks
+# (ruff, ruff-format, mypy --strict over src/ and tests/) plus the test suite.
+all: precommit test


### PR DESCRIPTION
## BLUF

- **Priority: medium.** Contributor tooling — no runtime code changes.
- `make` can report a clean pass on a branch that CI then fails. Three separate gaps, all in `Makefile`:
  1. **`make precommit` cannot see new files.** `pre-commit run --all-files` enumerates via `git ls-files` — *tracked files only*. A file you just wrote and have not `git add`-ed is invisible to every hook.
  2. **`make lint` / `make format` cover `src/` only**, while the ruff pre-commit hooks pass no path restriction and so also cover `tests/`.
  3. **`make all` isn't the gate.** The default goal runs `lint format typecheck test` — `ruff check src/` and `mypy src/mulder` — whereas CI runs the pre-commit hooks (`mypy --strict` over `src/` **and** `tests/`) plus `pytest`.
- Fix: `precommit` runs over the tracked *and* untracked-not-ignored set; `lint`/`format` match the hooks' scope; `all` becomes `precommit test`; new `make hooks` installs the git hook.
- Scope: `Makefile` only. No workflow change, no config change, no source change.

## Why gap 1 is the dangerous one

The output is actively reassuring. With an untracked `tests/_probe.py` containing `def f(x): return x` — a `no-untyped-def` error under `--strict`:

```
$ pre-commit run --all-files          # the old target
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed

$ pre-commit run --files $(git ls-files -co --exclude-standard)   # the new one
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Failed
```

Same tree, same hooks, opposite verdicts. The old run says `165 files left unchanged` and never mentions the file it did not look at.

One nuance worth knowing: for a *formatting* hook the new target rewrites the untracked file in place but still reports `Passed` — pre-commit detects "files were modified by this hook" through `git diff`, which cannot see an untracked file. The file is fixed before it is ever committed, so CI stays green either way; checking hooks like mypy fail loudly as shown above.

## The change

```make
hooks:
	pre-commit install

lint:
	ruff check src/ tests/

format:
	ruff format src/ tests/

precommit:
	pre-commit run --files $$(git ls-files -co --exclude-standard)

all: precommit test
```

`typecheck` is deliberately left as the narrower `mypy src/mulder`: it is a fast inner-loop target, and the `--strict` pass belongs to pre-commit's own isolated environment (running `mypy --strict` from a local venv picks up stub sets CI never installs). The comments in the file say so.

## Verification

- `uvx ruff check src/ tests/` → **All checks passed**; `uvx ruff format --check src/ tests/` → **150 files already formatted**. The widened scope is already clean on `main`, so this adds no work to anyone's branch.
- `uvx pre-commit run --all-files` → ruff, ruff-format, mypy all pass.
- The A/B above was run on this branch, not reasoned about: the same untracked file passes the old target and fails the new one.
- `pre-commit install` verified in a worktree — a freshly staged, unformatted file is blocked at commit time. It installs into the common git dir, so one install covers every worktree of the clone.

## Motivation

Two of my own draft PRs (#92, #93) were pushed after a green local `make`-equivalent run and failed CI's `Pre-commit checks` on `ruff-format`, in both cases on the new test file the PR added. A third (#91) passed only because its new file happened to already be format-clean. That is gap 1 exactly. Gap 3 is the same shape as the earlier round of `no-untyped-def` / `unused-ignore` CI failures on test files, which `mypy src/mulder` cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
