### PR TITLE
[high] fix(olevba): stop reporting an unreadable document as macro-free

### DIFF
--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _OLEVBA_TIMEOUT = 120
+_STDERR_PREVIEW_CHARS = 500
 _PDFID_TIMEOUT = 60
 _PDF_PARSER_TIMEOUT = 120
 
@@ -221,7 +222,9 @@ def _analyze_macros_olevba(
 
     Raises:
         subprocess.TimeoutExpired: If olevba exceeds the timeout.
-        OSError: If olevba cannot be executed or exits non-zero with no output.
+        OSError: If olevba cannot be executed, or exits non-zero without
+            producing a usable result -- no output at all, output that is not
+            JSON, or JSON whose only content is olevba's own error records.
     """
     # oletools is a mulder dependency, so its console scripts live in mulder's
     # own venv bin/ — which pipx does not link onto PATH.  Invoke the module.
@@ -249,6 +252,11 @@ def _analyze_macros_olevba(
     try:
         raw: Any = json.loads(output)
     except json.JSONDecodeError:
+        if proc.returncode != 0:
+            raise OSError(
+                f"olevba failed (exit {proc.returncode}) and its output was not JSON: "
+                f"{output[:_STDERR_PREVIEW_CHARS]}"
+            ) from None
         logger.warning("Failed to parse olevba JSON output for %s", file_path)
         return [], [], False
 
@@ -291,6 +299,17 @@ def _analyze_macros_olevba(
             )
             if indicator.get("type") in ("VBA", "AutoExec", "Suspicious"):
                 has_vba = True
+
+    # olevba reports its own failures as JSON records on stdout and still exits
+    # non-zero (5 for an unreadable file, 3 for a missing one), so the
+    # stdout-emptiness test above cannot catch them.  Without this, a document
+    # olevba could not open is returned as a clean, macro-free document.
+    errors = [r for r in results if r.get("type") == "error"]
+    if proc.returncode != 0 and errors and not macros and not indicators:
+        detail = "; ".join(
+            f"{e.get('error', 'error')}: {e.get('message', '')}".strip() for e in errors
+        )
+        raise OSError(f"olevba failed (exit {proc.returncode}): {detail[:_STDERR_PREVIEW_CHARS]}")
 
     return macros, indicators, has_vba
 
@@ -673,6 +692,7 @@ def analyze_office_document(
             params,
             f"Failed to execute olevba: {exc}",
             (time.monotonic() - t0) * 1000,
+            error_type="tool_failed",
         )
 
     risk = _assess_office_risk(macros, has_vba)

--- a/tests/test_olevba_exit_code.py
+++ b/tests/test_olevba_exit_code.py
@@ -1,0 +1,174 @@
+"""A document olevba could not read must not be reported as macro-free.
+
+``_analyze_macros_olevba`` already refused a non-zero exit that produced *no*
+stdout. But olevba reports its own failures as JSON records on stdout and
+still exits non-zero -- 5 for a file it cannot open, 3 for a missing one -- so
+that stdout-emptiness test never fires for the failures that actually happen.
+The error JSON then parses into a result list carrying no ``macros`` and no
+``analysis``, and ``analyze_office_document`` returns ``status: success`` with
+``has_vba: false`` and ``macro_count: 0``.
+
+For a potentially malicious document that is the worst available answer: an
+analysis that never ran, presented as a clean bill of health.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.documents import _analyze_macros_olevba, analyze_office_document
+
+_META = {
+    "script_name": "olevba",
+    "version": "0.60.2",
+    "type": "MetaInformation",
+}
+_FILE_OPEN_ERROR = {
+    "file": "invoice.doc",
+    "type": "error",
+    "error": "FileOpenError",
+    "message": "Failed to open file invoice.doc is not a supported file type, "
+    "cannot extract VBA Macros.",
+}
+
+
+@pytest.fixture
+def document(tmp_path: Path) -> Path:
+    """A .doc that exists, so the run reaches olevba itself."""
+    path = tmp_path / "invoice.doc"
+    path.write_bytes(b"\xd0\xcf\x11\xe0")
+    return path
+
+
+def _olevba(returncode: int, payload: object, stderr: str = "") -> Any:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.CompletedProcess(
+        args=["olevba"], returncode=returncode, stdout=body, stderr=stderr
+    )
+
+
+def _invoke(document: Path, proc: Any) -> tuple[Any, list[str]]:
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    with (
+        patch("mulder.server.tools.documents.subprocess.run", return_value=proc),
+        patch("mulder.server.tools.documents.extract_and_index", side_effect=_record),
+    ):
+        result = analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(document), analyze_dde=False
+        )
+    return result, indexed
+
+
+def test_an_unreadable_document_is_an_error_not_a_clean_one(document: Path) -> None:
+    """The shape that made this silent: exit 5 with error JSON on stdout."""
+    result, _indexed = _invoke(document, _olevba(5, [_META, _FILE_OPEN_ERROR]))
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert "exit 5" in message
+    assert "FileOpenError" in message
+    # The analysis never ran, so it must not answer the question it was asked.
+    assert "preview" not in result
+
+
+def test_a_failed_analysis_is_never_indexed_as_evidence(document: Path) -> None:
+    """'Has VBA: False' must not reach the case DB for a document never read."""
+    _result, indexed = _invoke(document, _olevba(5, [_META, _FILE_OPEN_ERROR]))
+
+    assert indexed == [], f"a failed olevba run was summarised into the case: {indexed}"
+
+
+def test_non_json_output_from_a_failed_run_is_an_error(document: Path) -> None:
+    """A crashed olevba printing a traceback must not read as 'no macros'."""
+    result, _indexed = _invoke(
+        document, _olevba(1, "Traceback (most recent call last):\n  ImportError")
+    )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    assert "not JSON" in str(result["error_message"])
+
+
+def test_a_genuinely_macro_free_document_is_still_clean(document: Path) -> None:
+    """Pins the fix's narrowness: exit 0 with no macros stays a success.
+
+    Most documents are benign. They must keep reporting as analysed-and-clean,
+    or the fix trades silent failures for false alarms.
+    """
+    clean = [_META, {"file": "invoice.doc", "type": "OLE", "macros": [], "analysis": []}]
+
+    result, indexed = _invoke(document, _olevba(0, clean))
+
+    assert result["status"] == "success"
+    # tool_response returns a compact preview envelope once `source` is set,
+    # so the verdict is carried in the preview rather than as a top-level key.
+    assert '"has_vba": false' in str(result["preview"])
+    assert '"macro_count": 0' in str(result["preview"])
+    assert indexed, "a clean analysis must still be indexed"
+
+
+def test_unparseable_output_from_a_successful_run_is_still_tolerated(
+    document: Path,
+) -> None:
+    """Pins narrowness the other way: exit 0 keeps its existing lenient path."""
+    result, _indexed = _invoke(document, _olevba(0, "not json at all"))
+
+    assert result["status"] == "success"
+    assert '"has_vba": false' in str(result["preview"])
+
+
+def test_macros_found_before_a_non_zero_exit_are_kept(document: Path) -> None:
+    """olevba can fail on one member of a container after parsing another.
+
+    The guard is conjunctive -- non-zero *and* error records *and* nothing
+    extracted -- so real macro findings are never discarded.
+    """
+    partial = [
+        _META,
+        {
+            "file": "invoice.doc",
+            "type": "OLE",
+            "macros": [{"vba_filename": "M1", "code": 'Sub AutoOpen()\nShell "cmd"\nEnd Sub'}],
+            "analysis": [],
+        },
+        _FILE_OPEN_ERROR,
+    ]
+
+    result, indexed = _invoke(document, _olevba(5, partial))
+
+    assert result["status"] == "success"
+    # Assert on what reached the case DB: the preview is length-capped, the
+    # indexed text is not.
+    assert indexed and "Module: M1" in indexed[0]
+    assert "Has VBA: True" in indexed[0]
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util", fromlist=["util"]).find_spec("oletools") is None,
+    reason="oletools not installed",
+)
+def test_the_real_olevba_binary_rejects_a_corrupt_document(tmp_path: Path) -> None:
+    """No mocks: drive the actual olevba that ships as a mulder dependency.
+
+    A random-bytes .doc passes mulder's existence and extension checks, so this
+    is reachable through the MCP tool. olevba exits 5 and prints a FileOpenError
+    record; before this fix the wrapper turned that into ([], [], False).
+    """
+    doc = tmp_path / "invoice.doc"
+    doc.write_bytes(os.urandom(2048))
+
+    with pytest.raises(OSError, match="olevba failed"):
+        _analyze_macros_olevba(doc)


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- A document **olevba could not open** is reported as `status: success`, `has_vba: false`, `macro_count: 0` — a malware analysis that never ran, presented as a clean bill of health. `"Has VBA: False"` is also written into the case DB.
- `_analyze_macros_olevba` *does* already guard a non-zero exit with **no stdout**. The gap is that olevba reports its own failures as **JSON records on stdout** and still exits non-zero, so the emptiness test never fires for the failures that actually occur.
- Verified against the real olevba 0.60.2 shipped as a mulder dependency — not inferred: a 2 KB random-bytes `invoice.doc` (which passes mulder's existence *and* extension checks) exits **5** with a `FileOpenError` record, and the wrapper returned `([], [], False)`.
- Fix: raise when olevba exits non-zero having emitted error records and nothing usable, and when a failed run's output is not JSON at all. Both guards conjunctive, so partial results survive. The error is now typed `tool_failed`.
- Scope: `src/mulder/server/tools/documents.py`, the olevba path only. No shared helper, no new abstraction.

## The bug

The existing guard, with its own stated intent:

```python
    output = proc.stdout.strip()
    # Module invocation always execs successfully, so a broken oletools would
    # otherwise be indistinguishable from "this document has no macros" — the
    # worst possible false negative for a potentially malicious document.
    if proc.returncode != 0 and not output:
        raise OSError(...)
```

`output` is never empty on the failures that matter. Reproduced with the pinned dependency:

```
$ python -m oletools.olevba --json /tmp/corrupt.doc ; echo "EXIT=$?"
[
      { "script_name": "olevba", "version": "0.60.2", "type": "MetaInformation" }
,     {
          "file": "/tmp/corrupt.doc",
          "type": "error",
          "error": "FileOpenError",
          "message": "Failed to open file /tmp/corrupt.doc is not a supported file type, cannot extract VBA Macros."
      }
]
EXIT=5
```

Those records carry no `macros` and no `analysis` keys, so the extraction loop leaves `macros == []` and `has_vba == False`, and `analyze_office_document` reports a clean document. Driving the real function on unmodified `main`:

```
macros    = []
indicators= []
has_vba   = False
```

A missing file exits `3` with `PathNotFoundException`; an unreadable one exits `5`. The corrupt-file case is reachable through the MCP tool because `analyze_office_document` only checks that the path exists and the suffix is an Office extension.

## The fix

```python
    # olevba reports its own failures as JSON records on stdout and still exits
    # non-zero (5 for an unreadable file, 3 for a missing one), so the
    # stdout-emptiness test above cannot catch them.  Without this, a document
    # olevba could not open is returned as a clean, macro-free document.
    errors = [r for r in results if r.get("type") == "error"]
    if proc.returncode != 0 and errors and not macros and not indicators:
        detail = "; ".join(
            f"{e.get('error', 'error')}: {e.get('message', '')}".strip() for e in errors
        )
        raise OSError(f"olevba failed (exit {proc.returncode}): {detail[:_STDERR_PREVIEW_CHARS]}")
```

plus the same concern one branch earlier — a failed run whose output is not JSON at all (a traceback, say) previously fell through `except json.JSONDecodeError` to `return [], [], False`:

```python
    except json.JSONDecodeError:
        if proc.returncode != 0:
            raise OSError(
                f"olevba failed (exit {proc.returncode}) and its output was not JSON: "
                f"{output[:_STDERR_PREVIEW_CHARS]}"
            ) from None
        logger.warning(...)   # exit 0: unchanged, still lenient
        return [], [], False
```

`analyze_office_document`'s existing `except OSError` handler now passes `error_type="tool_failed"` instead of falling through to the default `"unknown"`.

Both guards are **conjunctive on purpose** — olevba can fail on one member of a container after parsing another, and those macro findings must not be discarded. Three of the seven tests pin that narrowness:

- exit 0 with no macros → still `success`, still indexed (a benign document is the common case);
- exit 0 with unparseable output → unchanged, still lenient;
- exit 5 with a `FileOpenError` record **but a macro recovered** → still `success`, `Module: M1` and `Has VBA: True` reach the case DB.

## Deliberately out of scope

- **msodde.** The same function's DDE branch swallows failures in a different way (a non-zero exit is only `logger.warning`-ed while the caller still receives `dde_links: []`). That is **PR #101**, branched independently off `main` — **not stacked** on this one, and touching a disjoint code path. Either can merge first, in either order.
- **Closed PR #79** (`fix/document-analysis`, "report obfuscated JavaScript, URLs and embedded files") covers the same file but a different concern. None of it is pulled in.
- **The `_DDE_EXECUTORS` verdict-narrowing change** that closed PR #70 also carried is a third concern and is left out.
- **Partial-result surfacing.** Attaching a `warning` to the successful response would not reach the caller: once `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key. Changing that envelope is a separate concern and is not proposed here.

## Verification

- `uvx pre-commit run --all-files`, run **with the new file staged** so the hooks actually see it → ruff, ruff-format, mypy all pass.
- `pytest tests/ -q` → **760 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check** — `src/mulder/server/tools/documents.py` restored to `origin/main` with the new tests kept:

```
FAILED tests/test_olevba_exit_code.py::test_an_unreadable_document_is_an_error_not_a_clean_one - AssertionError: assert 'success' == 'error'
FAILED tests/test_olevba_exit_code.py::test_a_failed_analysis_is_never_indexed_as_evidence - AssertionError: a failed olevba run was summarised into the case: ['File: /...
FAILED tests/test_olevba_exit_code.py::test_non_json_output_from_a_failed_run_is_an_error - AssertionError: assert 'success' == 'error'
FAILED tests/test_olevba_exit_code.py::test_the_real_olevba_binary_rejects_a_corrupt_document - Failed: DID NOT RAISE <class 'OSError'>
4 failed, 3 passed
```

The four bug tests fail, the three narrowness tests pass. One of the four drives the **real olevba binary** with no mocking at all, so the premise cannot be an artefact of the test double.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one function, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Note that this PR's premise is **narrower and better evidenced** than #70's: the plain "return code is never read" claim is no longer true of `main`, which already guards the empty-stdout case. What remains is the error-JSON path that guard cannot see.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
