### PR TITLE
[high] fix(zircolite): index the detections, not just how many there were

### DIFF
--- a/src/mulder/server/tools/zircolite.py
+++ b/src/mulder/server/tools/zircolite.py
@@ -62,6 +62,57 @@ _FORMAT_FLAGS: dict[str, list[str]] = {
 
 _LEVEL_ORDER = ["informational", "low", "medium", "high", "critical"]
 
+# How many detections the tool response carries back. The index is not bounded
+# by this: every detection is indexed, and the list is truncated only for the
+# response, which tool_response reduces to a preview anyway.
+_MAX_RESPONSE_DETECTIONS = 500
+
+# Field order for the indexed lines. Timestamp first, so the per-window
+# timestamp extraction in extract_and_index picks up the detection's own time
+# rather than the first timestamp that happens to appear in the window.
+_DETECTION_FIELDS = (
+    "timestamp",
+    "rule_level",
+    "rule_title",
+    "rule_id",
+    "count",
+    "mitre_attack",
+    "rule_description",
+    "matched_fields",
+)
+
+# matched_fields carries the whole matched event. Long enough to keep the
+# fields an analyst searches for (process image, command line, user), short
+# enough that one detection cannot fill a 4096-character index window.
+_FIELD_CHARS = 2000
+
+
+def _detection_field(value: object) -> str:
+    """Render one detection field as a single-line, bounded string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, bool | int | float):
+        text = str(value)
+    else:
+        text = json.dumps(value, default=str, separators=(",", ":"), sort_keys=True)
+    return text.replace("\t", " ").replace("\r", " ").replace("\n", " ")[:_FIELD_CHARS]
+
+
+def _detection_lines(detections: list[dict[str, Any]]) -> list[str]:
+    """Render detections as one tab-separated line each, for indexing.
+
+    ``extract_and_index`` stores exactly the text it is handed, so handing it a
+    count stored a count. One line per detection matters twice over: the window
+    builder splits on line boundaries, so no detection is cut in half, and
+    timestamp extraction runs per window rather than finding a single timestamp
+    for a whole summary.
+    """
+    return [
+        "\t".join(_detection_field(d.get(name)) for name in _DETECTION_FIELDS) for d in detections
+    ]
+
 
 def _missing_zircolite_modules() -> list[str]:
     """Return Zircolite dependencies not importable from mulder's interpreter."""
@@ -238,7 +289,9 @@ def _parse_zircolite_output(
     return {
         "events_path": events_path,
         "log_format": log_format,
-        "detections": detections[:500],
+        # Not truncated here: run_zircolite indexes every detection before
+        # bounding the list for the response.
+        "detections": detections,
         "total_detections": len(detections),
         "total_events_processed": sum(level_counts.values()),
         "level_counts": level_counts,
@@ -401,9 +454,19 @@ def run_zircolite(
             for tactic, techniques in result["mitre_coverage"].items():
                 text_parts.append(f"  {tactic}: {', '.join(techniques[:5])}")
 
+        # Index the detections themselves, not just how many there were: the
+        # source is called "zircolite.detections", so a search over the case
+        # must be able to find a rule title, a MITRE technique or a matched
+        # field, none of which the header lines above contain.
+        detections: list[dict[str, Any]] = result["detections"]
+        text_parts.extend(_detection_lines(detections))
+
         summary = extract_and_index(
             "\n".join(text_parts), "zircolite.detections", events_path, "zircolite"
         )
+
+        # The index holds every detection; the response stays bounded.
+        result["detections"] = detections[:_MAX_RESPONSE_DETECTIONS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000

--- a/tests/test_zircolite_detection_indexing.py
+++ b/tests/test_zircolite_detection_indexing.py
@@ -1,0 +1,200 @@
+"""Zircolite must index the detections, not just how many there were.
+
+``run_zircolite`` registers its output under the source name
+``zircolite.detections``, but handed ``extract_and_index`` only a header --
+"Total detections: 412", the per-level counts and a MITRE tactic roll-up. Not
+one rule title, rule id, timestamp or matched field ever reached the case
+database, so ``search(query, source="zircolite.detections")`` could not answer
+the questions the tool was run to answer.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.helpers import tool_response as real_tool_response
+from mulder.server.tools.zircolite import run_zircolite
+
+_DETECTION = {
+    "timestamp": "2024-03-11T09:15:22",
+    "rule_title": "Suspicious Base64 Encoded Shell Command",
+    "rule_id": "b7c4f9a1-2e3d-4c5b-8a90-1122334455ff",
+    "rule_level": "critical",
+    "rule_description": "Detects a base64-encoded payload passed to /bin/sh",
+    "rule_mitre": [{"tactic": "execution", "technique": "T1059.004"}],
+    "matched_fields": {
+        "process.executable": "/bin/sh",
+        "process.command_line": "sh -c echo cGF5bG9hZA== | base64 -d | sh",
+        "user.name": "svc_backup",
+    },
+    "count": 3,
+}
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> dict[str, Path]:
+    script = tmp_path / "zircolite.py"
+    script.write_text("")
+    events = tmp_path / "audit.log"
+    events.write_text("type=EXECVE msg=audit(1710148522.000:1): argc=1\n")
+    ruleset = tmp_path / "rules"
+    ruleset.mkdir()
+    return {"script": script, "events": events, "ruleset": ruleset}
+
+
+def _run(evidence: dict[str, Path], raw: list[dict[str, Any]]) -> tuple[Any, str]:
+    """Run the tool over *raw* Zircolite output; return (response, indexed text).
+
+    ``tool_response`` collapses the results to a preview when a source is set,
+    so tests that need the structured results read ``_results`` on the returned
+    response, captured before that collapse.
+    """
+    indexed: list[str] = []
+    captured: list[dict[str, object]] = []
+
+    def _record(text: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(text)
+        return {}
+
+    def _write(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        Path(cmd[cmd.index("--outfile") + 1]).write_text(json.dumps(raw))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    def _capture(*args: Any, **kwargs: Any) -> dict[str, object]:
+        captured.append(args[3])
+        return real_tool_response(*args, **kwargs)
+
+    with (
+        patch("mulder.server.tools.zircolite.sources_already_indexed", return_value=[]),
+        patch(
+            "mulder.server.tools.zircolite.importlib.util.find_spec",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "mulder.server.tools.zircolite._zircolite_script",
+            return_value=evidence["script"],
+        ),
+        patch("mulder.server.tools.zircolite.subprocess.run", side_effect=_write),
+        patch("mulder.server.tools.zircolite.extract_and_index", side_effect=_record),
+        patch("mulder.server.tools.zircolite.tool_response", side_effect=_capture),
+    ):
+        result = run_zircolite.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence["events"]),
+            ruleset_path=str(evidence["ruleset"]),
+            sigma_level_filter=None,
+        )
+    assert indexed, "extract_and_index was never called"
+    assert captured, "tool_response was never called"
+    result["_results"] = captured[0]
+    return result, indexed[0]
+
+
+def test_the_detection_content_reaches_the_index(evidence: dict[str, Path]) -> None:
+    """Every field an analyst would search for must be in the indexed text."""
+    _result, text = _run(evidence, [_DETECTION])
+
+    assert "Suspicious Base64 Encoded Shell Command" in text
+    assert "b7c4f9a1-2e3d-4c5b-8a90-1122334455ff" in text
+    assert "2024-03-11T09:15:22" in text
+    assert "T1059.004" in text
+    # The matched event is what proves the detection; it must be searchable.
+    assert "svc_backup" in text
+    assert "base64 -d" in text
+
+
+def test_the_header_summary_is_still_indexed(evidence: dict[str, Path]) -> None:
+    """Pins the fix's narrowness: the counts are kept, not replaced."""
+    _result, text = _run(evidence, [_DETECTION])
+
+    assert "Total detections: 1" in text
+    assert "critical: 1" in text
+
+
+def test_one_line_per_detection_so_none_is_split_across_windows(
+    evidence: dict[str, Path],
+) -> None:
+    """The window builder splits on line boundaries.
+
+    A detection spread over several lines could be cut in half between two
+    index windows, and the per-window timestamp would come from whichever
+    fragment happened to carry one.
+    """
+    raw = [dict(_DETECTION, rule_id=f"rule-{i}") for i in range(5)]
+
+    _result, text = _run(evidence, raw)
+
+    detection_lines = [line for line in text.splitlines() if "\t" in line]
+    assert len(detection_lines) == 5
+    for i, line in enumerate(detection_lines):
+        assert f"rule-{i}" in line
+        assert line.startswith("2024-03-11T09:15:22"), "timestamp must lead each line"
+
+
+def test_a_newline_inside_a_matched_field_cannot_break_the_line(
+    evidence: dict[str, Path],
+) -> None:
+    """A multi-line command line must not become several index records.
+
+    A nested value is JSON-encoded, which already escapes the newline; a
+    top-level string field is stripped of newlines directly. Both paths must
+    yield exactly one line.
+    """
+    raw = [
+        dict(
+            _DETECTION,
+            matched_fields={"cmd": "line one\nline two"},
+            rule_description="desc one\ndesc two",
+        )
+    ]
+
+    _result, text = _run(evidence, raw)
+
+    detection_lines = [line for line in text.splitlines() if "\t" in line]
+    assert len(detection_lines) == 1
+    assert "desc one desc two" in detection_lines[0]
+    assert "line one" in detection_lines[0]
+    assert "line two" in detection_lines[0]
+
+
+def test_every_detection_is_indexed_even_past_the_response_cap(
+    evidence: dict[str, Path],
+) -> None:
+    """The response is bounded at 500; the index must not be.
+
+    Truncating before indexing would silently drop detection 501 onward from
+    the case database, with nothing to say they existed.
+    """
+    raw = [dict(_DETECTION, rule_id=f"rule-{i}") for i in range(600)]
+
+    result, text = _run(evidence, raw)
+
+    assert "rule-599" in text, "detections past the response cap were not indexed"
+    assert result["status"] == "success"
+
+
+def test_the_response_stays_bounded(evidence: dict[str, Path]) -> None:
+    """Pins the other half: indexing everything must not unbound the response."""
+    raw = [dict(_DETECTION, rule_id=f"rule-{i}") for i in range(600)]
+
+    result, _text = _run(evidence, raw)
+
+    results = result["_results"]
+    assert results["total_detections"] == 600
+    assert len(results["detections"]) == 500
+
+
+def test_a_quiet_log_indexes_a_header_and_no_detection_lines(
+    evidence: dict[str, Path],
+) -> None:
+    """No detections is still a real answer, and must index as one."""
+    result, text = _run(evidence, [])
+
+    assert "Total detections: 0" in text
+    assert [line for line in text.splitlines() if "\t" in line] == []
+    assert result["status"] == "success"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_zircolite` registers its output under the source name **`zircolite.detections`** — but never indexed a detection.
- It handed `extract_and_index` only a header: the total, the per-level counts and a MITRE tactic roll-up. `extract_and_index` stores exactly the text it is given, so no rule title, rule id, timestamp or matched field ever reached the case database. `search(query, source="zircolite.detections")` could not find a single detection.
- Second defect in the same path: the parser truncated to 500 **before** indexing, so detection 501 onward was dropped from the case with nothing to record that it had existed.
- Fix: render each detection as one tab-separated line and index those alongside the existing header; bound the list for the *response* only.
- Scope: `src/mulder/server/tools/zircolite.py` only. The closed branch's shared `format_records` helper is **not** added.

## The bug

```python
        text_parts = [
            f"Zircolite {log_format} analysis of {events_path}",
            f"Total detections: {result['total_detections']}",
            f"Events processed: {result['total_events_processed']}",
        ]
        for level, count in result.get("level_counts", {}).items():
            text_parts.append(f"  {level}: {count}")
        ...
        summary = extract_and_index(
            "\n".join(text_parts), "zircolite.detections", events_path, "zircolite"
        )
```

`result["detections"]` — the parsed rule titles, ids, timestamps, MITRE techniques and matched events — is never referenced. It rides back in the response, which `tool_response` reduces to a preview, and is then gone.

And in `_parse_zircolite_output`:

```python
        "detections": detections[:500],
```

The cap was applied at the parser, upstream of indexing.

## The fix

```python
        detections: list[dict[str, Any]] = result["detections"]
        text_parts.extend(_detection_lines(detections))

        summary = extract_and_index(
            "\n".join(text_parts), "zircolite.detections", events_path, "zircolite"
        )

        # The index holds every detection; the response stays bounded.
        result["detections"] = detections[:_MAX_RESPONSE_DETECTIONS]
```

with a module-local renderer:

```python
def _detection_lines(detections: list[dict[str, Any]]) -> list[str]:
    return [
        "\t".join(_detection_field(d.get(name)) for name in _DETECTION_FIELDS) for d in detections
    ]
```

**One line per detection matters twice over.** `extract_and_index` builds windows on line boundaries, so a detection can never be cut in half between two windows; and its timestamp extraction runs per window, so each window carries the detection's own time rather than the first timestamp that happens to appear in a summary. `timestamp` is therefore the leading field.

Nested values (`matched_fields`, `mitre_attack`) are JSON-encoded so the matched event stays searchable, embedded newlines and tabs are flattened, and every field is bounded at 2000 characters so one pathological command line cannot fill a 4096-character window.

## Deliberately out of scope

- **The shared `format_records` helper.** The closed branch added one to `extract_helpers.py` and rewired chainsaw, hayabusa, mvt, phone and carving through it. That is a cross-cutting refactor across nine modules; it is left out entirely and the formatting here is local to zircolite. Other tools with the same defect should get their own narrow PRs.
- **Failure reporting** (open PR #91) and **the invalid `--json` flag** (PR #104) are separate concerns in separate PRs. This PR touches neither's lines.
- The rejected outcome framework and `classify_tool_exit` are **not** reintroduced.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check** — with `zircolite.py` restored to `origin/main` and the new tests kept, **4 of 7 fail**:

```
FAILED test_the_detection_content_reaches_the_index - AssertionError: assert 'Suspicious Base64 Encoded Shell Command' in 'Zircol...
FAILED test_one_line_per_detection_so_none_is_split_across_windows - assert 0 == 5
FAILED test_a_newline_inside_a_matched_field_cannot_break_the_line - assert 0 == 1
FAILED test_every_detection_is_indexed_even_past_the_response_cap - AssertionError: detections past the response cap were not indexed
4 failed, 3 passed
```

The three that pass on both trees are the narrowness tests: the header counts are still indexed, the response is still capped at 500, and a log with no detections still indexes a header and no detection lines.

## Context

Recovered from closed PR #74, which made this change across nine modules at once behind a new shared helper. Only the zircolite fix is here, with the helper inlined locally, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
