### PR TITLE
[high] fix(binary): never triage a binary as benign when rabin2 failed

### DIFF
--- a/src/mulder/server/tools/binary.py
+++ b/src/mulder/server/tools/binary.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _RABIN2_TIMEOUT = 60
+_STDERR_PREVIEW_CHARS = 500
 _CAPA_TIMEOUT = 300
 _FLOSS_TIMEOUT = 600
 _DIEC_TIMEOUT = 120
@@ -122,10 +123,15 @@ def _run_rabin2(flags: str, file_path: Path) -> dict[str, Any]:
         file_path: Path to the target binary.
 
     Returns:
-        Parsed JSON output, or empty dict on failure.
+        Parsed JSON output. An empty dict means rabin2 ran successfully and
+        had nothing to report (a binary with no imports, say) -- never that
+        rabin2 failed, which raises instead.
 
     Raises:
         subprocess.TimeoutExpired: If rabin2 exceeds the timeout.
+        OSError: If rabin2 exits non-zero *and* produced no parseable output.
+            A non-zero exit that still yielded JSON is kept: rabin2 reports a
+            partial parse that way, and that data is real.
     """
     cmd = ["rabin2", f"-{flags}j", str(file_path)]
     proc = subprocess.run(
@@ -135,13 +141,18 @@ def _run_rabin2(flags: str, file_path: Path) -> dict[str, Any]:
         timeout=_RABIN2_TIMEOUT,
         check=False,
     )
-    if not proc.stdout.strip():
-        return {}
-    try:
-        loaded = json.loads(proc.stdout)
-    except json.JSONDecodeError:
-        logger.warning("Failed to parse rabin2 -%s JSON output", flags)
-        return {}
+    loaded: Any = None
+    if proc.stdout.strip():
+        try:
+            loaded = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse rabin2 -%s JSON output", flags)
+            loaded = None
+
+    if proc.returncode != 0 and loaded is None:
+        detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
+        raise OSError(f"rabin2 -{flags} exited {proc.returncode} and produced no output: {detail}")
+
     if isinstance(loaded, dict):
         result: dict[str, Any] = loaded
         return result
@@ -403,6 +414,7 @@ def _compute_verdict(
     suspicious_imports: dict[str, list[str]],
     timestamp: dict[str, object],
     sections: list[dict[str, object]],
+    incomplete: list[str] | None = None,
 ) -> dict[str, object]:
     """Compute an overall triage verdict from analysis results.
 
@@ -415,6 +427,9 @@ def _compute_verdict(
         suspicious_imports: Imports grouped by threat category.
         timestamp: Timestamp validity assessment dict.
         sections: Section metadata with entropy and permissions.
+        incomplete: Descriptions of analysis steps that failed. A binary
+            whose analysis did not complete cannot be called benign, because
+            the absence of indicators may simply be the absence of data.
 
     Returns:
         Dict with classification, confidence, and reasons.
@@ -460,6 +475,15 @@ def _compute_verdict(
     else:
         classification = "benign_indicators"
         confidence = "medium"
+
+    if incomplete:
+        reasons.append("Analysis incomplete: " + "; ".join(incomplete))
+        # Indicators that *were* found are real evidence and are kept. What
+        # cannot survive a partial analysis is a clean bill of health: with
+        # data missing, "no indicators found" is not a finding.
+        if classification == "benign_indicators":
+            classification = "inconclusive"
+            confidence = "none"
 
     return {
         "classification": classification,
@@ -718,6 +742,7 @@ def triage_binary(
         )
 
     raw_parts: list[str] = []
+    incomplete: list[str] = []
 
     try:
         info_raw = _run_rabin2("I", target)
@@ -737,6 +762,7 @@ def triage_binary(
             params,
             f"Failed to execute rabin2: {exc}",
             (time.monotonic() - t0) * 1000,
+            error_type="tool_failed",
         )
 
     file_info = _parse_file_info(info_raw)
@@ -762,15 +788,18 @@ def triage_binary(
             raw_parts.append(json.dumps(strings_raw, indent=2, default=str))
         except subprocess.TimeoutExpired:
             logger.warning("rabin2 timed out during standard analysis of %s", file_path)
-        except OSError:
+            incomplete.append(f"imports/sections/strings timed out after {_RABIN2_TIMEOUT}s")
+        except OSError as exc:
             logger.warning("Failed to run rabin2 standard analysis on %s", file_path)
+            incomplete.append(f"imports/sections/strings unavailable ({exc})")
 
     if depth == "deep":
         try:
             libs_raw = _run_rabin2("l", target)
             raw_parts.append(json.dumps(libs_raw, indent=2, default=str))
-        except (subprocess.TimeoutExpired, OSError):
+        except (subprocess.TimeoutExpired, OSError) as exc:
             logger.warning("rabin2 library enumeration failed for %s", file_path)
+            incomplete.append(f"library enumeration unavailable ({exc})")
 
         if require_binary("rahash2"):
             try:
@@ -799,7 +828,9 @@ def triage_binary(
         raw_ts = None
     timestamp = _assess_timestamp(raw_ts)
 
-    verdict = _compute_verdict(packing_indicators, suspicious_imports, timestamp, sections)
+    verdict = _compute_verdict(
+        packing_indicators, suspicious_imports, timestamp, sections, incomplete
+    )
 
     combined_output = "\n\n".join(raw_parts)
     summary = extract_and_index(combined_output, "binary.triage", file_path, "rabin2")

--- a/tests/test_rabin2_exit_code.py
+++ b/tests/test_rabin2_exit_code.py
@@ -1,0 +1,243 @@
+"""A failed rabin2 parse must never be triaged as a benign binary.
+
+``_run_rabin2`` never read ``proc.returncode``: it returned ``{}`` whenever
+stdout was empty or unparseable, which is indistinguishable from a successful
+run that genuinely had nothing to report. ``triage_binary`` then swallowed the
+resulting ``OSError``/timeout with a ``logger.warning`` and carried on to
+``_compute_verdict`` with empty inputs -- where ``score == 0`` falls through to
+``classification = "benign_indicators"``, ``confidence = "medium"``.
+
+A malware triage that never parsed the binary was reported to the agent as a
+confident clean bill of health.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import mulder.server.tools.binary as binary_module
+from mulder.server.tools.binary import _compute_verdict, _run_rabin2, triage_binary
+
+_RWX_SECTION: list[dict[str, object]] = [{"name": ".text", "permissions": "-rwx"}]
+
+
+# ---------------------------------------------------------------------------
+# _run_rabin2 -- the exit code must reach the caller
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_rabin2_raises_instead_of_returning_an_empty_dict() -> None:
+    """The silence itself: {} meant both 'nothing found' and 'never ran'."""
+    proc = subprocess.CompletedProcess(
+        args=["rabin2", "-Ij", "/evidence/sample.exe"],
+        returncode=1,
+        stdout="",
+        stderr="Cannot open file '/evidence/sample.exe'",
+    )
+
+    with (
+        patch("mulder.server.tools.binary.subprocess.run", return_value=proc),
+        pytest.raises(OSError) as excinfo,
+    ):
+        _run_rabin2("I", Path("/evidence/sample.exe"))
+
+    message = str(excinfo.value)
+    assert "rabin2 -I" in message
+    assert "exited 1" in message
+    assert "Cannot open file" in message
+
+
+def test_an_empty_result_from_a_successful_run_is_still_an_empty_dict() -> None:
+    """Pins the fix's narrowness: exit 0 with no output is a real answer.
+
+    A binary with no imports makes ``rabin2 -ij`` print nothing and exit 0.
+    That must keep returning {} rather than becoming an error.
+    """
+    proc = subprocess.CompletedProcess(
+        args=["rabin2", "-ij", "/evidence/sample.exe"], returncode=0, stdout="", stderr=""
+    )
+
+    with patch("mulder.server.tools.binary.subprocess.run", return_value=proc):
+        assert _run_rabin2("i", Path("/evidence/sample.exe")) == {}
+
+
+def test_json_produced_alongside_a_non_zero_exit_is_kept() -> None:
+    """The guard is conjunctive: a partial parse is real data.
+
+    rabin2 reports a partially-understood binary by exiting non-zero while
+    still emitting JSON. Discarding that would lose evidence.
+    """
+    proc = subprocess.CompletedProcess(
+        args=["rabin2", "-Sj", "/evidence/sample.exe"],
+        returncode=1,
+        stdout='{"sections": [{"name": ".text"}]}',
+        stderr="warning: truncated section table",
+    )
+
+    with patch("mulder.server.tools.binary.subprocess.run", return_value=proc):
+        result = _run_rabin2("S", Path("/evidence/sample.exe"))
+
+    assert result == {"sections": [{"name": ".text"}]}
+
+
+# ---------------------------------------------------------------------------
+# _compute_verdict -- missing data must not read as a clean binary
+# ---------------------------------------------------------------------------
+
+
+def test_an_incomplete_analysis_is_never_benign() -> None:
+    """The core defect: no data scored 0, and 0 meant 'benign, medium'."""
+    verdict = _compute_verdict([], {}, {}, [], ["imports/sections/strings unavailable"])
+
+    assert verdict["classification"] == "inconclusive"
+    assert verdict["confidence"] == "none"
+    reasons = verdict["reasons"]
+    assert isinstance(reasons, list)
+    assert any("Analysis incomplete" in str(r) for r in reasons)
+    assert any("imports/sections/strings unavailable" in str(r) for r in reasons)
+
+
+def test_a_complete_analysis_finding_nothing_is_still_benign() -> None:
+    """Pins the fix's narrowness AND pins the premise.
+
+    With no failures recorded, an empty analysis keeps its original
+    ``benign_indicators`` / ``medium`` verdict -- so this test also proves the
+    old behaviour is exactly what the incomplete case used to produce.
+    """
+    verdict = _compute_verdict([], {}, {}, [])
+
+    assert verdict["classification"] == "benign_indicators"
+    assert verdict["confidence"] == "medium"
+
+
+def test_indicators_found_before_a_failure_are_not_thrown_away() -> None:
+    """Evidence that *was* found survives an incomplete analysis.
+
+    Downgrading a real RWX-section detection to 'inconclusive' would lose a
+    finding, so only a would-be-clean verdict is replaced.
+    """
+    verdict = _compute_verdict(
+        ["UPX section names"],
+        {"process_injection": ["WriteProcessMemory", "CreateRemoteThread"]},
+        {},
+        _RWX_SECTION,
+        ["library enumeration unavailable"],
+    )
+
+    assert verdict["classification"] == "malicious_indicators"
+    assert verdict["confidence"] != "none"
+    reasons = verdict["reasons"]
+    assert isinstance(reasons, list)
+    assert any("Analysis incomplete" in str(r) for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# triage_binary -- end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample(tmp_path: Path) -> Path:
+    """A binary that exists, so the run reaches rabin2 itself."""
+    path = tmp_path / "sample.exe"
+    path.write_bytes(b"MZ\x90\x00")
+    return path
+
+
+def _triage(sample: Path, run: Any) -> tuple[Any, list[Any]]:
+    """Run triage_binary, capturing the results dict it hands to tool_response.
+
+    ``tool_response`` is called with ``source="binary.triage"``, so it returns a
+    compact preview envelope rather than the results themselves; capturing the
+    argument asserts on what the tool actually computed.
+    """
+    computed: list[Any] = []
+    # mypy --strict refuses attribute access on a re-exported name, so read
+    # it out of the module namespace instead.
+    real = vars(binary_module)["tool_response"]
+
+    def _capture(tc_id: str, name: str, params: Any, results: Any, *args: Any) -> Any:
+        computed.append(results)
+        return real(tc_id, name, params, results, *args)
+
+    with (
+        patch("mulder.server.tools.binary.require_binary", return_value=True),
+        patch("mulder.server.tools.binary.subprocess.run", side_effect=run),
+        patch("mulder.server.tools.binary.extract_and_index", return_value={}),
+        patch("mulder.server.tools.binary.tool_response", side_effect=_capture),
+    ):
+        result = triage_binary.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(sample), depth="standard"
+        )
+    return result, computed
+
+
+def test_a_binary_rabin2_could_not_open_is_an_error(sample: Path) -> None:
+    """The very first rabin2 call fails: nothing at all was parsed."""
+
+    def _fail(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr="Cannot open file"
+        )
+
+    result, _computed = _triage(sample, _fail)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    assert "Cannot open file" in str(result["error_message"])
+    assert "triage_verdict" not in result
+
+
+def test_a_partial_triage_is_inconclusive_not_benign(sample: Path) -> None:
+    """The headline case: headers parsed, everything else failed.
+
+    Before this fix the agent was handed ``benign_indicators`` with
+    ``medium`` confidence for a binary whose imports, sections and strings
+    were never read.
+    """
+
+    def _headers_only(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        if "-Ij" in cmd:
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout='{"info": {"arch": "x86", "bits": 64}}',
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=3, stdout="", stderr="rabin2: parse error"
+        )
+
+    result, computed = _triage(sample, _headers_only)
+
+    assert result["status"] == "success"
+    assert computed, "triage_binary never reached tool_response"
+    verdict = computed[0]["triage_verdict"]
+    assert verdict["classification"] == "inconclusive"
+    assert verdict["confidence"] == "none"
+    assert any("Analysis incomplete" in str(r) for r in verdict["reasons"])
+    assert any("parse error" in str(r) for r in verdict["reasons"])
+
+
+def test_a_fully_parsed_clean_binary_is_still_benign(sample: Path) -> None:
+    """Pins the fix's narrowness end to end: a real clean result survives."""
+
+    def _all_ok(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        if "-Ij" in cmd:
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout='{"info": {"arch": "x86"}}', stderr=""
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="{}", stderr="")
+
+    result, computed = _triage(sample, _all_ok)
+
+    assert result["status"] == "success"
+    assert computed, "triage_binary never reached tool_response"
+    verdict = computed[0]["triage_verdict"]
+    assert verdict["classification"] == "benign_indicators"
+    assert verdict["confidence"] == "medium"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `triage_binary` reports **`classification: "benign_indicators"`, `confidence: "medium"`** for a binary that rabin2 never actually parsed. A malware triage that did not run is handed to the agent as a confident clean bill of health.
- Root cause, in two halves:
  - `_run_rabin2` never reads `proc.returncode`. It returns `{}` on failure — indistinguishable from a successful run that genuinely had nothing to report.
  - `_compute_verdict` scores the (empty) inputs at `0`, and `score < 4` falls through to the `else` branch: `benign_indicators` / `medium`. **Absence of data is scored as absence of indicators.**
- Fix: `_run_rabin2` raises `OSError` when rabin2 exits non-zero **and** produced no parseable output; `triage_binary` records the steps it could not complete and passes them to `_compute_verdict`, which appends an `"Analysis incomplete: …"` reason and replaces a would-be-clean verdict with `inconclusive` / `none`.
- Scope: `src/mulder/server/tools/binary.py` only — 42 insertions, 11 deletions. No shared helper, no new abstraction, no change to any other tool.

## The bug

`_run_rabin2` discards the exit code entirely:

```python
    proc = subprocess.run(cmd, capture_output=True, text=True,
                          timeout=_RABIN2_TIMEOUT, check=False)
    if not proc.stdout.strip():
        return {}                      # <- rabin2 failed? no imports? same answer
```

`triage_binary` then silences the failure and continues:

```python
        except OSError:
            logger.warning("Failed to run rabin2 standard analysis on %s", file_path)
```

and `_compute_verdict` turns the resulting emptiness into a verdict:

```python
    else:
        classification = "benign_indicators"
        confidence = "medium"
```

With `packing_indicators=[]`, `suspicious_imports={}`, `sections=[]` — the state produced by a rabin2 that could not open the file — `score` is `0` and the binary is pronounced benign.

## The fix

**1. The exit code reaches the caller.** The guard is conjunctive: rabin2 signals a partially-understood binary by exiting non-zero while still emitting JSON, and that data is real evidence.

```python
    if proc.returncode != 0 and loaded is None:
        detail = (proc.stderr.strip() or proc.stdout.strip())[:_STDERR_PREVIEW_CHARS]
        raise OSError(f"rabin2 -{flags} exited {proc.returncode} and produced no output: {detail}")
```

**2. A partial analysis cannot be clean.** `triage_binary` accumulates an `incomplete: list[str]`, and:

```python
    if incomplete:
        reasons.append("Analysis incomplete: " + "; ".join(incomplete))
        # Indicators that *were* found are real evidence and are kept. What
        # cannot survive a partial analysis is a clean bill of health: with
        # data missing, "no indicators found" is not a finding.
        if classification == "benign_indicators":
            classification = "inconclusive"
            confidence = "none"
```

### A deliberate refinement of #70's design

Closed PR #70 made **any** incomplete analysis `inconclusive`. This PR replaces only a *would-be-clean* verdict, because downgrading a genuine `malicious_indicators` detection to `inconclusive` would discard a real finding — the same class of harm, in the other direction. A test pins each side.

`inconclusive` is a fourth value in this function's own `classification` field; nothing outside `binary.py` reads it (verified by grep across `src/` and `tests/`). It is not a cross-cutting status taxonomy.

## Review round 2 — a clean exit is not a clean parse

@calebevans found the case the returncode guard cannot see: rabin2 reports a damaged container by printing `ERROR:` lines and **still exiting 0** with partial JSON. Against a truncated Mach-O, rabin2 5.9.8 printed

```
ERROR: parsing symtab
Cannot initialize items
```

returned 0, and produced partial JSON. The guard accepted that output and `triage_binary` classified the damaged file as `benign_indicators` with medium confidence — the same wrong answer this PR set out to remove, reached by a different route.

`_run_rabin2` now takes the `incomplete` collector and records any `ERROR:` line whatever the exit code:

```python
errors = _rabin2_parse_errors(proc.stderr)
if errors and incomplete is not None:
    incomplete.append(f"rabin2 -{flags} reported a parse error: {'; '.join(errors)}")
```

The partial data is still returned and still reported. `_compute_verdict` already keeps every indicator it found and only downgrades `benign_indicators` to `inconclusive`/`none` when anything is incomplete, so the damaged file cannot buy a clean bill of health.

**Only `ERROR:` counts.** rabin2 prints `WARN:` routinely for healthy binaries — a stripped symbol table, an unknown section flag — and treating those as failure would make every ordinary triage inconclusive. A test pins that a `WARN:`-only run stays unremarked.

All five call sites pass the collector, including the leading `-I` call that previously was not wired to it.

Confirmed discriminating: against the previous commit the new end-to-end test fails with `assert 'benign_indicators' == 'inconclusive'`.

## Deliberately out of scope

- **The `tool_response` envelope.** With `source` set it builds a fresh compact preview dict and drops every other key, so a `warning` on the success path would never reach the caller. This is exactly why the `inconclusive` verdict is the right mechanism here: it lives *inside* `results`, so it survives into the preview. (Related, and **not** fixed here: `triage_verdict` is appended near the end of `summary`, after up to 100 strings, so it can be truncated out of the preview. Separate concern.)
- **Other `binary.py` concerns.** Closed #80 (parser schemas) and #82 (verdict indexing), open #81 (PE timestamp) and #89 (binary patterns) all touch this module for different reasons. None are pulled in.
- **`rahash2`.** Its failure handler is left as-is: hashes are not verdict inputs.

## Verification

- `uvx pre-commit run --all-files` (with the new file **staged**, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **762 passed**, 1 deselected.
- The deselected test is `test_disk_pcap.py::TestAnalyzeDiskPcapsTool::test_size_filtering_skips_large_pcaps`; it writes a real 200 MB file and fails here with `OSError: [Errno 122] Disk quota exceeded` on unmodified `main` too — an environment disk quota, not a regression.
- **Discriminating check:** with `src/mulder/server/tools/binary.py` restored to `origin/main` and the new tests kept, **5 of 9 fail** and the 4 narrowness tests pass:

```
FAILED test_a_failed_rabin2_raises_instead_of_returning_an_empty_dict - Failed: DID NOT RAISE OSError
FAILED test_an_incomplete_analysis_is_never_benign - TypeError: _compute_verdict() takes 4 positional arguments but 5 were given
FAILED test_indicators_found_before_a_failure_are_not_thrown_away - TypeError: _compute_verdict() takes 4 positional arguments but 5 were given
FAILED test_a_binary_rabin2_could_not_open_is_an_error - AssertionError: assert 'success' == 'error'
FAILED test_a_partial_triage_is_inconclusive_not_benign - AssertionError: assert 'benign_indicators' == 'inconclusive'
5 failed, 4 passed
```

That last line is the whole bug in one assertion. The tests cannot pass against a codebase where it never existed.

The four that pass on both are the narrowness pins: exit 0 with empty output still returns `{}`; a non-zero exit that emitted JSON keeps the JSON; a *complete* analysis finding nothing is still `benign_indicators` / `medium`; and a fully-parsed clean binary is still benign end to end.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one module, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

