### PR TITLE
[high] fix(email): detect an attachment by its filename, not its disposition

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -149,11 +149,19 @@ def _parse_email_message(
     has_suspicious = False
 
     for part in msg.walk():
-        if part.get_content_disposition() == "attachment":
-            filename = part.get_filename() or "unnamed"
-            attachments.append(filename)
-            ext = Path(filename).suffix.lower()
-            if ext in _SUSPICIOUS_EXTENSIONS:
+        if part.is_multipart():
+            continue
+        filename = part.get_filename()
+        disposition = part.get_content_disposition()
+        # An attachment is anything carrying a filename, not only what
+        # declares `Content-Disposition: attachment`. Malicious payloads
+        # arrive as `inline`, or with no disposition header at all, and both
+        # were previously invisible -- including to the suspicious-extension
+        # check, which is the point of this function.
+        if disposition == "attachment" or filename:
+            name = filename or "unnamed"
+            attachments.append(name)
+            if Path(name).suffix.lower() in _SUSPICIOUS_EXTENSIONS:
                 has_suspicious = True
 
     return {

--- a/tests/test_pst_inline_attachments.py
+++ b/tests/test_pst_inline_attachments.py
@@ -1,0 +1,141 @@
+"""An attachment is anything carrying a filename, not only a declared one.
+
+``_parse_email_message`` collected a part only when it declared
+``Content-Disposition: attachment``. A payload delivered as ``inline``, or
+with no disposition header at all, was therefore invisible -- it appeared in
+neither ``attachments`` nor, more seriously, the ``has_suspicious_attachment``
+check, which is the security purpose of that function.
+
+Both shapes are ordinary: ``inline`` is what mail clients emit for anything
+they might render, and a bare ``Content-Type`` with a ``name`` parameter is
+what several older senders produce.
+"""
+
+from __future__ import annotations
+
+import email as email_lib
+
+from mulder.server.tools.email import _parse_email_message
+
+
+def _message(disposition_header: str) -> email_lib.message.Message:
+    """A two-part message whose second part carries an .exe filename."""
+    raw = (
+        "From: attacker@example.com\n"
+        "To: victim@example.com\n"
+        "Subject: Invoice\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        'Content-Type: multipart/mixed; boundary="B"\n'
+        "\n"
+        "--B\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "see attached\n"
+        "--B\n"
+        'Content-Type: application/octet-stream; name="invoice.exe"\n'
+        f"{disposition_header}"
+        "\n"
+        "payload\n"
+        "--B--\n"
+    )
+    return email_lib.message_from_string(raw)
+
+
+def test_an_inline_payload_is_detected() -> None:
+    """`inline` is the disposition a client uses for anything it may render."""
+    parsed = _parse_email_message(_message("Content-Disposition: inline\n"), "Inbox")
+
+    assert parsed["attachments"] == ["invoice.exe"]
+
+
+def test_an_inline_payload_trips_the_suspicious_check() -> None:
+    """The security consequence: the .exe check never saw the .exe."""
+    parsed = _parse_email_message(_message("Content-Disposition: inline\n"), "Inbox")
+
+    assert parsed["has_suspicious_attachment"] is True
+
+
+def test_a_payload_with_no_disposition_header_is_detected() -> None:
+    """A bare Content-Type with a name= parameter is still an attachment."""
+    parsed = _parse_email_message(_message(""), "Inbox")
+
+    assert parsed["attachments"] == ["invoice.exe"]
+    assert parsed["has_suspicious_attachment"] is True
+
+
+def test_a_declared_attachment_still_works() -> None:
+    """Narrowness: the case that already worked is unchanged."""
+    parsed = _parse_email_message(
+        _message('Content-Disposition: attachment; filename="invoice.exe"\n'), "Inbox"
+    )
+
+    assert parsed["attachments"] == ["invoice.exe"]
+    assert parsed["has_suspicious_attachment"] is True
+
+
+def test_a_plain_message_has_no_attachments() -> None:
+    """Narrowness: a body-only message must not gain a phantom attachment."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Plain\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "hello\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+
+    assert parsed["attachments"] == []
+    assert parsed["has_suspicious_attachment"] is False
+
+
+def test_an_alternative_body_part_is_not_an_attachment() -> None:
+    """Narrowness: multipart/alternative parts carry no filename, so neither
+    the HTML nor the plain body may be counted as an attachment."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Both\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        'Content-Type: multipart/alternative; boundary="B"\n'
+        "\n"
+        "--B\n"
+        "Content-Type: text/plain; charset=utf-8\n"
+        "\n"
+        "plain\n"
+        "--B\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n"
+        "<p>html</p>\n"
+        "--B--\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+
+    assert parsed["attachments"] == []
+
+
+def test_a_benign_inline_image_is_listed_but_not_suspicious() -> None:
+    """An inline image is a real attachment; it is not a suspicious one."""
+    raw = (
+        "From: a@example.com\n"
+        "To: b@example.com\n"
+        "Subject: Signature\n"
+        "Date: Mon, 11 Mar 2024 09:14:02 +0100\n"
+        'Content-Type: multipart/related; boundary="B"\n'
+        "\n"
+        "--B\n"
+        "Content-Type: text/html; charset=utf-8\n"
+        "\n"
+        "<p>hi</p>\n"
+        "--B\n"
+        'Content-Type: image/png; name="logo.png"\n'
+        "Content-Disposition: inline\n"
+        "\n"
+        "binary\n"
+        "--B--\n"
+    )
+    parsed = _parse_email_message(email_lib.message_from_string(raw), "Inbox")
+
+    assert parsed["attachments"] == ["logo.png"]
+    assert parsed["has_suspicious_attachment"] is False


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- An emailed `.exe` delivered as `Content-Disposition: inline` — or with no disposition header at all — was reported as a message **with no attachments**, and `has_suspicious_attachment` stayed `False`.
- That check is the security purpose of `_parse_email_message`. It was blind to exactly the delivery shapes an attacker can choose freely.
- Root cause: a part was collected only when it declared `Content-Disposition: attachment`.
- Fix: treat any **leaf part carrying a filename** as an attachment, in addition to any part that declares the attachment disposition.
- Scope: `src/mulder/server/tools/email.py` only. No new abstraction, no change to any other tool.

## The bug

```python
    for part in msg.walk():
        if part.get_content_disposition() == "attachment":
            filename = part.get_filename() or "unnamed"
            attachments.append(filename)
            ext = Path(filename).suffix.lower()
            if ext in _SUSPICIOUS_EXTENSIONS:
                has_suspicious = True
```

`Content-Disposition` is a **hint from the sender**, not a property of the data. A part like

```
Content-Type: application/octet-stream; name="invoice.exe"
Content-Disposition: inline
```

carries an executable and is skipped entirely. So is a part with no disposition header at all, which several older senders emit. In both cases `attachments` comes back `[]` and `has_suspicious_attachment` comes back `False` — the message is reported as clean.

`inline` is not an exotic choice: it is what mail clients emit for anything they might render, so it does not even look anomalous in transit.

## The fix

```python
    for part in msg.walk():
        if part.is_multipart():
            continue
        filename = part.get_filename()
        disposition = part.get_content_disposition()
        # An attachment is anything carrying a filename, not only what
        # declares `Content-Disposition: attachment`. Malicious payloads
        # arrive as `inline`, or with no disposition header at all, and both
        # were previously invisible -- including to the suspicious-extension
        # check, which is the point of this function.
        if disposition == "attachment" or filename:
            name = filename or "unnamed"
            attachments.append(name)
            if Path(name).suffix.lower() in _SUSPICIOUS_EXTENSIONS:
                has_suspicious = True
```

The `is_multipart()` skip matters: without it a `multipart/alternative` container could be counted. Body parts carry no filename, so a plain or HTML body is never mistaken for an attachment — pinned by a test.

Widening detection does **not** widen suspicion: an inline `logo.png` is now correctly listed as an attachment and correctly left non-suspicious. That is also pinned by a test, so the fix cannot be mistaken for making every message look dangerous.

## Deliberately out of scope

`fix/email-parsing` (closed #78) bundled this with five other independent defects in the same file — the lexicographic date comparison, RFC 2047 header decoding, `_parse_recipients` splitting on a comma inside a quoted display name, HTML-only messages having no searchable body, and `Cc` never being searched. Each is a separate root cause and is being submitted as its own PR.

Attachment **filenames** are left undecoded here: a name sent as `=?utf-8?B?…?=` will still be listed encoded. That is the RFC 2047 concern and belongs with the header-decoding fix, not this one.

Relationship to **open PR #96** (`fix/readpst-exit-code`): that one guards the case where readpst *failed*. This is the success path. Different functions, no overlap; verified conflict-free with `git merge-tree`.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- Full suite → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `email.py` restored to `origin/main` and the new tests kept, **4 of 7 fail**:

```
FAILED test_an_inline_payload_is_detected                 - AssertionError: assert [] == ['invoice.exe']
FAILED test_an_inline_payload_trips_the_suspicious_check  - assert False is True
FAILED test_a_payload_with_no_disposition_header_is_detected - AssertionError: assert [] == ['invoice.exe']
FAILED test_a_benign_inline_image_is_listed_but_not_suspicious - AssertionError: assert [] == ['logo.png']
4 failed, 3 passed
```

The second line is the security consequence in one assertion: a real `.exe` in the message, and the suspicious-attachment flag reporting `False`.

The three that pass on both trees are the narrowness tests — a declared attachment still works, a body-only message gains no phantom attachment, and `multipart/alternative` body parts are not counted — so they pin the fix rather than the bug.

## Context

Recovered from closed PR #78, which bundled six independent defects behind one title. The rejected outcome framework and `classify_tool_exit` are **not** reintroduced — this is a self-contained fix to attachment detection, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

