### PR TITLE
[high] fix(email): search the Cc line and attachment names a PST search already parsed

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -109,6 +109,7 @@ def _matches_search(
     body: str | None,
     recipients: list[str],
     search_term: str,
+    attachments: list[str] | None = None,
 ) -> bool:
     """Check whether an email matches the search keyword.
 
@@ -116,8 +117,12 @@ def _matches_search(
         subject: Email subject line.
         sender: Sender address.
         body: Plain text body (may be None).
-        recipients: List of recipient addresses.
+        recipients: Every recipient -- To, Cc *and* Bcc. Cc and Bcc were
+            parsed and then never searched, so a search naming a copied
+            recipient silently missed the message.
         search_term: Keyword to search for (case insensitive).
+        attachments: Attachment filenames, which is how an analyst looks
+            for a named payload.
 
     Returns:
         True if the term appears in any searchable field.
@@ -129,7 +134,9 @@ def _matches_search(
         return True
     if body and term in body.lower():
         return True
-    return any(term in r.lower() for r in recipients)
+    if any(term in r.lower() for r in recipients):
+        return True
+    return any(term in a.lower() for a in attachments or [])
 
 
 def _parse_email_message(
@@ -225,9 +232,14 @@ def _parse_extracted_emails(
             sender = str(parsed.get("sender", ""))
             body_val = parsed.get("body_text")
             body_str = str(body_val) if body_val is not None else None
-            to_val = parsed.get("recipients_to")
-            to_list = [str(r) for r in to_val] if isinstance(to_val, list) else []
-            if not _matches_search(subject, sender, body_str, to_list, search_term):
+            recipients: list[str] = []
+            for key in ("recipients_to", "recipients_cc"):
+                val = parsed.get(key)
+                if isinstance(val, list):
+                    recipients.extend(str(r) for r in val)
+            att_val_s = parsed.get("attachments")
+            att_names = [str(a) for a in att_val_s] if isinstance(att_val_s, list) else []
+            if not _matches_search(subject, sender, body_str, recipients, search_term, att_names):
                 continue
 
         if parsed.get("has_suspicious_attachment"):

--- a/tests/test_pst_search_coverage.py
+++ b/tests/test_pst_search_coverage.py
@@ -1,0 +1,114 @@
+"""A PST keyword search must look at every field it parses.
+
+``_parse_extracted_emails`` parsed ``Cc`` into ``recipients_cc`` and then
+passed only ``recipients_to`` to ``_matches_search``. Searching for an address
+that was copied rather than addressed silently returned nothing, even though
+the parser had the address in hand.
+
+Attachment filenames were likewise collected and never searched, so looking
+for a named payload -- ``invoice.exe`` -- found no message that carried it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mulder.server.tools.email import _parse_extracted_emails
+
+
+def _write(folder: Path, name: str, *, cc: str = "", attachment: str = "") -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    headers = [
+        "From: sender@example.com",
+        "To: recipient@example.com",
+        f"Subject: {name.removesuffix('.eml')}",
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100",
+    ]
+    if cc:
+        headers.append(f"Cc: {cc}")
+
+    if attachment:
+        headers.append('Content-Type: multipart/mixed; boundary="B"')
+        body = (
+            "\n--B\n"
+            "Content-Type: text/plain; charset=utf-8\n"
+            "\n"
+            "see attached\n"
+            "--B\n"
+            "Content-Type: application/octet-stream\n"
+            f'Content-Disposition: attachment; filename="{attachment}"\n'
+            "\n"
+            "payload\n"
+            "--B--\n"
+        )
+    else:
+        headers.append("Content-Type: text/plain; charset=utf-8")
+        body = "\nordinary body\n"
+
+    (folder / name).write_text("\n".join(headers) + "\n" + body, encoding="utf-8")
+
+
+@pytest.fixture
+def mailbox(tmp_path: Path) -> Path:
+    folder = tmp_path / "Inbox"
+    _write(folder, "copied.eml", cc="legal@example.com")
+    _write(folder, "payload.eml", attachment="invoice.exe")
+    _write(folder, "plain.eml")
+    return tmp_path
+
+
+def _subjects(result: dict[str, Any]) -> list[str]:
+    emails = result["emails"]
+    assert isinstance(emails, list)
+    return sorted(str(e["subject"]) for e in emails)
+
+
+def test_a_copied_recipient_is_searchable(mailbox: Path) -> None:
+    """``Cc`` was parsed into the result and then never searched."""
+    result = _parse_extracted_emails(
+        mailbox, "/evidence/mail.pst", search_term="legal@example.com"
+    )
+
+    assert _subjects(result) == ["copied"]
+
+
+def test_an_attachment_name_is_searchable(mailbox: Path) -> None:
+    """Looking for a named payload is how an analyst pivots on one."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst", search_term="invoice.exe")
+
+    assert _subjects(result) == ["payload"]
+
+
+def test_an_addressed_recipient_still_matches(mailbox: Path) -> None:
+    """Narrowness: the To field kept working."""
+    result = _parse_extracted_emails(
+        mailbox, "/evidence/mail.pst", search_term="recipient@example.com"
+    )
+
+    assert _subjects(result) == ["copied", "payload", "plain"]
+
+
+def test_the_subject_still_matches(mailbox: Path) -> None:
+    """Narrowness: subject search is unchanged."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst", search_term="plain")
+
+    assert _subjects(result) == ["plain"]
+
+
+def test_a_term_matching_nothing_still_matches_nothing(mailbox: Path) -> None:
+    """Narrowness: widening the search must not make it match everything."""
+    result = _parse_extracted_emails(
+        mailbox, "/evidence/mail.pst", search_term="no-such-term-anywhere"
+    )
+
+    assert _subjects(result) == []
+
+
+def test_no_search_term_returns_everything(mailbox: Path) -> None:
+    """Narrowness: unfiltered behaviour is untouched."""
+    result = _parse_extracted_emails(mailbox, "/evidence/mail.pst")
+
+    assert _subjects(result) == ["copied", "payload", "plain"]


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- Searching a PST for a **copied recipient** (`Cc`) returned nothing — even though the parser had already extracted that exact address into the result it returned.
- Searching for an **attachment filename** — `invoice.exe`, the way an analyst pivots onto a named payload — likewise matched no message that carried it.
- Root cause: `_parse_extracted_emails` built the recipient list from `recipients_to` alone and never passed `recipients_cc`; `attachments` was collected and never consulted.
- Fix: pass `To` and `Cc` together, and give `_matches_search` the attachment names.
- Scope: `src/mulder/server/tools/email.py` only. No new abstraction, no change to any other tool.

## The bug

```python
        if search_term:
            ...
            to_val = parsed.get("recipients_to")
            to_list = [str(r) for r in to_val] if isinstance(to_val, list) else []
            if not _matches_search(subject, sender, body_str, to_list, search_term):
                continue
```

`parsed` at that point already contains:

```python
        "recipients_cc": _parse_recipients(msg.get("Cc", "")),
        ...
        "attachments": attachments,
```

Both are returned to the caller and both are ignored by the filter. The data was never missing — it simply was not consulted. An examiner searching for the address of someone kept in the loop, or for the name of a payload, got an empty result with no indication that the filter rather than the mailbox was responsible.

## The fix

```python
            recipients: list[str] = []
            for key in ("recipients_to", "recipients_cc"):
                val = parsed.get(key)
                if isinstance(val, list):
                    recipients.extend(str(r) for r in val)
            att_val_s = parsed.get("attachments")
            att_names = [str(a) for a in att_val_s] if isinstance(att_val_s, list) else []
            if not _matches_search(
                subject, sender, body_str, recipients, search_term, att_names
            ):
                continue
```

`attachments` is an optional parameter defaulting to `None`, so `_matches_search` keeps its existing signature for any other caller.

This widens **which parsed fields are consulted**, not what counts as a match — the term still has to appear literally, case-insensitively, in one of them. A test pins that a term matching nothing still matches nothing, so the fix cannot be mistaken for making search indiscriminate.

`Bcc` is deliberately not included: it is not present in a delivered message's headers, so adding it would suggest a capability that does not exist for the common case.

## Deliberately out of scope

`fix/email-parsing` (closed #78) bundled this with five other independent defects in the same file — the lexicographic date comparison, RFC 2047 header decoding, `_parse_recipients` splitting on a comma inside a quoted display name, HTML-only messages having no searchable body, and attachments detected only via `Content-Disposition: attachment`. Each is a separate root cause and is being submitted as its own PR.

In particular, this PR does **not** change which attachments are detected — only that the names already detected become searchable. A message whose payload arrives `inline` is still missed, and that is a separate fix.

Relationship to **open PR #96** (`fix/readpst-exit-code`): that one guards the case where readpst *failed*. This is the success path, where messages were extracted and then filtered too aggressively. Different functions, no overlap; verified conflict-free with `git merge-tree`.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- Full suite → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `email.py` restored to `origin/main` and the new tests kept, **2 of 6 fail**:

```
FAILED test_a_copied_recipient_is_searchable - AssertionError: assert [] == ['copied']
FAILED test_an_attachment_name_is_searchable - AssertionError: assert [] == ['payload']
2 failed, 4 passed
```

The four that pass on both trees are the narrowness tests — `To` still matches, subject still matches, a nonsense term still matches nothing, and an unfiltered call still returns everything — so they pin the fix rather than the bug.

## Context

Recovered from closed PR #78, which bundled six independent defects behind one title. The rejected outcome framework and `classify_tool_exit` are **not** reintroduced — this is a self-contained fix to which fields the filter reads, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

