### PR TITLE
[high] fix(chainsaw): pass the --mapping that hunt mode's --sigma requires

### DIFF
--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -57,6 +57,17 @@ def _default_sigma_rules() -> Path:
     return asset_display_path("sigma-rules", "rules", "windows")
 
 
+def _default_chainsaw_mapping() -> Path:
+    """The Sigma-to-EVTX mapping Chainsaw requires alongside ``--sigma``.
+
+    Chainsaw cannot apply third-party Sigma rules without a mapping that tells
+    it which event fields those rules refer to, so ``--sigma`` *requires*
+    ``--mapping``.  The mapping ships in the Chainsaw release tarball and is
+    also pulled by the asset supplement, so ``mulder setup`` always provides it.
+    """
+    return asset_display_path("chainsaw", "mappings", "sigma-event-logs-all.yml")
+
+
 def _resolve_evtx_evidence(evidence_path: str) -> str:
     """Resolve a disk image path to its EVTX extraction directory.
 
@@ -108,6 +119,7 @@ def _run_chainsaw_hunt(
     binary: str,
     evidence_path: Path,
     sigma_rules_path: Path,
+    mapping_path: Path,
     output_dir: Path,
     time_start: str | None = None,
     time_end: str | None = None,
@@ -119,6 +131,7 @@ def _run_chainsaw_hunt(
         binary: Resolved Chainsaw executable.
         evidence_path: Directory containing .evtx files.
         sigma_rules_path: Path to Sigma rules directory.
+        mapping_path: Chainsaw mapping file; required alongside --sigma.
         output_dir: Output directory for results.
         time_start: Optional time range start (ISO 8601).
         time_end: Optional time range end (ISO 8601).
@@ -137,6 +150,8 @@ def _run_chainsaw_hunt(
         str(evidence_path),
         "-s",
         str(sigma_rules_path),
+        "--mapping",
+        str(mapping_path),
         "--json",
         "--output",
         str(output_file),
@@ -419,6 +434,7 @@ def run_chainsaw(
     evidence_path: str,
     mode: Literal["hunt", "search", "srum", "timeline"] = "hunt",
     sigma_rules_path: str = "",
+    mapping_path: str = "",
     search_term: str | None = None,
     time_range_start: str | None = None,
     time_range_end: str | None = None,
@@ -440,6 +456,10 @@ def run_chainsaw(
             "timeline" dumps all events chronologically.
         sigma_rules_path: Path to the Sigma rules directory. Empty
             resolves to the rules installed by 'mulder setup'.
+        mapping_path: Path to the Chainsaw mapping file that tells it how
+            to read third-party Sigma rules. Chainsaw requires this
+            whenever Sigma rules are supplied. Empty resolves to the
+            mapping installed by 'mulder setup'.
         search_term: Required when mode="search". The keyword or
             regex pattern to search for in EVTX records.
         time_range_start: Optional ISO 8601 timestamp to filter results
@@ -454,6 +474,7 @@ def run_chainsaw(
         "evidence_path": evidence_path,
         "mode": mode,
         "sigma_rules_path": sigma_rules_path,
+        "mapping_path": mapping_path,
         "search_term": search_term,
         "time_range_start": time_range_start,
         "time_range_end": time_range_end,
@@ -513,6 +534,21 @@ def run_chainsaw(
 
     rules = Path(sigma_rules_path) if sigma_rules_path else _default_sigma_rules()
 
+    mapping = Path(mapping_path) if mapping_path else _default_chainsaw_mapping()
+
+    if mode == "hunt" and not mapping.exists():
+        return error_response(
+            tc_id,
+            "run_chainsaw",
+            params,
+            f"Chainsaw Sigma mapping not found: {mapping}",
+            error_type="file_not_found",
+            suggestion=(
+                "Run 'mulder setup' (provisions Chainsaw 2.16.0 and its "
+                "mappings/ directory), or pass mapping_path explicitly."
+            ),
+        )
+
     timeout = adaptive_timeout(evidence_path, base=_CHAINSAW_TIMEOUT)
     with tempfile.TemporaryDirectory(prefix="mulder_chainsaw_") as tmpdir:
         output_dir = Path(tmpdir)
@@ -522,6 +558,7 @@ def run_chainsaw(
                     binary,
                     Path(evidence_path),
                     rules,
+                    mapping,
                     output_dir,
                     time_range_start,
                     time_range_end,

--- a/tests/test_binary_resolution.py
+++ b/tests/test_binary_resolution.py
@@ -34,6 +34,20 @@ def _completed(**kwargs: Any) -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
+def _chainsaw_mapping(asset_root: Path) -> Path:
+    """Provision the mapping the chainsaw asset ships.
+
+    Chainsaw requires ``--mapping`` alongside ``--sigma``, so hunt mode
+    pre-flights it.  These tests are about binary resolution, so the mapping is
+    incidental setup here -- but it has to exist for the run to reach
+    ``subprocess.run`` at all.
+    """
+    mapping = asset_root / "chainsaw" / "mappings" / "sigma-event-logs-all.yml"
+    mapping.parent.mkdir(parents=True, exist_ok=True)
+    mapping.write_text("---\n")
+    return mapping
+
+
 class TestChainsaw:
     def test_execs_the_binary_the_gate_found(self, tmp_path: Path) -> None:
         from mulder.server.tools.chainsaw import run_chainsaw
@@ -41,6 +55,8 @@ class TestChainsaw:
         chainsaw = _fake_binary(tmp_path, "chainsaw")
         evidence = tmp_path / "evtx"
         evidence.mkdir()
+        mapping = tmp_path / "sigma-event-logs-all.yml"
+        mapping.write_text("---\n")
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
@@ -50,7 +66,9 @@ class TestChainsaw:
                 "mulder.server.tools.chainsaw.subprocess.run", return_value=_completed()
             ) as mock_run,
         ):
-            result = run_chainsaw.__wrapped__(str(evidence))  # type: ignore[attr-defined]
+            result = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+                str(evidence), mapping_path=str(mapping)
+            )
 
         assert result.get("error_type") != "binary_missing"
         assert mock_run.call_args[0][0][0] == str(chainsaw)
@@ -76,6 +94,7 @@ class TestChainsaw:
         binary = installed / "chainsaw"
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
+        _chainsaw_mapping(asset_root)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
@@ -104,6 +123,7 @@ class TestChainsaw:
         chainsaw.mkdir()
         (chainsaw / "chainsaw").write_text("")
         (chainsaw / "chainsaw").chmod(0o755)
+        _chainsaw_mapping(asset_root)
 
         with (
             patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),

--- a/tests/test_chainsaw_hunt_mapping.py
+++ b/tests/test_chainsaw_hunt_mapping.py
@@ -1,0 +1,201 @@
+"""Chainsaw hunt mode must pass the ``--mapping`` that ``--sigma`` requires.
+
+``_run_chainsaw_hunt`` built ``chainsaw hunt <evidence> -s <sigma> --json
+--output <file>``.  Chainsaw declares ``--mapping`` as a hard requirement of
+``--sigma``, so clap rejects that command line before Chainsaw opens a single
+log.  Verified against the pinned release, chainsaw 2.16.0::
+
+    $ chainsaw hunt ./evidence -s ./sigma --json --output out.json
+    error: the following required arguments were not provided:
+      --mapping <MAPPING>
+    Usage: chainsaw hunt --mapping <MAPPING> --sigma <SIGMA> --json \
+        --output <OUTPUT> <RULES> [PATH]...
+    (exit 2)
+
+The requirement is not visible in ``chainsaw hunt --help``, which lists
+``--mapping`` as an ordinary option -- it is enforced only at parse time.  Hunt
+mode is Chainsaw's Sigma engine, so on current ``main`` it can never execute.
+
+These tests deliberately do not import the new resolver, so that against
+unmodified ``main`` they fail on the missing flag rather than on an ImportError.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+import mulder.server.tools.chainsaw as chainsaw_mod
+from mulder.server.tools.chainsaw import run_chainsaw
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> Path:
+    """An evidence directory holding one EVTX file, so the run reaches Chainsaw."""
+    evtx = tmp_path / "Security.evtx"
+    evtx.write_bytes(b"ElfFile\x00")
+    return tmp_path
+
+
+@pytest.fixture
+def rules(tmp_path: Path) -> Path:
+    path = tmp_path / "sigma"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def mapping(tmp_path: Path) -> Path:
+    """Stands in for the mapping ``mulder setup`` provisions."""
+    path = tmp_path / "mappings" / "sigma-event-logs-all.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("---\n")
+    return path
+
+
+def _run_mode(evidence: Path, mode: str, rules: Path, mapping: Path) -> list[list[str]]:
+    """Run *mode* with Chainsaw mocked; return every argv it built.
+
+    ``asset_display_path`` is patched rather than the new resolver, so this
+    helper works identically against fixed and unfixed code.
+    """
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    def _assets(*parts: str) -> Path:
+        if "mappings" in parts:
+            return mapping
+        return rules
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.asset_display_path", side_effect=_assets),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence),
+            mode=mode,
+            sigma_rules_path=str(rules),
+        )
+
+    assert calls, "Chainsaw was never invoked"
+    return calls
+
+
+def test_hunt_passes_the_mapping_that_sigma_requires(
+    evidence: Path, rules: Path, mapping: Path
+) -> None:
+    """The exact argv defect: ``--sigma`` present, ``--mapping`` absent.
+
+    Against unmodified ``main`` this argv makes chainsaw 2.16.0 exit 2.
+    """
+    argv = _run_mode(evidence, "hunt", rules, mapping)[0]
+
+    assert "--mapping" in argv, f"chainsaw 2.16.0 exits 2 on this argv: {argv}"
+    assert argv[argv.index("--mapping") + 1] == str(mapping)
+
+
+def test_the_mapping_accompanies_the_sigma_flag(
+    evidence: Path, rules: Path, mapping: Path
+) -> None:
+    """Pins the coupling, not merely the presence of a flag.
+
+    ``--mapping`` is required *because* ``-s/--sigma`` is passed, so a later
+    edit that keeps one and drops the other reintroduces the bug.
+    """
+    argv = _run_mode(evidence, "hunt", rules, mapping)[0]
+
+    assert "-s" in argv
+    assert argv[argv.index("-s") + 1] == str(rules)
+    assert "--mapping" in argv
+
+
+def test_the_default_mapping_is_one_the_chainsaw_asset_provides(
+    evidence: Path, rules: Path, mapping: Path
+) -> None:
+    """The mapping must be looked up inside the chainsaw asset's mappings/.
+
+    ``mappings/sigma-event-logs-all.yml`` ships in the 2.16.0 release tarball
+    and is also listed in the asset's ``supplement_paths``.
+    """
+    seen: list[tuple[str, ...]] = []
+
+    def _assets(*parts: str) -> Path:
+        seen.append(parts)
+        return mapping if "mappings" in parts else rules
+
+    def _record(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.asset_display_path", side_effect=_assets),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence), mode="hunt", sigma_rules_path=str(rules)
+        )
+
+    assert ("chainsaw", "mappings", "sigma-event-logs-all.yml") in seen, (
+        f"the mapping was not resolved from the chainsaw asset; lookups were {seen}"
+    )
+
+
+def test_a_missing_mapping_is_reported_not_left_to_clap(
+    evidence: Path, rules: Path, tmp_path: Path
+) -> None:
+    """Without the asset, the analyst gets a real message and a fix.
+
+    Otherwise Chainsaw exits 2 with a clap error the wrapper never reads.
+    """
+    absent = tmp_path / "does-not-exist" / "sigma-event-logs-all.yml"
+
+    def _assets(*parts: str) -> Path:
+        return absent if "mappings" in parts else rules
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.asset_display_path", side_effect=_assets),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        result: Any = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence), mode="hunt", sigma_rules_path=str(rules)
+        )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "file_not_found"
+    assert "mapping" in str(result["error_message"]).lower()
+    assert "mulder setup" in str(result["suggestion"])
+
+
+def test_timeline_mode_does_not_get_a_mapping(evidence: Path, rules: Path, mapping: Path) -> None:
+    """Narrowness: only hunt passes ``--sigma``, so only hunt needs a mapping.
+
+    ``timeline`` loads no Sigma rules; adding ``--mapping`` there would be a new
+    argv defect rather than a fix.
+    """
+    argv = _run_mode(evidence, "timeline", rules, mapping)[0]
+
+    assert "--mapping" not in argv
+    assert "-s" not in argv
+
+
+def test_the_resolver_exists_and_names_the_shipped_mapping() -> None:
+    """The helper itself, once present, must name the file the asset ships."""
+    resolver = getattr(chainsaw_mod, "_default_chainsaw_mapping", None)
+    assert resolver is not None, "_default_chainsaw_mapping is missing"
+    path = resolver()
+    assert path.name == "sigma-event-logs-all.yml"
+    assert path.parent.name == "mappings"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- **Chainsaw hunt mode can never execute on current `main`.** It is Chainsaw's Sigma detection engine — the whole reason the tool is wrapped — and every invocation is rejected by argument parsing before a single log is opened.
- Root cause: `_run_chainsaw_hunt` passes `-s <sigma rules>` but never `--mapping`. Chainsaw declares `--mapping` a **hard requirement** of `--sigma`.
- The requirement is **invisible in `chainsaw hunt --help`**, which lists `--mapping` as an ordinary option — it is enforced only at parse time. That is why the defect survived review.
- Fix: resolve the mapping the chainsaw asset **already ships** and pass it with `--sigma`; report a missing mapping as `file_not_found` instead of letting it surface as an opaque exit 2; add a `mapping_path` override mirroring the existing `sigma_rules_path`.
- Scope: `src/mulder/server/tools/chainsaw.py`, hunt mode only. No shared helper, no new abstraction, no change to search/srum/timeline.

## The bug

```python
    output_file = output_dir / "chainsaw_hunt.json"
    cmd = [
        binary,
        "hunt",
        str(evidence_path),
        "-s",
        str(sigma_rules_path),
        "--json",
        "--output",
        str(output_file),
    ]
```

**Verified empirically against the pinned release** — I downloaded `chainsaw_x86_64-unknown-linux-gnu.tar.gz` for v2.16.0 (the version in `manifest.py`) and ran mulder's exact argv:

```console
$ ./chainsaw --version
chainsaw 2.16.0

$ ./chainsaw hunt ./evidence -s ./sigma --json --output out.json
error: the following required arguments were not provided:
  --mapping <MAPPING>

Usage: chainsaw hunt --mapping <MAPPING> --sigma <SIGMA> --json --output <OUTPUT> <RULES> [PATH]...
(exit 2)
```

Adding the mapping is also **sufficient** — the same command line then runs, and Chainsaw resolves mulder's positional layout correctly:

```console
$ ./chainsaw hunt ./evidence -s ./sigma -m mappings/sigma-event-logs-all.yml --json --output out.json
[+] Loading detection rules from: ./sigma
[+] Loaded 1 detection rules
[+] Loading forensic artefacts from: ./evidence (extensions: .evt, .evtx)
```

(It then exits 1 only because my throwaway evidence directory was empty.)

## The fix

```python
def _default_chainsaw_mapping() -> Path:
    """The Sigma-to-EVTX mapping Chainsaw requires alongside ``--sigma``."""
    return asset_display_path("chainsaw", "mappings", "sigma-event-logs-all.yml")
```

```python
        "-s",
        str(sigma_rules_path),
        "--mapping",
        str(mapping_path),
```

plus a pre-flight so a missing asset is legible:

```python
    mapping = Path(mapping_path) if mapping_path else _default_chainsaw_mapping()

    if mode == "hunt" and not mapping.exists():
        return error_response(
            tc_id, "run_chainsaw", params,
            f"Chainsaw Sigma mapping not found: {mapping}",
            error_type="file_not_found",
            suggestion=(
                "Run 'mulder setup' (provisions Chainsaw 2.16.0 and its "
                "mappings/ directory), or pass mapping_path explicitly."
            ),
        )
```

**No new asset is required.** `mappings/sigma-event-logs-all.yml` ships inside the release tarball (`strip_components=1` lands it in the asset dir) and is also listed in the asset's `supplement_paths=("mappings", "rules")`.

The `mapping_path` parameter mirrors the existing `sigma_rules_path` and exists for a concrete reason: `_chainsaw_binary()` deliberately lets a PATH install win ("so a SIFT/apt/cargo install keeps being used"), and such an install keeps its mappings elsewhere. Without an override, the pre-flight would hard-block exactly the users that docstring protects.

## Deliberately out of scope

- **`sigma-event-logs-legacy.yml`.** Chainsaw ships two mappings; `-all` is the general one. Selecting per-log-format is a separate concern — the new `mapping_path` parameter is the escape hatch in the meantime.
- **Surfacing the failure.** Open PR #95 (`fix/chainsaw-exit-code`) makes a failed Chainsaw run report an error instead of a clean scan. The two are **complementary and independent**: #95 makes this failure *visible*, this PR removes its *cause*. Neither depends on the other, and both branch off `main`.
- **The srum invocation** has its own separate CLI defects; those are a different PR against a different subcommand.
- I noticed while testing that `chainsaw analyse srum` exits **0** even when it fails to parse the database, so a returncode guard alone will not catch that case. Noting it; not addressed here.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **862 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `chainsaw.py` restored to `origin/main` and the new tests kept, **5 of 6 fail**:

```
FAILED test_hunt_passes_the_mapping_that_sigma_requires - AssertionError: chainsaw 2.16.0 exits 2 on this argv: ['/usr/bin/chainsaw', ...]
FAILED test_the_mapping_accompanies_the_sigma_flag - AssertionError: assert '--mapping' in ['/usr/bin/chainsaw', 'hunt', '/tmp/p...
FAILED test_the_default_mapping_is_one_the_chainsaw_asset_provides - AssertionError: the mapping was not resolved from the chainsaw asset; looku...
FAILED test_a_missing_mapping_is_reported_not_left_to_clap - AssertionError: assert 'os_error' == 'file_not_found'
FAILED test_the_resolver_exists_and_names_the_shipped_mapping - AssertionError: _default_chainsaw_mapping is missing
5 failed, 1 passed
```

  The tests assert on the **parsed argv**, not on a mock call count, and they deliberately avoid importing the new resolver at module scope so the failure is the missing flag rather than an `ImportError`. `test_timeline_mode_does_not_get_a_mapping` passes against both trees — it pins the fix's narrowness rather than the bug.

- Three tests in `tests/test_binary_resolution.py` now provision the mapping. They assert on **binary resolution** and none of them asserts anything about mappings; the mapping is incidental setup needed to reach `subprocess.run` at all. Nothing they check was weakened.

## Context

Recovered from closed PR #69, which changed the CLI contract of every wrapped tool at once. This is one tool, one subcommand, one flag. The rejected outcome framework is **not** reintroduced and there is no `classify_tool_exit` or second status taxonomy here, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
