### PR TITLE
[high] fix(case): enforce extract_archive's documented destination contract

### DIFF
--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -5,6 +5,7 @@ Tier 1 tools: help the agent orient before running any extractions.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import shutil
@@ -14,6 +15,7 @@ import time
 import zipfile
 from pathlib import Path
 
+from mulder.path_policy import PathPolicyError, resolve_allowed_path
 from mulder.server.app import (
     create_case,
     get_cfg,
@@ -452,6 +454,19 @@ def _extract_7z(archive: Path, dest: Path) -> list[str]:
     return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
 
 
+def _archive_slot(archive: Path) -> str:
+    """Return a per-archive directory name that cannot collide.
+
+    ``archive.stem`` alone is ambiguous: two unrelated archives called
+    ``evidence.zip`` collect in the same slot, and the second call then takes
+    the "already extracted" path and reports the *first* archive's files as
+    its own.  Appending a digest of the resolved source path keeps the name
+    readable while making it unique to one archive on disk.
+    """
+    digest = hashlib.blake2b(str(archive).encode(), digest_size=6).hexdigest()
+    return f"{archive.stem}-{digest}"
+
+
 @mcp.tool()
 @tool_access(Role.CATALOG | Role.EXTRACT_EXECUTOR)
 def extract_archive(
@@ -489,11 +504,23 @@ def extract_archive(
             error_type="file_not_found",
         )
 
+    cfg = get_cfg()
+    extract_root = Path(cfg.db_dir) / "extracted"
+
     if extract_to:
-        dest = Path(extract_to).expanduser().resolve()
+        try:
+            dest = resolve_allowed_path(Path(extract_to).expanduser(), [extract_root])
+        except PathPolicyError as exc:
+            return error_response(
+                tc_id,
+                "extract_archive",
+                params,
+                f"{exc}: extract_to must stay under {extract_root}",
+                (time.monotonic() - t0) * 1000,
+                error_type="invalid_input",
+            )
     else:
-        cfg = get_cfg()
-        dest = cfg.db_dir / "extracted" / archive.stem
+        dest = extract_root / _archive_slot(archive)
 
     # Idempotent: if already extracted, return the existing files
     if dest.exists() and any(dest.iterdir()):

--- a/tests/test_archive_destination_contract.py
+++ b/tests/test_archive_destination_contract.py
@@ -1,0 +1,129 @@
+"""``extract_archive`` must honour the destination contract it documents.
+
+The docstring promises output goes to "a writable directory under the mulder
+cases directory", but the code resolved ``extract_to`` and used it verbatim,
+so an MCP client could unpack an attacker-supplied archive anywhere the server
+could write.  Separately, the default slot was keyed on ``archive.stem``, so
+two unrelated archives called ``evidence.zip`` shared one directory and the
+second call reported the *first* archive's files as its own.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.tools.case import extract_archive
+
+
+@pytest.fixture
+def cases_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "cases"
+    d.mkdir()
+    return d
+
+
+def _zip(path: Path, name: str, data: bytes) -> Path:
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(name, data)
+    return path
+
+
+def _invoke(cases_dir: Path, archive: Path, extract_to: str | None = None) -> Any:
+    cfg = MagicMock()
+    cfg.db_dir = cases_dir
+    with (
+        patch("mulder.server.tools.case.get_cfg", return_value=cfg),
+        patch("mulder.server.tools.case.has_ctx", return_value=False),
+        patch("mulder.server.tools.case.EvidenceClassifier", create=True),
+    ):
+        return extract_archive.__wrapped__(  # type: ignore[attr-defined]
+            str(archive), extract_to=extract_to
+        )
+
+
+def test_an_extract_to_outside_the_cases_dir_is_refused(cases_dir: Path, tmp_path: Path) -> None:
+    """The documented contract, now enforced.
+
+    Without this, ``extract_to`` is an arbitrary write primitive: the archive
+    decides the filenames and the caller decides the directory.
+    """
+    archive = _zip(tmp_path / "eq.zip", "payload.txt", b"x")
+    outside = tmp_path / "somewhere-else"
+
+    result = _invoke(cases_dir, archive, extract_to=str(outside))
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "invalid_input"
+    assert "extract_to must stay under" in str(result["error_message"])
+    assert not outside.exists(), "the refused destination must not be created"
+
+
+def test_traversal_out_of_the_extract_root_is_refused(cases_dir: Path, tmp_path: Path) -> None:
+    """``..`` segments are collapsed before the containment check, not after."""
+    archive = _zip(tmp_path / "eq.zip", "payload.txt", b"x")
+    escape = str(cases_dir / "extracted" / ".." / ".." / ".." / "etc")
+
+    result = _invoke(cases_dir, archive, extract_to=escape)
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "invalid_input"
+
+
+def test_an_extract_to_inside_the_extract_root_is_allowed(cases_dir: Path, tmp_path: Path) -> None:
+    """Pins the fix's narrowness: a legitimate explicit destination still works."""
+    archive = _zip(tmp_path / "eq.zip", "payload.txt", b"hello")
+    inside = cases_dir / "extracted" / "my-slot"
+
+    result = _invoke(cases_dir, archive, extract_to=str(inside))
+
+    assert result["status"] == "success"
+    assert (inside / "payload.txt").read_bytes() == b"hello"
+
+
+def test_two_archives_with_the_same_name_do_not_share_a_slot(
+    cases_dir: Path, tmp_path: Path
+) -> None:
+    """The forensic bite: archive B reported archive A's contents as its own.
+
+    Both are called ``evidence.zip``; only their directory differs.
+    """
+    a_dir = tmp_path / "seizure-a"
+    b_dir = tmp_path / "seizure-b"
+    a_dir.mkdir()
+    b_dir.mkdir()
+    a = _zip(a_dir / "evidence.zip", "from-a.txt", b"a")
+    b = _zip(b_dir / "evidence.zip", "from-b.txt", b"b")
+
+    first = _invoke(cases_dir, a)
+    second = _invoke(cases_dir, b)
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    assert first["extracted_to"] != second["extracted_to"]
+
+    b_files = list(Path(str(second["extracted_to"])).rglob("*.txt"))
+    assert [f.name for f in b_files] == ["from-b.txt"], (
+        f"archive B's slot holds {[f.name for f in b_files]}"
+    )
+
+
+def test_the_slot_is_stable_for_one_archive(tmp_path: Path) -> None:
+    """Idempotency must survive: the same archive maps to the same slot."""
+    from mulder.server.tools.case import _archive_slot
+
+    archive = tmp_path / "evidence.zip"
+    assert _archive_slot(archive) == _archive_slot(archive)
+    assert archive.stem in _archive_slot(archive)
+
+
+def test_the_slot_differs_for_same_named_archives_elsewhere(tmp_path: Path) -> None:
+    from mulder.server.tools.case import _archive_slot
+
+    a = tmp_path / "one" / "evidence.zip"
+    b = tmp_path / "two" / "evidence.zip"
+    assert _archive_slot(a) != _archive_slot(b)


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `extract_archive` documents that it writes "to a writable directory under the mulder cases directory" — but nothing enforced it. `extract_to` was resolved and used **verbatim**.
- The archive supplies the filenames and the caller supplies the directory; together that is an **arbitrary file-write primitive** driven by attacker-controlled evidence.
- A second, quieter defect in the same block: the default slot was keyed on `archive.stem`, so two unrelated archives both named `evidence.zip` shared one directory — and the second call took the *"already extracted"* branch and reported **the first archive's files as its own**.
- Fix: confine `extract_to` with `resolve_allowed_path` (the helper `artifacts.py` already uses) rooted at `<db_dir>/extracted`, and key the default slot on a digest of the resolved archive path.
- Scope: `src/mulder/server/tools/case.py`, `extract_archive` and one new private helper. No new abstraction — it reuses the merged path-policy mechanism.

## The bug

```python
    if extract_to:
        dest = Path(extract_to).expanduser().resolve()
    else:
        cfg = get_cfg()
        dest = cfg.db_dir / "extracted" / archive.stem
```

`resolve()` collapses `..` but never checks *where it landed*. And `archive.stem` discards the directory the archive came from, so `/seizure-a/evidence.zip` and `/seizure-b/evidence.zip` both map to `extracted/evidence`.

The collision is the forensically serious half. Combined with the idempotency branch a few lines below, the second extraction never runs:

```python
    if dest.exists() and any(dest.iterdir()):
        ...
        "status": "already_extracted",
```

so `extract_archive("/seizure-b/evidence.zip")` returns seizure A's file list, attributed to B.

## The fix

```python
    cfg = get_cfg()
    extract_root = Path(cfg.db_dir) / "extracted"

    if extract_to:
        try:
            dest = resolve_allowed_path(Path(extract_to).expanduser(), [extract_root])
        except PathPolicyError as exc:
            return error_response(
                tc_id, "extract_archive", params,
                f"{exc}: extract_to must stay under {extract_root}",
                (time.monotonic() - t0) * 1000,
                error_type="invalid_input",
            )
    else:
        dest = extract_root / _archive_slot(archive)
```

`resolve_allowed_path` comes from `mulder.path_policy` — introduced by the **merged** PR #31 and already used by `artifacts.py::_resolve_artifact_path`. This PR adds no new containment mechanism; it applies the existing one to the one tool that writes files.

`_archive_slot` keeps the readable stem and appends a short blake2b digest of the resolved source path, so the slot stays stable for a given archive (idempotency is preserved) while differing between same-named archives.

## Deliberately out of scope

- **Resource limits** (member count / total uncompressed bytes). A zip bomb is a separate defect with separate tests; it is its own PR.
- **The partial-extraction bug** in the `already_extracted` branch, and **plain `.gz` being routed to the tar extractor** — both separate PRs from closed #85.
- **No compression-ratio heuristic.** An earlier revision of closed #84 capped per-member expansion at 500×. That was removed as wrong and is *not* revived here: a zeroed 64 MiB region compresses ~1029×, so the metric cannot tell an unallocated `dd` region or a fresh VM memory dump — ordinary evidence — from an attack.
- **`_extract_zip` / `_safe_tar_filter` member sanitisation** is left alone; Python's own `ZipFile.extract` and the tar `filter=` already handle member-level traversal. This PR is about the *destination*, not the members.

## Relationship to open PR #83

Open PR **#83 (`fix/case-id-validation`)** is the same *class* of fix — untrusted input reaching a path — but touches `scan_evidence` and `open_case` and validates `case_id`. This PR touches `extract_archive` and validates the destination directory. Disjoint functions, disjoint lines; verified conflict-free with `git merge-tree --write-tree`. Also verified conflict-free against open #88 (`fix/list-cases-leak`), the other open PR on this file.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `case.py` restored to `origin/main` and the new tests kept, 3 of the 4 behavioural tests fail:

```
FAILED test_an_extract_to_outside_the_cases_dir_is_refused - AssertionError: assert 'success' == 'error'
FAILED test_traversal_out_of_the_extract_root_is_refused   - AssertionError: assert 'success' == 'error'
FAILED test_two_archives_with_the_same_name_do_not_share_a_slot
  - AssertionError: assert 'already_extracted' == 'success'
```

That third line is the collision bug caught in the act: archive B lands in archive A's slot and is reported as already extracted. `test_an_extract_to_inside_the_extract_root_is_allowed` passes against **both** trees — it pins that a legitimate explicit destination still works, so the fix cannot be credited with more than it fixes.

## Context

Recovered from closed PR **#84** (`fix/archive-containment`), which bundled containment, slot naming and resource limits into one 231-line change and was closed unmerged. This is the destination concern only, branched fresh from current `main` (`2e5432c`) — the closed branch was not revised in place. None of the rejected outcome framework is reintroduced.

## Note on the sibling PRs

This is one of four narrow PRs recovered from closed #84/#85, all touching `extract_archive` in `src/mulder/server/tools/case.py`:

| PR | Concern |
|----|---------|
| #103 | destination containment + slot collision |
| #111 | resource limits (member count / total bytes) |
| #117 | partial extraction reported as complete |
| #124 | plain `.gz`/`.bz2` routed to the tar extractor |

Each is independently branched off `main` and independently testable, and **all four are verified conflict-free against open #83 and #88**, the other PRs on this file.

They are **not** all conflict-free against each other — four of the six pairs touch overlapping lines of the same function (`git merge-tree` reports `CONFLICT (content): src/mulder/server/tools/case.py` for dest×partial, dest×gzip, limits×partial, partial×gzip). That is inherent to splitting one function's defects into one-fix-per-PR rather than shipping a bundle. Merge them in any order; whichever lands first, I will rebase the rest — say the word and I will do that immediately, or collapse any subset into a single PR if you would rather review them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
