### PR TITLE
[high] fix(helpers): stop run_cli_tool reporting a failed tool as a clean run

### DIFF
--- a/src/mulder/server/helpers.py
+++ b/src/mulder/server/helpers.py
@@ -535,7 +535,9 @@ def run_cli_tool(
         check_exists: Optional file path to verify exists before running.
 
     Returns:
-        Standardized tool response dict (success or error).
+        Standardized tool response dict (success or error). A tool that exits
+        non-zero without writing anything to stdout is reported as an error
+        rather than indexed as an empty result.
     """
     import time
 
@@ -566,6 +568,17 @@ def run_cli_tool(
     if isinstance(result, str):
         return error_response(tc_id, tool_name, params, result, error_type="timeout")
     proc = result
+
+    if proc.returncode != 0 and not proc.stdout.strip():
+        detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[:_PREVIEW_CHAR_LIMIT]
+        return error_response(
+            tc_id,
+            tool_name,
+            params,
+            f"{binary} exited {proc.returncode} and produced no output: {detail}",
+            (time.monotonic() - t0) * 1000,
+            error_type="tool_failed",
+        )
 
     summary = extract_and_index(proc.stdout.strip(), source_name, source_path, extractor_label)
     elapsed = (time.monotonic() - t0) * 1000

--- a/tests/test_run_cli_tool_exit_code.py
+++ b/tests/test_run_cli_tool_exit_code.py
@@ -1,0 +1,176 @@
+"""A CLI tool that failed must not be reported as a clean, empty extraction.
+
+``run_cli_tool`` never inspected ``proc.returncode``. It indexed
+``proc.stdout.strip()`` -- the empty string, when the tool died before writing
+anything -- and returned ``status: success``. Because ``extract_and_index``
+registers a source row for empty input (``blake2b:empty``,
+``status: indexed_empty``), a failed run left a durable case-DB record
+asserting the extraction had happened and found nothing.
+
+Five wrapped tools route through this wrapper: strings, hashdeep, exiftool,
+ssdeep and pasco.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.extract.misc import run_exiftool, run_strings
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> Path:
+    """A target that exists, so the run reaches the wrapped binary."""
+    path = tmp_path / "evidence.bin"
+    path.write_bytes(b"\x00" * 64)
+    return path
+
+
+def _invoke(
+    tool: Any, target: Path, proc: subprocess.CompletedProcess[str]
+) -> tuple[Any, list[str]]:
+    """Run *tool* with the wrapped binary replaced by *proc*.
+
+    ``extract_and_index`` is patched where it is defined, not on ``helpers``:
+    ``run_cli_tool`` imports it inside the function body.
+    """
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {"source_name": "s", "windows_indexed": 0, "line_count": 0}
+
+    with (
+        patch("mulder.server.helpers.require_binary", return_value=True),
+        patch("mulder.server.helpers.run_subprocess", return_value=proc),
+        patch("mulder.server.extract_helpers.extract_and_index", side_effect=_record),
+    ):
+        result = tool.__wrapped__(str(target))
+    return result, indexed
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_strings, "strings"), (run_exiftool, "exiftool")],
+)
+def test_a_failed_tool_is_an_error_not_an_empty_extraction(
+    tool: Any, binary: str, evidence: Path
+) -> None:
+    """The observed shape: exit 1, message on stderr, nothing on stdout.
+
+    Recorded from the real binary::
+
+        $ strings -n8 /nonexistent/evidence.bin
+        exit=1  stdout bytes=0
+        stderr: strings: '/nonexistent/evidence.bin': No such file
+    """
+    proc = subprocess.CompletedProcess(
+        args=[binary],
+        returncode=1,
+        stdout="",
+        stderr=f"{binary}: evidence.bin: Permission denied",
+    )
+
+    result, _indexed = _invoke(tool, evidence, proc)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert binary in message
+    assert "exited 1" in message
+    assert "Permission denied" in message
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_strings, "strings"), (run_exiftool, "exiftool")],
+)
+def test_a_failed_tool_registers_no_source_in_the_case(
+    tool: Any, binary: str, evidence: Path
+) -> None:
+    """The durable harm: ``extract_and_index("")`` registers a source row.
+
+    For empty input it writes a source with ``source_hash="blake2b:empty"``
+    and ``status="indexed_empty"`` -- a permanent case record saying this
+    extractor ran against this evidence and found nothing. A run that never
+    read the evidence must not leave that behind, so the wrapper must not
+    reach ``extract_and_index`` at all.
+    """
+    proc = subprocess.CompletedProcess(
+        args=[binary], returncode=1, stdout="", stderr="cannot open input"
+    )
+
+    _result, indexed = _invoke(tool, evidence, proc)
+
+    assert indexed == [], f"a failed {binary} run was indexed as a source: {indexed!r}"
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_strings, "strings"), (run_exiftool, "exiftool")],
+)
+def test_a_genuinely_empty_result_is_still_a_success(
+    tool: Any, binary: str, evidence: Path
+) -> None:
+    """Pins the fix's narrowness: exit 0 with no output is a real answer.
+
+    Recorded from the real binary -- a file with no printable runs::
+
+        $ strings -n8 zeros.bin
+        exit=0  stdout bytes=0  stderr: (empty)
+
+    That is "this evidence contains no strings", which is a finding. It must
+    keep reporting as a success and must still be indexed.
+    """
+    proc = subprocess.CompletedProcess(args=[binary], returncode=0, stdout="", stderr="")
+
+    result, indexed = _invoke(tool, evidence, proc)
+
+    assert result["status"] == "success"
+    assert indexed == [""], "a genuinely empty result must still register its source"
+
+
+@pytest.mark.parametrize(
+    ("tool", "binary"),
+    [(run_strings, "strings"), (run_exiftool, "exiftool")],
+)
+def test_output_produced_before_a_non_zero_exit_is_kept(
+    tool: Any, binary: str, evidence: Path
+) -> None:
+    """A tool can fail on one input after writing results for earlier ones.
+
+    The guard is conjunctive -- non-zero *and* empty stdout -- so real output
+    is never discarded because of a late failure.
+    """
+    proc = subprocess.CompletedProcess(
+        args=[binary],
+        returncode=1,
+        stdout="/evidence/one.bin: MZ header found\n",
+        stderr="/evidence/two.bin: Permission denied",
+    )
+
+    result, indexed = _invoke(tool, evidence, proc)
+
+    assert result["status"] == "success"
+    assert indexed == ["/evidence/one.bin: MZ header found"]
+
+
+def test_whitespace_only_output_counts_as_no_output(evidence: Path) -> None:
+    """The guard uses the same ``.strip()`` the index call already uses.
+
+    A tool that emitted only a newline before dying produced nothing usable,
+    and must not be treated as having output.
+    """
+    proc = subprocess.CompletedProcess(
+        args=["strings"], returncode=1, stdout="\n  \n", stderr="read error"
+    )
+
+    result, indexed = _invoke(run_strings, evidence, proc)
+
+    assert result["status"] == "error"
+    assert indexed == []


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_cli_tool` never inspects `proc.returncode`. A wrapped tool that failed is reported to the agent as `status: success` with an empty extraction.
- **Five tools route through this wrapper**, all in `src/mulder/server/tools/extract/misc.py`: **`strings`** (`run_strings`), **`hashdeep`** (`run_hashdeep`), **`exiftool`** (`run_exiftool`), **`ssdeep`** (`run_ssdeep`), **`pasco`** (`run_pasco`).
- The harm is durable, not just cosmetic: `extract_and_index("")` **registers a source row** with `source_hash="blake2b:empty"` and `status="indexed_empty"`, so every failed run leaves a permanent case-DB record asserting that the extractor ran against that evidence and found nothing.
- Fix: when the tool exits non-zero **and** wrote nothing to stdout, return `error_response(..., error_type="tool_failed")` with the binary, exit code and a stderr/stdout preview.
- Scope: one guard inside `run_cli_tool`. **No new constant, no new helper, no new abstraction** — net diff is +14 lines in one function plus a docstring line.

## The bug

```python
    result = run_subprocess(cmd, timeout=timeout)
    if isinstance(result, str):
        return error_response(tc_id, tool_name, params, result, error_type="timeout")
    proc = result

    summary = extract_and_index(proc.stdout.strip(), source_name, source_path, extractor_label)
    elapsed = (time.monotonic() - t0) * 1000
    return tool_response(tc_id, tool_name, params, summary, source_name, elapsed)
```

`returncode` is never read. On failure `proc.stdout.strip()` is `""`, and `extract_and_index` treats empty input as a real, empty extraction:

```python
    if not raw_output or not raw_output.strip():
        source_id = ctx.db.register_source(
            source_name=source_name, source_path=source_path,
            source_hash="blake2b:empty", extractor=extractor_name, line_count=0,
        )
        return {..., "windows_indexed": 0, "line_count": 0, "status": "indexed_empty"}
```

## The fix

```python
    if proc.returncode != 0 and not proc.stdout.strip():
        detail = ((proc.stderr or "").strip() or (proc.stdout or "").strip())[:_PREVIEW_CHAR_LIMIT]
        return error_response(
            tc_id,
            tool_name,
            params,
            f"{binary} exited {proc.returncode} and produced no output: {detail}",
            (time.monotonic() - t0) * 1000,
            error_type="tool_failed",
        )
```

It reuses the module's existing `_PREVIEW_CHAR_LIMIT` (500) rather than introducing a second constant of the same value in the same file: both govern the same thing — how much raw tool output to surface to the agent.

### Why the conjunction, measured rather than assumed

`strings` is the one of the five installed in this environment, so its behaviour was recorded rather than reasoned about:

| case | exit | stdout | stderr |
|---|---|---|---|
| `strings -n8 /nonexistent/evidence.bin` | 1 | 0 bytes | `strings: '/nonexistent/evidence.bin': No such file` |
| `strings -n8 unreadable.bin` (mode 000) | 1 | 0 bytes | `strings: unreadable.bin: Permission denied` |
| `strings -n8 zeros.bin` (64 zero bytes) | **0** | 0 bytes | *(empty)* |

The third row is the one that must keep working: "this evidence contains no printable strings" is a finding, and it still returns `success` and still registers its source. Under this predicate **no currently-useful result becomes an error** — if stdout is empty and the exit was 0 there was genuinely nothing to report; if the exit was non-zero but stdout has content, the tool produced usable output before failing and it is kept. The guard reuses the same `.strip()` the index call already used, so whitespace-only output counts as empty for both.

**What this does not catch, stated plainly:** the guard detects "ran and produced nothing". A tool that prints an error message *to stdout* and exits non-zero still indexes that message. `exiftool` in particular emits `Error: ...` lines on stdout, so not every `exiftool` failure is covered by this change. Only the "exited non-zero, wrote nothing" class is fixed here.

## Why this one touches `helpers.py`

The other tool-failure fixes in this series deliberately inline their check in a single tool module. This one is different in kind: `run_cli_tool` is an **existing shared wrapper** whose own error handling is incomplete — it already owns the binary check, the file-existence check and the timeout branch, and the exit-code check is the missing member of that same set. Fixing it here is not a new cross-cutting abstraction; it is completing a function that already exists.

Explicitly: the `classify_tool_exit` helper from closed PR #70 is **not** reintroduced, and **no new status taxonomy is added**. `error_type` is an existing free-form string field with roughly 19 distinct values already in use across the codebase (`binary_missing`, `file_not_found`, `timeout`, `os_error`, `extraction_failed`, …); this adds one more descriptive value to that set and nothing else.

## Deliberately out of scope

- **Partial-result surfacing.** Attaching a `warning` to a successful response would not reach the caller: when `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.
- The `isinstance(result, str)` branch labels an `OSError` from `run_subprocess` as `error_type="timeout"`, which is inaccurate. Adjacent, real, and left alone — it is not this PR's concern.

## Verification

- `uvx pre-commit run --all-files`, with the new test file **staged first** so the hooks actually see it → ruff, ruff-format, mypy all pass (141 source files).
- Full suite → **762 passed**. The only failure is `test_disk_pcap.py::TestAnalyzeDiskPcapsTool::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and dies with `OSError: [Errno 122] Disk quota exceeded` in this environment; it fails identically on unmodified `main` and passes in CI. Not a regression.
- No existing test referenced `run_cli_tool` or any of the five tools, so nothing encoded the old behaviour.
- **Discriminating check** — with `src/mulder/server/helpers.py` restored to `origin/main` and the new tests kept, 5 of 9 fail and the 4 narrowness tests pass:

```
guard present (must be False): False
FAILED test_a_failed_tool_is_an_error_not_an_empty_extraction[run_strings-strings] - AssertionError: assert 'success' == 'error'
FAILED test_a_failed_tool_is_an_error_not_an_empty_extraction[run_exiftool-exiftool] - AssertionError: assert 'success' == 'error'
FAILED test_a_failed_tool_registers_no_source_in_the_case[run_strings-strings] - AssertionError: a failed strings run was indexed as a source: ['']
FAILED test_a_failed_tool_registers_no_source_in_the_case[run_exiftool-exiftool] - AssertionError: a failed exiftool run was indexed as a source: ['']
FAILED test_whitespace_only_output_counts_as_no_output - AssertionError: assert 'success' == 'error'
5 failed, 4 passed
```

The `['']` in those two lines is the empty string that was being registered as a source. The check asserts the reverted file is actually the one imported (`guard present: False`) before drawing that conclusion, so the result cannot come from testing the wrong copy of the module.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place. Verified conflict-free against the other open PR that touches `helpers.py` (#86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
