### PR TITLE
[critical] fix(pdf): stop hex-obfuscated names erasing pdfid's indicators

### DIFF
--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -148,6 +148,11 @@ _SUSPICIOUS_JS_FUNCTIONS: list[str] = [
 #: Everything above it is banner/log noise.
 _MSODDE_LINK_MARKER = "DDE Links:"
 
+# pdfid keyword rows end in the total count, optionally followed by the
+# hex-obfuscated tally in parentheses: "1", or "1(1)" when the name was
+# written as e.g. /J#61vaScript.
+_PDFID_COUNT_RE = re.compile(r"^(?P<total>\d+)(?:\((?P<hexcode>\d+)\))?$")
+
 
 def _parse_msodde_output(stdout: str) -> list[dict[str, object]]:
     """Extract DDE links from msodde's output.
@@ -418,6 +423,12 @@ def _run_pdfid(file_path: Path) -> list[dict[str, object]]:
 def _extract_pdfid_count(line: str) -> int:
     """Extract the numeric count from a pdfid output line.
 
+    pdfid formats a keyword row as ``' %-16s %7d'`` and, when any occurrence
+    of the name was written with a hex-escaped character, appends the
+    hex-encoded tally as ``'(%d)'`` with no separating space -- so a name that
+    an attacker obfuscated arrives as ``/JavaScript            1(1)``. The
+    total count is the part before that suffix; it must not be discarded.
+
     Args:
         line: A single line from pdfid output.
 
@@ -425,12 +436,12 @@ def _extract_pdfid_count(line: str) -> int:
         Integer count value, or 0 if not parseable.
     """
     parts = line.rsplit(None, 1)
-    if len(parts) == 2:
-        try:
-            return int(parts[1])
-        except ValueError:
-            return 0
-    return 0
+    if len(parts) != 2:
+        return 0
+    match = _PDFID_COUNT_RE.match(parts[1])
+    if match is None:
+        return 0
+    return int(match.group("total"))
 
 
 def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:

--- a/tests/test_pdfid_obfuscated_counts.py
+++ b/tests/test_pdfid_obfuscated_counts.py
@@ -1,0 +1,90 @@
+"""Hex-obfuscated PDF names must not make pdfid's indicators disappear.
+
+pdfid prints a keyword row as ``' %-16s %7d'`` and appends the hex-encoded
+tally as ``'(%d)'`` -- with no separating space -- whenever any occurrence of
+that name was written with an escaped character. So a PDF whose action is
+spelled ``/J#61vaScript`` comes back as::
+
+     /JavaScript            1(1)
+
+``_extract_pdfid_count`` did ``int(line.rsplit(None, 1)[1])``, which raises
+``ValueError`` on ``"1(1)"`` and returned ``0``. ``_run_pdfid`` keeps only
+indicators whose count is ``> 0``, so the indicator was dropped outright:
+``has_javascript`` came back ``False``, no "Contains JavaScript" reason was
+recorded, and ``analyze_pdf`` never even called the JavaScript extractor --
+which it gates on that same indicator.
+
+Escaping a name is the textbook way to hide it from pdfid, and it is exactly
+the case this parser turned into silence.
+"""
+
+from __future__ import annotations
+
+from mulder.server.tools.documents import _compute_pdf_risk, _extract_pdfid_count
+
+# Verbatim rows from pdfid 0.2.10 run against a PDF using /J#61vaScript
+# and /J#53 for its OpenAction JavaScript.
+_OBFUSCATED_ROWS = [
+    " /JS                    1(1)",
+    " /JavaScript            1(1)",
+    " /OpenAction            1",
+]
+
+
+def test_a_hex_obfuscated_name_still_reports_its_count() -> None:
+    """The row pdfid actually emits for an escaped name."""
+    assert _extract_pdfid_count(" /JavaScript            1(1)") == 1
+
+
+def test_the_count_is_the_total_not_the_hexcode_tally() -> None:
+    """pdfid's first number counts every occurrence; the suffix is a subset.
+
+    In pdfid's ``UpdateWords`` the total is incremented for each occurrence and
+    the hexcode tally only additionally, so ``2(1)`` means two occurrences, one
+    of which was escaped -- not three, and not one.
+    """
+    assert _extract_pdfid_count(" /EmbeddedFile          2(1)") == 2
+    assert _extract_pdfid_count(" /Launch                7(3)") == 7
+
+
+def test_a_plain_row_is_unchanged() -> None:
+    """Pins the fix's narrowness: ordinary rows must parse exactly as before."""
+    assert _extract_pdfid_count(" /OpenAction            1") == 1
+    assert _extract_pdfid_count(" /JS                   12") == 12
+    assert _extract_pdfid_count(" /EmbeddedFile          0") == 0
+
+
+def test_junk_still_parses_as_zero() -> None:
+    """Non-numeric trailing fields must not raise or invent a count."""
+    assert _extract_pdfid_count(" PDF Header: %PDF-1.4") == 0
+    assert _extract_pdfid_count(" /JS                 (1)") == 0
+    assert _extract_pdfid_count(" /JS                  1(") == 0
+    assert _extract_pdfid_count(" /JS                 1(1)x") == 0
+    assert _extract_pdfid_count("") == 0
+    assert _extract_pdfid_count("single") == 0
+
+
+def test_an_obfuscated_pdf_is_no_longer_reported_without_javascript() -> None:
+    """The end-to-end consequence: the risk assessment regains the JS finding.
+
+    Built from the real pdfid rows above. Before the fix both JavaScript rows
+    parsed to 0 and were discarded, leaving only /OpenAction -- so the report
+    said ``has_javascript: False`` for a PDF that auto-runs a script.
+    """
+    indicators = [
+        {"keyword": kw, "count": _extract_pdfid_count(row), "risk_level": risk}
+        for row, kw, risk in (
+            (_OBFUSCATED_ROWS[0], "/JS", "high"),
+            (_OBFUSCATED_ROWS[1], "/JavaScript", "high"),
+            (_OBFUSCATED_ROWS[2], "/OpenAction", "high"),
+        )
+        if _extract_pdfid_count(row) > 0
+    ]
+
+    risk = _compute_pdf_risk(indicators, [])
+
+    assert risk["has_javascript"] is True
+    reasons = risk["reasons"]
+    assert isinstance(reasons, list)
+    assert "Contains JavaScript" in reasons
+    assert risk["has_auto_action"] is True


### PR DESCRIPTION
## BLUF

- **Priority: critical.**
- A PDF that hex-escapes a name — `/J#61vaScript` instead of `/JavaScript` — is reported by `analyze_pdf` with **`has_javascript: False`** and no "Contains JavaScript" reason. Name escaping is the textbook way to hide from pdfid, and this parser turned it into silence.
- Root cause: `_extract_pdfid_count` does `int(line.rsplit(None, 1)[1])`. pdfid appends the hex-encoded tally to the count with **no separating space**, so the field is `"1(1)"`, `int()` raises `ValueError`, and the function returns `0`.
- `_run_pdfid` keeps only indicators with `count > 0`, so the indicator is **discarded outright** — and `analyze_pdf` gates JavaScript extraction on that same indicator, so the JS is never even extracted. One bad `int()` cascades into a clean bill of health.
- Fix: parse the count with a regex that accepts the optional `(N)` suffix and keeps the total.
- Scope: `src/mulder/server/tools/documents.py`, one function plus one module constant.

## The bug

pdfid 0.2.10 formats each keyword row (`pdfid.py`, `PDFiD2String`):

```python
result += ' %-16s %7d' % (node.getAttribute('Name'), int(node.getAttribute('Count')))
if int(node.getAttribute('HexcodeCount')) > 0:
    result += '(%d)' % int(node.getAttribute('HexcodeCount'))
```

and mulder parsed it:

```python
    parts = line.rsplit(None, 1)
    if len(parts) == 2:
        try:
            return int(parts[1])
        except ValueError:
            return 0          # <- every hex-obfuscated row lands here
    return 0
```

**Verified against the real tool.** A minimal PDF whose OpenAction is `/S /J#61vaScript /J#53 (...)`, run through pdfid 0.2.10:

```
 /JS                    1(1)
 /JavaScript            1(1)
 /OpenAction            1
```

and through today's `documents.py`:

```
' /JS                    1(1)'   -> count=0
' /JavaScript            1(1)'   -> count=0
' /OpenAction            1'      -> count=1
' /EmbeddedFile          2(1)'   -> count=0
risk_level: medium | has_javascript: False
reasons: ['Auto-execution trigger present']
```

A PDF that auto-executes a script is reported as having no JavaScript. `/EmbeddedFile` vanishes the same way.

## The fix

```python
_PDFID_COUNT_RE = re.compile(r"^(?P<total>\d+)(?:\((?P<hexcode>\d+)\))?$")
```

```python
    parts = line.rsplit(None, 1)
    if len(parts) != 2:
        return 0
    match = _PDFID_COUNT_RE.match(parts[1])
    if match is None:
        return 0
    return int(match.group("total"))
```

The total is the right number to keep: in pdfid's `UpdateWords`, `words[name][0] += 1` runs for **every** occurrence and the hexcode tally `[1] += 1` only additionally — so `2(1)` means two occurrences, one of which was escaped. Two tests pin that reading and the unchanged behaviour of ordinary rows.

## Deliberately out of scope

- **Using the hexcode tally as a signal.** A hex-escaped `/JavaScript` has no legitimate purpose and is arguably an indicator in its own right; the regex captures it as `hexcode` but nothing consumes it yet. Feeding it into `_compute_pdf_risk` changes risk scoring and belongs in its own PR.
- **The unimplemented `extract_urls` / `extract_embedded` parameters** (`summary["urls"] = []`, `summary["embedded_files"] = []`) — a separate defect, submitted separately.
- **The tool-failure paths for olevba and msodde** — open PRs #99 and #101 cover those. This PR touches neither; it only changes pdfid output parsing, so it is complementary to both and conflict-free with them (verified with `git merge-tree --write-tree`).

## Verification

- `uvx pre-commit run` over the changed files → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **860 passed**, nothing deselected.
- Evidence above came from running the real pdfid 0.2.10 against a crafted PDF, not from reading documentation.
- **Discriminating check** — with `documents.py` restored to `origin/main` and the new tests kept, 3 of 5 fail and the 2 narrowness tests pass:

```
FAILED tests/test_pdfid_obfuscated_counts.py::test_a_hex_obfuscated_name_still_reports_its_count - AssertionError: assert 0 == 1
FAILED tests/test_pdfid_obfuscated_counts.py::test_the_count_is_the_total_not_the_hexcode_tally - AssertionError: assert 0 == 2
FAILED tests/test_pdfid_obfuscated_counts.py::test_an_obfuscated_pdf_is_no_longer_reported_without_javascript - assert False is True
3 failed, 2 passed
```

## Context

Recovered from closed PR #79, which bundled several unrelated PDF detection gaps into a 284-line diff. This is one of them, resubmitted on its own. No outcome framework, no shared taxonomy, no new abstraction — one regex and one function, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
