### PR TITLE
[critical] fix(zircolite): drop the --json flag Zircolite has no option for

### DIFF
--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -100,9 +100,11 @@ def _run_zircolite_process(
         str(events_path),
         "--ruleset",
         str(ruleset_path),
-        "--json",
         "--outfile",
         str(output_file),
+        # The input format is declared by format_flags alone. Zircolite has no
+        # --json option: seven of its options start with that prefix, so
+        # argparse rejects it as ambiguous before reading a single event.
         *format_flags,
     ]
 

--- a/tests/test_zircolite_cli_contract.py
+++ b/tests/test_zircolite_cli_contract.py
@@ -1,0 +1,117 @@
+"""Mulder's Zircolite command line must be one Zircolite 2.20.0 accepts.
+
+``_run_zircolite_process`` passed a ``--json`` flag that Zircolite does not
+define. Seven of its options begin with that prefix, so argparse rejected the
+invocation as ambiguous and exited 2 before opening a single event log --
+every ``run_zircolite`` call, on every log format.
+
+The contract test below rebuilds Zircolite's own parser from the option
+strings in the pinned release and feeds it the argv mulder actually builds, so
+it fails against any invocation that release would refuse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mulder.assets.manifest import ZIRCOLITE_VERSION
+from mulder.server.tools.zircolite import _FORMAT_FLAGS, _run_zircolite_process
+
+_FORMATS = ["auditd", "sysmon_linux", "json", "evtx"]
+
+
+def _zircolite_parser() -> argparse.ArgumentParser:
+    """Zircolite 2.20.0's input-format options, verbatim.
+
+    Copied from ``zircolite.py`` at tag 2.20.0 (the pinned ``git_ref``), lines
+    1925-1962: one mutually exclusive group holding every input-format option,
+    plus the three flags mulder supplies. ``exit_on_error`` stays default, so
+    a rejected option raises ``SystemExit`` exactly as it does in production.
+    """
+    parser = argparse.ArgumentParser(prog="zircolite.py")
+    formats = parser.add_mutually_exclusive_group()
+    formats.add_argument(
+        "-j", "--jsononly", "--jsonline", "--jsonl", "--json-input", action="store_true"
+    )
+    formats.add_argument("--jsonarray", "--json-array", "--json-array-input", action="store_true")
+    formats.add_argument("-D", "--dbonly", "--db-input", action="store_true")
+    formats.add_argument(
+        "-S", "--sysmon4linux", "--sysmon-linux", "--sysmon-linux-input", action="store_true"
+    )
+    formats.add_argument("-AU", "--auditd", "--auditd-input", action="store_true")
+    parser.add_argument("-e", "--events", "--evtx", type=str)
+    parser.add_argument("-r", "--ruleset", type=str)
+    parser.add_argument("-o", "--outfile", type=str)
+    return parser
+
+
+def _built_argv(log_format: str, tmp_path: Path) -> list[str]:
+    """The argv mulder hands to Zircolite, minus the interpreter and script."""
+    with patch("mulder.server.tools.zircolite.subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        _run_zircolite_process(
+            str(tmp_path / "zircolite.py"),
+            tmp_path / "events.log",
+            log_format,
+            tmp_path / "rules",
+            tmp_path,
+        )
+    cmd: list[str] = run.call_args[0][0]
+    assert cmd[0] == sys.executable
+    return cmd[2:]
+
+
+def test_the_pinned_release_is_the_one_this_contract_describes() -> None:
+    """The parser above is transcribed from 2.20.0; fail loudly on a bump."""
+    assert ZIRCOLITE_VERSION == "2.20.0"
+
+
+@pytest.mark.parametrize("log_format", _FORMATS)
+def test_zircolite_accepts_the_command_mulder_builds(log_format: str, tmp_path: Path) -> None:
+    """The whole point: the pinned release must parse our argv.
+
+    Against the unfixed code this raises SystemExit(2) with
+    "ambiguous option: --json could match --jsononly, --jsonline, ...".
+    """
+    argv = _built_argv(log_format, tmp_path)
+
+    parsed = _zircolite_parser().parse_args(argv)
+
+    assert parsed.events == str(tmp_path / "events.log")
+    assert parsed.ruleset == str(tmp_path / "rules")
+
+
+@pytest.mark.parametrize("log_format", _FORMATS)
+def test_no_bare_json_flag_is_passed(log_format: str, tmp_path: Path) -> None:
+    """``--json`` is not a Zircolite option in any release mulder pins."""
+    assert "--json" not in _built_argv(log_format, tmp_path)
+
+
+def test_the_input_format_is_still_declared(tmp_path: Path) -> None:
+    """Pins the fix's narrowness: removing --json must not lose the format.
+
+    The format is declared by ``_FORMAT_FLAGS`` alone, so a JSON log must
+    still arrive as ``--jsononly`` -- otherwise Zircolite would read JSON
+    lines as EVTX and find nothing.
+    """
+    argv = _built_argv("json", tmp_path)
+
+    assert "--jsononly" in argv
+    assert _zircolite_parser().parse_args(argv).jsononly is True
+
+
+def test_every_format_flag_is_a_real_option() -> None:
+    """Each mapped flag must be one the pinned release actually defines."""
+    parser = _zircolite_parser()
+    for log_format, flags in _FORMAT_FLAGS.items():
+        for flag in flags:
+            try:
+                parser.parse_args([flag])
+            except SystemExit:  # pragma: no cover - only on a bad mapping
+                pytest.fail(f"{log_format} maps to {flag}, which Zircolite does not define")


### PR DESCRIPTION
## BLUF

- **Priority: critical.**
- `run_zircolite` **cannot succeed on any input**. `_run_zircolite_process` passes `--json`, which Zircolite 2.20.0 does not define.
- Seven of Zircolite's input-format options begin with `--json`, so argparse rejects the invocation as **ambiguous** and exits 2 — before opening a single event log. Linux Sigma detection has never run.
- The flag was **redundant as well as invalid**: the input format is already declared by `_FORMAT_FLAGS`.
- Fix: delete the flag. One line.
- Scope: `src/mulder/server/tools/zircolite.py` only, plus a new CLI-contract test.

## The bug

```python
    cmd = [
        sys.executable,
        script,
        "--events", str(events_path),
        "--ruleset", str(ruleset_path),
        "--json",                        # <- not a Zircolite option
        "--outfile", str(output_file),
        *format_flags,
    ]
```

Verified against the pinned release itself (`ZIRCOLITE_VERSION = "2.20.0"`, `git_ref` 2.20.0). In `zircolite.py` lines 1925-1962 the input formats live in one mutually exclusive group:

```python
    eventFormatsArgs = parser.add_mutually_exclusive_group()
    eventFormatsArgs.add_argument(
        "-j", "--jsononly", "--jsonline", "--jsonl", "--json-input", ...
    )
    eventFormatsArgs.add_argument(
        "--jsonarray", "--json-array", "--json-array-input", ...
    )
```

Feeding that parser the argv mulder builds:

```
zircolite.py: error: ambiguous option: --json could match --jsononly, --jsonline,
--jsonl, --json-input, --jsonarray, --json-array, --json-array-input
SystemExit code: 2
```

`--json` is not merely unknown — it is an ambiguous **prefix**, which argparse refuses outright. And it was never needed: `_FORMAT_FLAGS` already maps `"json"` to `--jsononly`, one of the very options `--json` is ambiguous against and a member of the same mutually exclusive group, so the two could not have coexisted even had the prefix resolved.

## The fix

```python
        "--ruleset",
        str(ruleset_path),
        "--outfile",
        str(output_file),
        # The input format is declared by format_flags alone. Zircolite has no
        # --json option: seven of its options start with that prefix, so
        # argparse rejects it as ambiguous before reading a single event.
        *format_flags,
    ]
```

The test does not assert on a string. It **rebuilds Zircolite's parser** from the pinned release's option strings and asserts that the argv mulder actually constructs parses cleanly, for all four log formats — so it fails against any invocation 2.20.0 would refuse, not just this one flag. A guard test pins `ZIRCOLITE_VERSION == "2.20.0"` so a version bump forces the transcription to be rechecked.

Narrowness is pinned too: `test_the_input_format_is_still_declared` asserts a JSON log still arrives as `--jsononly` and parses to `jsononly is True`, so removing `--json` cannot silently lose the format and make Zircolite read JSON lines as EVTX.

## Deliberately out of scope

- **Failure reporting.** Open PR #91 (`fix/zircolite-exit-code`) makes `run_zircolite` return an error when Zircolite exits non-zero having written no results. The two are complementary and disjoint: **#91 surfaces the failure, this PR removes its cause.** Neither touches the other's lines; verified conflict-free with `git merge-tree`.
- **Detection indexing.** A separate concern in its own PR.
- The rejected outcome framework and `classify_tool_exit` are **not** reintroduced here.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **865 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- Zircolite 2.20.0's `zircolite.py` was downloaded from the pinned tag and its option strings read directly; the ambiguity was reproduced by running argparse, not inferred.
- **Discriminating check** — with `zircolite.py` restored to `origin/main` and the new tests kept, **9 of 11 fail**:

```
FAILED test_zircolite_accepts_the_command_mulder_builds[auditd] - SystemExit: 2
FAILED test_zircolite_accepts_the_command_mulder_builds[sysmon_linux] - SystemExit: 2
FAILED test_zircolite_accepts_the_command_mulder_builds[json] - SystemExit: 2
FAILED test_zircolite_accepts_the_command_mulder_builds[evtx] - SystemExit: 2
FAILED test_no_bare_json_flag_is_passed[auditd] - AssertionError: assert '--json' not in [...]
FAILED test_no_bare_json_flag_is_passed[sysmon_linux] - AssertionError: assert '--json' not in [...]
FAILED test_no_bare_json_flag_is_passed[json] - AssertionError: assert '--json' not in [...]
FAILED test_no_bare_json_flag_is_passed[evtx] - AssertionError: assert '--json' not in [...]
FAILED test_the_input_format_is_still_declared - SystemExit: 2
9 failed, 2 passed
```

with the underlying error `argparse.ArgumentError: ambiguous option: --json could match --jsononly, --jsonline, --jsonl, --json-input, --jsonarray, --json-array, --json-array-input`.

## Context

Recovered from closed PR #69, which changed the CLI contract of every wrapped tool in one branch. Only the zircolite change is here; the other tools' flag fixes are separate concerns and are not bundled in. The rejected outcome framework is not reintroduced, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
