### PR TITLE
[high] fix(email): give an HTML-only message a searchable body

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import email as email_lib
 import email.parser
 import logging
+import re
 import subprocess
 import tempfile
 import time
@@ -54,6 +55,10 @@ _SUSPICIOUS_EXTENSIONS: set[str] = {
 
 _VALID_PST_SUFFIXES: set[str] = {".pst", ".ost"}
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_WS_RE = re.compile(r"[ \t]*\n[ \t]*")
+_SCRIPT_STYLE_RE = re.compile(r"(?is)<(script|style).*?</\1>")
+
 
 # ---------------------------------------------------------------------------
 # Parsing helpers
@@ -87,20 +92,56 @@ def _get_body(
     Returns:
         Body text or None if no matching part found.
     """
-    if msg.is_multipart():
-        for part in msg.walk():
-            if part.get_content_type() == content_type:
-                payload = part.get_payload(decode=True)
-                if isinstance(payload, bytes):
-                    charset = part.get_content_charset() or "utf-8"
-                    return payload.decode(charset, errors="replace")
-    else:
-        if msg.get_content_type() == content_type:
-            payload = msg.get_payload(decode=True)
-            if isinstance(payload, bytes):
-                charset = msg.get_content_charset() or "utf-8"
+    for part in msg.walk():
+        if part.is_multipart():
+            continue
+        # A text/plain *attachment* is evidence, but it is not the body.
+        if part.get_content_disposition() == "attachment":
+            continue
+        if part.get_content_type() != content_type:
+            continue
+        payload = part.get_payload(decode=True)
+        if isinstance(payload, bytes):
+            charset = part.get_content_charset() or "utf-8"
+            try:
                 return payload.decode(charset, errors="replace")
+            except LookupError:
+                # A charset the platform does not know must not lose the body.
+                return payload.decode("utf-8", errors="replace")
     return None
+
+
+def _html_to_text(html: str) -> str:
+    """Strip markup from an HTML body so its words are searchable."""
+    text = _SCRIPT_STYLE_RE.sub(" ", html)
+    text = _HTML_TAG_RE.sub(" ", text)
+    for entity, char in (
+        ("&nbsp;", " "),
+        ("&amp;", "&"),
+        ("&lt;", "<"),
+        ("&gt;", ">"),
+        ("&quot;", '"'),
+        ("&#39;", "'"),
+    ):
+        text = text.replace(entity, char)
+    return _HTML_WS_RE.sub("\n", text).strip()
+
+
+def _get_searchable_body(msg: email_lib.message.Message) -> str | None:
+    """The message body as text, whatever it was sent as.
+
+    ``text/plain`` when present, otherwise ``text/html`` with the markup
+    stripped. An HTML-only message -- which is most phishing -- previously
+    had no body at all, so no keyword could match it and nothing of its
+    content reached the case.
+    """
+    plain = _get_body(msg, "text/plain")
+    if plain and plain.strip():
+        return plain
+    html = _get_body(msg, "text/html")
+    if html and html.strip():
+        return _html_to_text(html)
+    return plain or html
 
 
 def _matches_search(
@@ -163,7 +204,7 @@ def _parse_email_message(
         "recipients_to": _parse_recipients(msg.get("To", "")),
         "recipients_cc": _parse_recipients(msg.get("Cc", "")),
         "date": msg.get("Date"),
-        "body_text": _get_body(msg, "text/plain"),
+        "body_text": _get_searchable_body(msg),
         "attachments": attachments,
         "folder": folder,
         "importance": msg.get("Importance", "normal"),

--- a/tests/test_pst_html_body.py
+++ b/tests/test_pst_html_body.py
@@ -1,0 +1,169 @@
+"""An HTML-only message must still have a searchable, indexable body.
+
+``_parse_email_message`` set ``body_text`` from ``_get_body(msg, "text/plain")``
+alone. Most phishing is sent as ``text/html`` only, so those messages had
+``body_text: None``: a ``search_term`` naming a phrase in the body could never
+match them, and none of their content reached the case DB.
+
+``_get_body`` had a second defect -- for a multipart message it walked every
+part including nested containers and attachments, and it raised ``LookupError``
+outright on a charset the platform does not know, losing the body entirely.
+"""
+
+from __future__ import annotations
+
+import email as email_lib
+from pathlib import Path
+from typing import Any
+
+from mulder.server.tools.email import _parse_email_message, _parse_extracted_emails
+
+_PHISH_HTML = (
+    "<html><head><style>p{color:red}</style></head><body>"
+    "<p>Please action this <b>wire&nbsp;transfer</b> today.</p>"
+    "<script>var x=1;</script>"
+    "</body></html>"
+)
+
+
+def _html_only_message() -> email_lib.message.Message:
+    raw = (
+        "From: attacker@example.com\n"
+        "To: cfo@example.com\n"
+        "Subject: Invoice\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n" + _PHISH_HTML + "\n"
+    )
+    return email_lib.message_from_string(raw)
+
+
+def _write_html_only(folder: Path, name: str) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / name).write_text(
+        "From: attacker@example.com\n"
+        "To: cfo@example.com\n"
+        "Subject: Invoice\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n" + _PHISH_HTML + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_an_html_only_message_has_a_body(tmp_path: Path) -> None:
+    parsed = _parse_email_message(_html_only_message(), "Inbox")
+
+    body = parsed["body_text"]
+    assert body is not None, "an HTML-only message was left with no body at all"
+    assert "wire transfer" in str(body)
+
+
+def test_markup_is_stripped_not_indexed(tmp_path: Path) -> None:
+    """Tags, scripts and styles are not evidence and must not reach the case."""
+    parsed = _parse_email_message(_html_only_message(), "Inbox")
+    body = str(parsed["body_text"])
+
+    assert "<p>" not in body
+    assert "var x=1" not in body
+    assert "color:red" not in body
+
+
+def test_a_keyword_search_finds_an_html_only_message(tmp_path: Path) -> None:
+    """The forensic consequence: the message was invisible to search."""
+    _write_html_only(tmp_path / "Inbox", "phish.eml")
+
+    result: dict[str, Any] = _parse_extracted_emails(
+        tmp_path, "/evidence/mail.pst", search_term="wire transfer"
+    )
+
+    assert result["total_emails"] == 1
+
+
+def test_plain_text_still_wins_over_html(tmp_path: Path) -> None:
+    """Narrowness: a multipart/alternative message keeps its text/plain part."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Both\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        'Content-Type: multipart/alternative; boundary="B"\n'
+        "\n"
+        "--B\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "the plain part\n"
+        "--B\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n"
+        "<p>the html part</p>\n"
+        "--B--\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+
+    assert str(parsed["body_text"]).strip() == "the plain part"
+
+
+def test_a_text_attachment_is_not_mistaken_for_the_body() -> None:
+    """An attached .txt is evidence, but it is not the message body."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: With attachment\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        'Content-Type: multipart/mixed; boundary="B"\n'
+        "\n"
+        "--B\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n"
+        "<p>real body</p>\n"
+        "--B\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        'Content-Disposition: attachment; filename="notes.txt"\n'
+        "\n"
+        "attached notes\n"
+        "--B--\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+    body = str(parsed["body_text"])
+
+    assert "real body" in body
+    assert "attached notes" not in body
+
+
+def test_an_unknown_charset_does_not_lose_the_body() -> None:
+    """``LookupError`` on an exotic charset previously discarded the body."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Odd charset\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        "Content-Type: text/plain; charset=x-not-a-real-charset\n"
+        "\n"
+        "still readable\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+
+    assert "still readable" in str(parsed["body_text"])
+
+
+def test_a_plain_text_message_is_unchanged(tmp_path: Path) -> None:
+    """Narrowness: the ordinary case must behave exactly as before."""
+    folder = tmp_path / "Inbox"
+    folder.mkdir()
+    (folder / "plain.eml").write_text(
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Plain\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "hello world\n",
+        encoding="utf-8",
+    )
+
+    result = _parse_extracted_emails(tmp_path, "/evidence/mail.pst")
+    emails = result["emails"]
+    assert isinstance(emails, list)
+
+    assert str(emails[0]["body_text"]).strip() == "hello world"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- A message sent as **HTML only** — which is most phishing — had `body_text: None`. A `search_term` naming a phrase in its body could never match it, and none of its content reached the case DB.
- Two further defects in the same helper: a `text/plain` **attachment** was returned as the message body, and an unrecognised charset raised `LookupError` and lost the body entirely.
- Root cause: `body_text` came from `_get_body(msg, "text/plain")` alone, and `_get_body` walked every MIME part including attachments while decoding without a guard.
- Fix: walk only leaf parts, skip attachments, fall back to UTF-8 on an unknown charset, and fall back to `text/html` with markup stripped when there is no plain part.
- Scope: `src/mulder/server/tools/email.py` only. No new abstraction, no change to any other tool.

## The bug

```python
        "body_text": _get_body(msg, "text/plain"),
```

and

```python
    if msg.is_multipart():
        for part in msg.walk():
            if part.get_content_type() == content_type:
                payload = part.get_payload(decode=True)
                if isinstance(payload, bytes):
                    charset = part.get_content_charset() or "utf-8"
                    return payload.decode(charset, errors="replace")
```

Three separate consequences:

1. **HTML-only message → no body.** `body_text` is `None`, so `_matches_search` receives `None`, the body is never searched, and the message is dropped from any keyword search. Its content is also absent from what gets indexed.
2. **A `text/plain` attachment is returned as the body.** The walk does not check `Content-Disposition`, so for a `multipart/mixed` message whose body is HTML and whose attachment is `notes.txt`, the *attachment text* becomes `body_text`.
3. **An unknown charset loses the body.** `payload.decode(charset, …)` raises `LookupError` — not caught anywhere — for a charset the platform does not know. `errors="replace"` does not help; the exception is raised before decoding starts.

## The fix

```python
    for part in msg.walk():
        if part.is_multipart():
            continue
        # A text/plain *attachment* is evidence, but it is not the body.
        if part.get_content_disposition() == "attachment":
            continue
        if part.get_content_type() != content_type:
            continue
        payload = part.get_payload(decode=True)
        if isinstance(payload, bytes):
            charset = part.get_content_charset() or "utf-8"
            try:
                return payload.decode(charset, errors="replace")
            except LookupError:
                # A charset the platform does not know must not lose the body.
                return payload.decode("utf-8", errors="replace")
    return None
```

plus `_get_searchable_body`, which prefers `text/plain` and falls back to `text/html` with tags, `<script>` and `<style>` blocks removed and the common entities decoded. Script and style content is stripped rather than indexed — neither is evidence, and indexing it would pollute keyword search.

**A message that has a `text/plain` part is completely unaffected**; that is pinned by a test.

## Deliberately out of scope

`fix/email-parsing` (closed #78) bundled this with five other independent defects in the same file — the lexicographic date comparison, RFC 2047 header decoding, `_parse_recipients` splitting on a comma inside a quoted display name, `Cc`/`Bcc` never being searched, and attachments detected only via `Content-Disposition: attachment`. Each is a separate root cause and is being submitted as its own PR.

HTML-to-text here is deliberately a tag strip, not a full renderer: it exists so the words are searchable, not to reproduce layout. Pulling in an HTML parsing dependency for that would be a much larger change than the defect warrants.

Relationship to **open PR #96** (`fix/readpst-exit-code`): that one guards the case where readpst *failed*. This one is the success path, where messages were extracted and then parsed lossily. Different functions, no overlap; verified conflict-free with `git merge-tree`.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- Full suite → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `email.py` restored to `origin/main` and the new tests kept, **4 of 7 fail**:

```
FAILED test_an_html_only_message_has_a_body           - AssertionError: an HTML-only message was left with no body at all
FAILED test_a_keyword_search_finds_an_html_only_message - assert 0 == 1
FAILED test_a_text_attachment_is_not_mistaken_for_the_body - AssertionError: assert 'real body' in 'attached notes'
FAILED test_an_unknown_charset_does_not_lose_the_body  - LookupError: unknown encoding: x-not-a-real-charset
4 failed, 3 passed
```

The second line is the forensic consequence stated as an assertion: a phishing message containing "wire transfer" in its body, invisible to a search for exactly that phrase. The third and fourth lines are defects 2 and 3, each reproduced directly rather than argued.

The three that pass on both trees are the narrowness tests — plain-text messages unchanged, and markup absent from the body — so they pin the fix rather than the bug.

## Context

Recovered from closed PR #78, which bundled six independent defects behind one title. The rejected outcome framework and `classify_tool_exit` are **not** reintroduced — this is a self-contained fix to body extraction, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

