### PR TITLE
[critical] fix(email): stop a date-bounded PST search discarding the whole mailbox

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -8,6 +8,8 @@ import logging
 import subprocess
 import tempfile
 import time
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 from mulder.server.app import mcp
@@ -132,6 +134,58 @@ def _matches_search(
     return any(term in r.lower() for r in recipients)
 
 
+def _message_date(raw: str | None) -> datetime | None:
+    """Parse an RFC 5322 ``Date`` header into an aware datetime.
+
+    Returns None when the header is absent or malformed, which the caller
+    treats as "cannot be excluded" rather than "excluded".
+    """
+    if not raw:
+        return None
+    try:
+        parsed = parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _in_date_range(raw: str | None, start: str | None, end: str | None) -> bool:
+    """Whether a message's ``Date`` falls in an inclusive YYYY-MM-DD range.
+
+    The ``Date`` header is RFC 5322 -- ``Mon, 11 Mar 2024 09:14:02 +0100`` --
+    and was previously compared against the bounds as a plain string.
+    ``"Mon, ..." > "2024-12-31"`` is true for every message ever sent,
+    because ``M`` (77) sorts above every digit (48-57), so ``date_end``
+    discarded the whole mailbox while ``date_start`` discarded nothing.
+
+    A message whose date is missing or unparseable is kept: a malformed
+    header must not silently hide evidence.
+    """
+    if not start and not end:
+        return True
+    when = _message_date(raw)
+    if when is None:
+        return True
+    day = when.date()
+    if start:
+        try:
+            if day < datetime.strptime(start, "%Y-%m-%d").date():
+                return False
+        except ValueError:
+            pass
+    if end:
+        try:
+            if day > datetime.strptime(end, "%Y-%m-%d").date():
+                return False
+        except ValueError:
+            pass
+    return True
+
+
 def _parse_email_message(
     msg: email_lib.message.Message,
     folder: str,
@@ -214,10 +268,7 @@ def _parse_extracted_emails(
 
         parsed = _parse_email_message(msg, folder)
 
-        date_val = str(parsed.get("date") or "")
-        if date_start and date_val and date_val < date_start:
-            continue
-        if date_end and date_val and date_val > date_end:
+        if not _in_date_range(str(parsed.get("date") or ""), date_start, date_end):
             continue
 
         if search_term:

--- a/tests/test_pst_date_range.py
+++ b/tests/test_pst_date_range.py
@@ -1,0 +1,112 @@
+"""A date-bounded PST search must not discard the entire mailbox.
+
+``_parse_extracted_emails`` compared the RFC 5322 ``Date`` header against the
+``YYYY-MM-DD`` bounds as a plain string::
+
+    if date_end and date_val and date_val > date_end:
+        continue
+
+``"Mon, 11 Mar 2024 09:14:02 +0100" > "2024-12-31"`` is ``True`` -- ``M`` (77)
+sorts above every digit (48-57) -- and every RFC 5322 date begins with a
+weekday name. So ``date_range_end`` dropped every message ever sent, and
+``date_range_start`` dropped none, in both cases silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mulder.server.tools.email import _parse_extracted_emails
+
+_MESSAGES = {
+    "2019.eml": "Tue, 15 Jan 2019 09:14:02 +0000",
+    "2022.eml": "Wed, 11 May 2022 17:02:41 +0200",
+    "2024.eml": "Mon, 11 Mar 2024 09:14:02 +0100",
+}
+
+
+def _write(path: Path, date_header: str, subject: str) -> None:
+    path.write_text(
+        "From: sender@example.com\n"
+        "To: recipient@example.com\n"
+        f"Subject: {subject}\n"
+        f"Date: {date_header}\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "body text\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def mailbox(tmp_path: Path) -> Path:
+    """Three messages, one per year, in a readpst-style output tree."""
+    folder = tmp_path / "Inbox"
+    folder.mkdir()
+    for name, header in _MESSAGES.items():
+        _write(folder / name, header, name.removesuffix(".eml"))
+    return tmp_path
+
+
+def _subjects(result: dict[str, Any]) -> list[str]:
+    emails = result["emails"]
+    assert isinstance(emails, list)
+    return sorted(str(e["subject"]) for e in emails)
+
+
+def test_an_end_bound_does_not_discard_the_whole_mailbox(mailbox: Path) -> None:
+    """The headline failure: every RFC 5322 date sorts above every ISO bound."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst", date_end="2024-12-31")
+
+    assert _subjects(result) == ["2019", "2022", "2024"]
+    assert result["total_emails"] == 3
+
+
+def test_an_end_bound_still_excludes_later_messages(mailbox: Path) -> None:
+    """Pins that the filter is fixed, not merely disabled."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst", date_end="2022-12-31")
+
+    assert _subjects(result) == ["2019", "2022"]
+
+
+def test_a_start_bound_actually_filters(mailbox: Path) -> None:
+    """``date_start`` previously excluded nothing at all."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst", date_start="2022-01-01")
+
+    assert _subjects(result) == ["2022", "2024"]
+
+
+def test_both_bounds_select_the_middle_message(mailbox: Path) -> None:
+    result = _parse_extracted_emails(
+        mailbox,
+        "/evidence/mail.pst",
+        date_start="2022-01-01",
+        date_end="2022-12-31",
+    )
+
+    assert _subjects(result) == ["2022"]
+
+
+def test_an_unparseable_date_is_kept_not_hidden(tmp_path: Path) -> None:
+    """A malformed header must not silently remove evidence from the case.
+
+    Excluding it would let a forged or broken ``Date`` hide a message from
+    every date-bounded search, which is the opposite of what an examiner needs.
+    """
+    folder = tmp_path / "Inbox"
+    folder.mkdir()
+    _write(folder / "broken.eml", "not a date at all", "malformed")
+
+    result = _parse_extracted_emails(tmp_path, "/evidence/mail.pst", date_end="2024-12-31")
+
+    assert _subjects(result) == ["malformed"]
+
+
+def test_no_bounds_returns_everything(mailbox: Path) -> None:
+    """Narrowness: with no date filter the fix changes nothing."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst")
+
+    assert _subjects(result) == ["2019", "2022", "2024"]


### PR DESCRIPTION
## BLUF

- **Priority: critical.**
- Any `parse_pst` call with `date_range_end` set returned **zero messages** — the entire mailbox, silently discarded, reported as `status: success` with `total_emails: 0`.
- `date_range_start` had the opposite failure: it filtered **nothing**, so a bounded search quietly returned the whole mailbox.
- Root cause: the RFC 5322 `Date` header was compared against the `YYYY-MM-DD` bounds **as a plain string**. Every RFC 5322 date begins with a weekday name, so it starts with a letter while the bound starts with a digit — and `M` (77) sorts above every digit (48–57).
- Fix: parse the header with `email.utils.parsedate_to_datetime` and compare dates to dates.
- Scope: `src/mulder/server/tools/email.py` only. No new abstraction, no change to any other tool.

## The bug

```python
        date_val = str(parsed.get("date") or "")
        if date_start and date_val and date_val < date_start:
            continue
        if date_end and date_val and date_val > date_end:
            continue
```

`parsed["date"]` is `msg.get("Date")` — the header exactly as sent, e.g. `Mon, 11 Mar 2024 09:14:02 +0100`. The bounds are `YYYY-MM-DD`. So:

```
>>> "Mon, 11 Mar 2024 09:14:02 +0100" > "2024-12-31"
True                      # every message is "after" every end bound
>>> "Mon, 11 Mar 2024 09:14:02 +0100" < "2020-01-01"
False                     # no message is ever "before" a start bound
>>> ord("M"), ord("2")
(77, 50)
```

There is no date for which this works. An examiner narrowing a mailbox to the week of an incident got an empty result and no indication that the filter, rather than the evidence, was responsible.

## The fix

```python
def _in_date_range(raw: str | None, start: str | None, end: str | None) -> bool:
    if not start and not end:
        return True
    when = _message_date(raw)
    if when is None:
        return True
    day = when.date()
    if start:
        try:
            if day < datetime.strptime(start, "%Y-%m-%d").date():
                return False
        except ValueError:
            pass
    ...
```

with `_message_date` wrapping `parsedate_to_datetime` and normalising a naive datetime to UTC.

**A message whose `Date` is missing or unparseable is kept, not dropped.** Excluding it would let a malformed or forged header hide a message from every date-bounded search — the opposite of what a forensic tool should do. That behaviour is pinned by a test.

## Deliberately out of scope

`fix/email-parsing` (closed #78) bundled this with five other independent defects in the same file — RFC 2047 header decoding, `_parse_recipients` splitting on a comma inside a quoted display name, HTML-only messages having no searchable body, `Cc`/`Bcc` never being searched, and attachments detected only via `Content-Disposition: attachment`. Each is a separate root cause and is being submitted as its own PR. This one changes only the date comparison.

Relationship to **open PR #96** (`fix/readpst-exit-code`): that one adds a guard for *readpst having failed* (non-zero exit **and** no `.eml` written). This one is the opposite case — readpst succeeded, messages were extracted, and the parser then discarded them. The two touch different functions and do not overlap; verified conflict-free with `git merge-tree`.

### A note on merge order

This PR is one of six recovered from closed #78, each branched independently off `main`. All six merge cleanly into `main` today, and none conflicts with open #96.

Three of them — this one, `fix/pst-recipient-parsing` and `fix/pst-header-decoding` — each add a `from email...` import at the same point in the import block, so **whichever merges second will report a conflict there**. It is confined to the import lines; no two of the six change the same statement. Resolution is to keep both imports.

Flagging it here rather than leaving it to be discovered at merge time.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- Full suite → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `email.py` restored to `origin/main` and the new tests kept, **5 of 6 fail**:

```
FAILED test_an_end_bound_does_not_discard_the_whole_mailbox - AssertionError: assert [] == ['2019', '2022', '2024']
FAILED test_an_end_bound_still_excludes_later_messages      - AssertionError: assert [] == ['2019', '2022']
FAILED test_a_start_bound_actually_filters                  - AssertionError: assert ['2019', '2022', '2024'] == ['2022', '2024']
FAILED test_both_bounds_select_the_middle_message           - AssertionError: assert [] == ['2022']
FAILED test_an_unparseable_date_is_kept_not_hidden          - AssertionError: assert [] == ['malformed']
5 failed, 1 passed
```

The first line is the bug in one assertion: three real messages in, nothing out. The `date_start` line shows the mirror-image failure — all three returned when two were asked for. The sixth test (no bounds → everything) passes on both trees, pinning that the fix does not change unfiltered behaviour.

## Context

Recovered from closed PR #78, which bundled six independent defects behind one title. The rejected outcome framework and `classify_tool_exit` are **not** reintroduced — this is a self-contained fix to one comparison, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


