### PR TITLE
[high] fix(msodde): report a crashed DDE check instead of "no DDE links found"

### DIFF
--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _OLEVBA_TIMEOUT = 120
+_STDERR_PREVIEW_CHARS = 500
 _PDFID_TIMEOUT = 60
 _PDF_PARSER_TIMEOUT = 120
 
@@ -688,20 +689,45 @@ def analyze_office_document(
                 timeout=_OLEVBA_TIMEOUT,
                 check=False,
             )
-            # DDE analysis is best-effort, but a broken msodde must not pass
-            # silently as "no DDE links found". msodde always prints its banner
-            # to stdout, so a stdout-emptiness test here would never fire.
-            if proc.returncode != 0:
-                logger.warning(
-                    "msodde failed for %s (exit %s): %s",
-                    file_path,
-                    proc.returncode,
-                    proc.stderr.strip()[:500] or proc.stdout.strip()[:500] or "no output",
-                )
-            else:
-                dde_links = _parse_msodde_output(proc.stdout)
-        except (subprocess.TimeoutExpired, OSError):
-            logger.debug("msodde analysis failed for %s", file_path)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            return error_response(
+                tc_id,
+                "analyze_office_document",
+                params,
+                f"msodde could not be run for {file_path}: {exc}",
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+                suggestion=(
+                    "Re-run with analyze_dde=False to get the macro analysis "
+                    "without the DDE check."
+                ),
+            )
+
+        # A broken msodde must not pass silently as "no DDE links found":
+        # DDEAUTO is a live code-execution vector, and an empty dde_links list
+        # is read as an authoritative all-clear. msodde always prints its
+        # banner to stdout, so a stdout-emptiness test here would never fire --
+        # the exit code is the only signal there is.
+        if proc.returncode != 0:
+            detail = (
+                proc.stderr.strip()[:_STDERR_PREVIEW_CHARS]
+                or proc.stdout.strip()[:_STDERR_PREVIEW_CHARS]
+                or "no output"
+            )
+            return error_response(
+                tc_id,
+                "analyze_office_document",
+                params,
+                f"msodde exited {proc.returncode}, so the DDE check did not run: {detail}",
+                (time.monotonic() - t0) * 1000,
+                error_type="tool_failed",
+                suggestion=(
+                    "Re-run with analyze_dde=False to get the macro analysis "
+                    "without the DDE check."
+                ),
+            )
+
+        dde_links = _parse_msodde_output(proc.stdout)
 
     index_parts: list[str] = [
         f"File: {file_path}",

--- a/tests/test_msodde_exit_code.py
+++ b/tests/test_msodde_exit_code.py
@@ -1,0 +1,217 @@
+"""A crashed msodde must not be reported as "no DDE links found".
+
+``analyze_office_document`` ran msodde, and on a non-zero exit merely called
+``logger.warning`` -- server-side text the MCP client never sees -- while still
+returning ``status: success`` with ``dde_links: []``. The caller could not
+distinguish a document with no DDE fields from one msodde never managed to
+read. DDEAUTO is a live code-execution vector, so an empty ``dde_links`` list
+is read as an authoritative all-clear.
+
+The function's own comment already stated the requirement -- "a broken msodde
+must not pass silently as 'no DDE links found'" -- but the code only logged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.documents import analyze_office_document
+
+_OLEVBA_CLEAN = json.dumps(
+    [
+        {"script_name": "olevba", "version": "0.60.2", "type": "MetaInformation"},
+        {"file": "invoice.doc", "type": "OLE", "macros": [], "analysis": []},
+    ]
+)
+#: msodde still prints its "DDE Links:" section header when it crashes, so the
+#: exit code is the only signal that the check did not actually run.
+_MSODDE_CRASH = (
+    '[{"msg": "Opening file: invoice.doc", "level": "WARNING", "type": "msg"}\n'
+    ',     {"msg": "\'utf-8\' codec can\'t decode byte 0xeb in position 3", '
+    '"level": "ERROR", "type": "msg"}\n'
+    ',     {"msg": "DDE Links:", "level": "WARNING", "type": "msg"}]'
+)
+
+
+@pytest.fixture
+def document(tmp_path: Path) -> Path:
+    """A .doc that exists, so the run reaches the tools themselves."""
+    path = tmp_path / "invoice.doc"
+    path.write_bytes(b"\xd0\xcf\x11\xe0")
+    return path
+
+
+def _recorder(sink: list[str]) -> Callable[..., dict[str, object]]:
+    """A stand-in for extract_and_index that captures what reached the case DB."""
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        sink.append(raw)
+        return {}
+
+    return _record
+
+
+def _proc(returncode: int, stdout: str, stderr: str = "") -> Any:
+    return subprocess.CompletedProcess(
+        args=["oletools"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _invoke(document: Path, msodde: Any) -> tuple[Any, list[str]]:
+    """olevba always succeeds cleanly; *msodde* is the second call's result."""
+    indexed: list[str] = []
+    calls = iter([_proc(0, _OLEVBA_CLEAN), msodde])
+
+    def _run(*args: object, **kwargs: object) -> Any:
+        return next(calls)
+
+    with (
+        patch("mulder.server.tools.documents.subprocess.run", side_effect=_run),
+        patch(
+            "mulder.server.tools.documents.extract_and_index",
+            side_effect=_recorder(indexed),
+        ),
+    ):
+        result = analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(document), analyze_dde=True
+        )
+    return result, indexed
+
+
+def test_a_crashed_msodde_is_an_error_not_an_all_clear(document: Path) -> None:
+    """The shape that made this silent: exit 1 with a banner still on stdout."""
+    result, _indexed = _invoke(document, _proc(1, _MSODDE_CRASH))
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    message = str(result["error_message"])
+    assert "msodde exited 1" in message
+    assert "DDE check did not run" in message
+
+
+def test_the_error_tells_the_analyst_how_to_get_the_macro_analysis(
+    document: Path,
+) -> None:
+    """Failing the whole call costs a good macro result, so say how to recover."""
+    result, _indexed = _invoke(document, _proc(1, _MSODDE_CRASH))
+
+    assert "analyze_dde=False" in str(result["suggestion"])
+
+
+def test_a_failed_dde_check_is_never_indexed_as_evidence(document: Path) -> None:
+    """No half-analysis reaches the case DB claiming the document was checked."""
+    _result, indexed = _invoke(document, _proc(1, _MSODDE_CRASH))
+
+    assert indexed == [], f"a failed DDE check was summarised into the case: {indexed}"
+
+
+def test_a_timeout_running_msodde_is_reported(document: Path) -> None:
+    """Previously swallowed by `except (TimeoutExpired, OSError): logger.debug`."""
+    indexed: list[str] = []
+    calls = [_proc(0, _OLEVBA_CLEAN)]
+
+    def _run(*args: object, **kwargs: object) -> Any:
+        if calls:
+            return calls.pop()
+        raise subprocess.TimeoutExpired(cmd="msodde", timeout=120)
+
+    with (
+        patch("mulder.server.tools.documents.subprocess.run", side_effect=_run),
+        patch(
+            "mulder.server.tools.documents.extract_and_index",
+            side_effect=_recorder(indexed),
+        ),
+    ):
+        result = analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(document), analyze_dde=True
+        )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "tool_failed"
+    assert indexed == []
+
+
+def test_a_document_with_no_dde_links_is_still_a_success(document: Path) -> None:
+    """Pins the fix's narrowness: msodde exiting 0 with no links is a result.
+
+    Most documents have no DDE fields. They must keep reporting as
+    checked-and-clean, or the fix trades silent failures for false alarms.
+    """
+    ok = '[{"msg": "DDE Links:", "level": "WARNING", "type": "msg"}]'
+
+    result, indexed = _invoke(document, _proc(0, ok))
+
+    assert result["status"] == "success"
+    assert indexed, "a clean analysis must still be indexed"
+
+
+def test_dde_links_found_on_a_successful_run_are_reported(document: Path) -> None:
+    """The positive path still works: a real DDEAUTO field is surfaced."""
+    found = json.dumps(
+        [
+            {"msg": "DDE Links:", "level": "WARNING", "type": "msg"},
+            {"msg": 'DDEAUTO c:\\windows\\system32\\cmd.exe "/k calc.exe"', "type": "msg"},
+        ]
+    )
+
+    result, _indexed = _invoke(document, _proc(0, found))
+
+    assert result["status"] == "success"
+
+
+def test_analyze_dde_false_never_runs_msodde(document: Path) -> None:
+    """Opting out of the DDE check must not be affected by this change."""
+    indexed: list[str] = []
+    runs: list[object] = []
+
+    def _run(cmd: list[str], **kwargs: object) -> Any:
+        runs.append(cmd)
+        return _proc(0, _OLEVBA_CLEAN)
+
+    with (
+        patch("mulder.server.tools.documents.subprocess.run", side_effect=_run),
+        patch(
+            "mulder.server.tools.documents.extract_and_index",
+            side_effect=_recorder(indexed),
+        ),
+    ):
+        result = analyze_office_document.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(document), analyze_dde=False
+        )
+
+    assert result["status"] == "success"
+    assert len(runs) == 1, "msodde must not run when analyze_dde is False"
+
+
+@pytest.mark.skipif(
+    __import__("importlib.util", fromlist=["util"]).find_spec("oletools") is None,
+    reason="oletools not installed",
+)
+def test_the_real_msodde_binary_fails_on_a_corrupt_document(tmp_path: Path) -> None:
+    """No mocks: the pinned msodde really does exit non-zero here.
+
+    It also still prints its "DDE Links:" section header while crashing, which
+    is why parsing stdout cannot substitute for reading the exit code.
+    """
+    doc = tmp_path / "invoice.doc"
+    doc.write_bytes(os.urandom(2048))
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "oletools.msodde", "--json", str(doc)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert proc.returncode != 0
+    assert "DDE Links:" in proc.stdout


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- When msodde **crashes**, `analyze_office_document` still returns `status: success` with `dde_links: []`. A DDE check that never ran is indistinguishable from a document with no DDE fields.
- DDEAUTO is a live code-execution vector, so an empty `dde_links` list is read as an authoritative all-clear. This is the same class of defect as a macro scan reporting "no macros" after failing to open the file.
- The failure *was* noticed in code — but only as `logger.warning`, server-side text the MCP client never sees. A timeout or `OSError` was quieter still, swallowed by `logger.debug`.
- The function's own comment already stated the requirement: *"a broken msodde must not pass silently as 'no DDE links found'"*. The code then did exactly that.
- Fix: return `error_response(..., error_type="tool_failed")` with the exit code and a stderr/stdout preview, plus a `suggestion` telling the analyst how to recover the macro analysis.
- Scope: `src/mulder/server/tools/documents.py`, the msodde branch only. No shared helper, no new abstraction.

## The bug

```python
            # DDE analysis is best-effort, but a broken msodde must not pass
            # silently as "no DDE links found". msodde always prints its banner
            # to stdout, so a stdout-emptiness test here would never fire.
            if proc.returncode != 0:
                logger.warning(
                    "msodde failed for %s (exit %s): %s", ...
                )
            else:
                dde_links = _parse_msodde_output(proc.stdout)
        except (subprocess.TimeoutExpired, OSError):
            logger.debug("msodde analysis failed for %s", file_path)
```

`dde_links` stays `[]` and the function proceeds to `tool_response(...)` — success.

Reproduced with the pinned dependency on a 2 KB random-bytes `invoice.doc`:

```
$ python -m oletools.msodde --json /tmp/corrupt.doc ; echo "EXIT=$?"
[
    {"msg": "Opening file: /tmp/corrupt.doc", "level": "WARNING", "type": "msg"}
,   {"msg": "'utf-8' codec can't decode byte 0xeb in position 3: invalid continuation byte
           Traceback (most recent call last): ... UnicodeDecodeError", "level": "ERROR", "type": "msg"}
,   {"msg": "DDE Links:", "level": "WARNING", "type": "msg"}
]
EXIT=1
```

Note the third record: msodde prints its **`DDE Links:` section header even while crashing**. That is the marker `_parse_msodde_output` scans for, so parsing stdout more carefully would still yield a confident empty list. The exit code is the only signal there is — which is exactly what the original comment says, and exactly what the code declined to act on.

## The fix

```python
        if proc.returncode != 0:
            detail = (
                proc.stderr.strip()[:_STDERR_PREVIEW_CHARS]
                or proc.stdout.strip()[:_STDERR_PREVIEW_CHARS]
                or "no output"
            )
            return error_response(
                tc_id, "analyze_office_document", params,
                f"msodde exited {proc.returncode}, so the DDE check did not run: {detail}",
                (time.monotonic() - t0) * 1000,
                error_type="tool_failed",
                suggestion=(
                    "Re-run with analyze_dde=False to get the macro analysis "
                    "without the DDE check."
                ),
            )
```

The `except (TimeoutExpired, OSError)` branch returns the same typed error rather than `logger.debug`.

**On the trade-off:** failing the whole call discards a macro analysis that did succeed. That is deliberate, and the `suggestion` field exists to make it recoverable in one step. The alternative — reporting success with a `warning` key — cannot work: once `source` is set, `tool_response` builds a fresh compact preview dict and drops every other key, so the warning would never reach the caller. Given the choice between an unreachable warning and a false all-clear on a code-execution vector, this errs toward the analyst noticing.

Narrowness is pinned by four of the eight tests:

- exit 0 with no DDE links → still `success`, still indexed (the common case);
- exit 0 with a real `DDEAUTO ... cmd.exe` field → still `success`, still surfaced;
- `analyze_dde=False` → msodde is never run at all (asserted on the call count);
- the real-binary test asserts msodde's actual exit code and banner, so the premise is pinned to the shipped tool rather than to a mock.

## Deliberately out of scope

- **olevba.** The same function's macro path swallows failures in a *different* way (a non-zero exit with error-typed JSON on stdout defeats the existing empty-stdout guard). That is **PR #99**, branched independently off `main` — **not stacked** on this one, and touching a disjoint code path. Either can merge first, in either order.
- **Closed PR #79** (`fix/document-analysis`, "report obfuscated JavaScript, URLs and embedded files") covers the same file but a different concern. None of it is pulled in.
- **The `_DDE_EXECUTORS` verdict-narrowing change** that closed PR #70 also carried is a third concern and is left out.
- **Partial-result surfacing**, for the envelope reason given above.

## Verification

- `uvx pre-commit run --all-files`, run **with the new file staged** so the hooks actually see it → ruff, ruff-format, mypy all pass.
- `pytest tests/ -q` → **761 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check** — `src/mulder/server/tools/documents.py` restored to `origin/main` with the new tests kept:

```
FAILED tests/test_msodde_exit_code.py::test_a_crashed_msodde_is_an_error_not_an_all_clear - AssertionError: assert 'success' == 'error'
FAILED tests/test_msodde_exit_code.py::test_the_error_tells_the_analyst_how_to_get_the_macro_analysis - KeyError: 'suggestion'
FAILED tests/test_msodde_exit_code.py::test_a_failed_dde_check_is_never_indexed_as_evidence - AssertionError: a failed DDE check was summarised into the case: ['File: /t...
FAILED tests/test_msodde_exit_code.py::test_a_timeout_running_msodde_is_reported - AssertionError: assert 'success' == 'error'
4 failed, 4 passed
```

The four bug tests fail, the four narrowness tests pass. The test run was driven through a launcher that asserts `mulder.server.tools.documents.__file__` resolves inside this branch's own worktree before collecting anything — this environment has an editable install pointing elsewhere, which would otherwise make a premise check silently meaningless.

## Context

Split out of closed PR #70, which changed every wrapped tool at once behind a shared `classify_tool_exit` helper. That shared taxonomy is **not** reintroduced here — the check is inlined in this one branch of one function, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`a61d162`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
