### PR TITLE
[high] fix(email): report a failed readpst run instead of an empty mailbox

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 _READPST_TIMEOUT = 600
 _READPST_BINARY = "/usr/bin/readpst"
+_STDERR_PREVIEW_CHARS = 500
 
 _SUSPICIOUS_EXTENSIONS: set[str] = {
     ".exe",
@@ -345,7 +346,7 @@ def parse_pst(
 
         pst_timeout = adaptive_timeout(file_path, base=_READPST_TIMEOUT)
         try:
-            subprocess.run(
+            proc = subprocess.run(
                 cmd,
                 capture_output=True,
                 text=True,
@@ -368,6 +369,17 @@ def parse_pst(
                 params,
                 f"Failed to execute readpst: {exc}",
                 (time.monotonic() - t0) * 1000,
+            )
+
+        if proc.returncode != 0 and not any(output_dir.rglob("*.eml")):
+            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
+            return error_response(
+                tc_id,
+                "parse_pst",
+                params,
+                f"readpst exited {proc.returncode} and extracted no messages: {detail}",
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
             )
 
         result = _parse_extracted_emails(

--- a/tests/test_readpst_exit_code.py
+++ b/tests/test_readpst_exit_code.py
@@ -1,0 +1,142 @@
+"""A failed readpst run must not be reported as a PST containing no mail.
+
+``parse_pst`` called ``subprocess.run(...)`` without even binding the result,
+so readpst's exit code was never read. When readpst fails it writes no ``.eml``
+files, ``_parse_extracted_emails`` walks an empty directory and answers
+``total_emails: 0``, and the wrapper indexes a bare ``"PST Analysis: <path>"``
+header into the case DB and returns ``status: success``. A mailbox that was
+never opened was indistinguishable from a mailbox with nothing in it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.email import parse_pst
+
+_FAILURE = "Error: unable to open PST file: not a valid PST"
+
+
+@pytest.fixture
+def pst(tmp_path: Path) -> Path:
+    """A .pst file that exists, so the run reaches readpst itself."""
+    path = tmp_path / "mailbox.pst"
+    path.write_bytes(b"!BDN" + b"\x00" * 512)
+    return path
+
+
+def _invoke(pst: Path, run: Any) -> tuple[Any, list[str]]:
+    """Run ``parse_pst`` with readpst itself replaced by *run*."""
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    kwargs = {"side_effect": run} if callable(run) else {"return_value": run}
+    with (
+        patch("mulder.server.tools.email.require_binary", return_value="/usr/bin/readpst"),
+        patch("mulder.server.tools.email.subprocess.run", **kwargs),
+        patch("mulder.server.tools.email.extract_and_index", side_effect=_record),
+    ):
+        result = parse_pst.__wrapped__("case-1", str(pst))  # type: ignore[attr-defined]
+    return result, indexed
+
+
+def _write_eml(cmd: list[str], count: int) -> None:
+    """Write *count* .eml files into the -o directory readpst was given."""
+    outdir = Path(cmd[cmd.index("-o") + 1])
+    outdir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):
+        (outdir / f"msg{i}.eml").write_text(
+            "From: alice@example.com\n"
+            "To: bob@example.com\n"
+            "Subject: quarterly numbers\n"
+            "Date: Mon, 1 Jan 2024 09:00:00 +0000\n"
+            "Content-Type: text/plain\n"
+            "\n"
+            "body\n"
+        )
+
+
+def test_a_failed_extraction_is_an_error_not_an_empty_mailbox(pst: Path) -> None:
+    """The shape that made this silent: readpst rejects the file outright."""
+    proc = subprocess.CompletedProcess(args=["readpst"], returncode=1, stdout="", stderr=_FAILURE)
+
+    result, _indexed = _invoke(pst, proc)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert "readpst" in message
+    assert "exited 1" in message
+    assert "not a valid PST" in message
+    # A mailbox that was never opened must not claim a message count.
+    assert "total_emails" not in result
+
+
+def test_a_failed_extraction_is_never_summarised_into_the_case(pst: Path) -> None:
+    """The sharpest edge: 'PST Analysis: <path>' entering the case DB.
+
+    That line is a forensic assertion that the PST was read. It must not be
+    manufactured from a run that never opened the file.
+    """
+    proc = subprocess.CompletedProcess(args=["readpst"], returncode=1, stdout="", stderr=_FAILURE)
+
+    _result, indexed = _invoke(pst, proc)
+
+    assert indexed == [], f"a failed extraction was indexed as a result: {indexed}"
+
+
+def test_the_report_carries_stdout_when_readpst_is_silent_on_stderr(pst: Path) -> None:
+    """Some readpst failures print only to stdout; the detail must survive."""
+    proc = subprocess.CompletedProcess(
+        args=["readpst"], returncode=2, stdout="cannot create output directory", stderr=""
+    )
+
+    result, _indexed = _invoke(pst, proc)
+
+    assert result["status"] == "error"
+    assert "cannot create output directory" in str(result["error_message"])
+
+
+def test_a_genuinely_empty_pst_is_still_a_success(pst: Path) -> None:
+    """Pins the fix's narrowness: exit 0 with no messages stays a success.
+
+    An archived-but-emptied mailbox is a real answer, not a failure, and must
+    keep reporting as one -- otherwise the fix trades silent failures for
+    false alarms.
+    """
+    proc = subprocess.CompletedProcess(args=["readpst"], returncode=0, stdout="", stderr="")
+
+    result, indexed = _invoke(pst, proc)
+
+    assert result["status"] == "success"
+    assert indexed, "a successful empty extraction must still be summarised"
+
+
+def test_messages_extracted_before_a_non_zero_exit_are_kept(pst: Path) -> None:
+    """readpst can fail on a corrupt folder after extracting earlier ones.
+
+    The guard is conjunctive -- non-zero *and* no .eml written -- so recovered
+    mail is never discarded because of a late failure.
+    """
+    written: list[int] = []
+
+    def _extract_then_fail(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        _write_eml(cmd, 2)
+        written.append(2)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr="corrupt folder at offset 4096"
+        )
+
+    result, indexed = _invoke(pst, _extract_then_fail)
+
+    assert written, "the fake readpst never wrote its .eml files"
+    assert result["status"] == "success"
+    assert indexed and "quarterly numbers" in indexed[0]


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `parse_pst` returns `status: success` with `total_emails: 0` when readpst **failed to run** — a PST that was never opened is reported to the agent as a mailbox containing no mail.
- Worse: the wrapper then **writes `"PST Analysis: <path>"` into the case DB**, a line that asserts the PST *was* read. An analyst searching the case later finds that claim backed by nothing.
- Root cause: `subprocess.run(...)` is called **without even binding its result**, so the exit code is never available, let alone checked. `_parse_extracted_emails` walks the empty output directory and answers `total_emails: 0`.
- Fix: capture the `CompletedProcess`; when readpst exited non-zero **and** wrote no `.eml` files, return `error_response(..., error_type="tool_failed")` with the exit code and a stderr/stdout preview.
- Scope: `src/mulder/server/tools/email.py` only. No shared helper, no new abstraction, no change to any other tool.

## The bug

```python
        try:
            subprocess.run(                     # <- result not even assigned
                cmd,
                capture_output=True,
                text=True,
                timeout=pst_timeout,
                check=False,
            )
        except subprocess.TimeoutExpired:
            ...

        result = _parse_extracted_emails(output_dir, file_path, ...)
```

and `_parse_extracted_emails` over an empty directory:

```python
    for eml_file in sorted(output_dir.rglob("*.eml")):
        ...
    return {"file_path": file_path, "total_emails": len(emails), ...}
```

A corrupt PST, a wrong password on an encrypted store, a missing output directory — all produce zero `.eml` files and are reported as an empty mailbox.

## The fix

```python
        if proc.returncode != 0 and not any(output_dir.rglob("*.eml")):
            detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
            return error_response(
                tc_id,
                "parse_pst",
                params,
                f"readpst exited {proc.returncode} and extracted no messages: {detail}",
                (time.monotonic() - t0) * 1000,
                error_type="tool_failed",
            )
```

The guard is **conjunctive on purpose** — readpst exits non-zero on a corrupt folder after having already extracted earlier ones, and that recovered mail must survive. Two of the five tests pin that narrowness:

- exit 0 with no messages → still `success`, still summarised (an archived-but-emptied mailbox is a real answer);
- exit 1 after two `.eml` files were written → still `success`, both messages parsed and indexed.

## Deliberately out of scope

- **Partial-result surfacing.** Attaching a `warning` to the successful response would not reach the caller: when `source` is set, `tool_response` in `helpers.py` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.
- **Message-level parsing.** Closed PR #78 (`fix/email-parsing`, "stop the PST parser silently dropping messages") addresses how individual messages are read once extraction has succeeded. That is a different concern and none of it is pulled in here.

## Verification

- `git add -A` then `uvx pre-commit run --all-files` → ruff, ruff-format, mypy all pass. (Staging first is load-bearing: `--all-files` enumerates via `git ls-files` and cannot see an untracked new test file.)
- `pytest tests/ -q --deselect "tests/test_disk_pcap.py::TestAnalyzeDiskPcapsTool::test_size_filtering_skips_large_pcaps"` → **758 passed**, 1 deselected. That test writes a real 200 MB file and fails here with `OSError: [Errno 122] Disk quota exceeded` on unmodified `main` too — an environment disk quota, not a regression.
- **Discriminating check:** with `src/mulder/server/tools/email.py` restored to `origin/main` and the new tests kept, **3 of 5 fail** while both narrowness tests pass:

```
FAILED tests/test_readpst_exit_code.py::test_a_failed_extraction_is_an_error_not_an_empty_mailbox
  - AssertionError: assert 'success' == 'error'
FAILED tests/test_readpst_exit_code.py::test_a_failed_extraction_is_never_summarised_into_the_case
  - AssertionError: a failed extraction was indexed as a result:
    ['PST Analysis: /tmp/pytest-of-elhoim/pytest-470/test_a_failed_extraction_is_ne0/mailbox.pst']
FAILED tests/test_readpst_exit_code.py::test_the_report_carries_stdout_when_readpst_is_silent_on_stderr
  - AssertionError: assert 'success' == 'error'
3 failed, 2 passed
```

The tests cannot pass against a codebase where the bug never existed.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one module, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
