### PR TITLE
[medium] fix(email): parse recipients with RFC 5322 quoting, not a comma split

### DIFF
--- a/src/mulder/server/tools/email.py
+++ b/src/mulder/server/tools/email.py
@@ -8,6 +8,7 @@ import logging
 import subprocess
 import tempfile
 import time
+from email.utils import getaddresses
 from pathlib import Path
 
 from mulder.server.app import mcp
@@ -61,17 +62,34 @@ _VALID_PST_SUFFIXES: set[str] = {".pst", ".ost"}
 
 
 def _parse_recipients(raw: str) -> list[str]:
-    """Parse a comma-separated recipient string into individual addresses.
+    """Parse a To/Cc header into individual addresses.
+
+    Splitting on "," is wrong, because a display name may legitimately
+    contain one. ``"Doe, John" <john@example.com>, jane@example.com`` split
+    that way yields ``'"Doe'``, ``'John" <john@example.com>'`` and
+    ``'jane@example.com'`` -- the first is not an address at all and the
+    second is mangled, so recipient search and address extraction both miss
+    them. RFC 5322 quoting is what ``email.utils.getaddresses`` exists for.
 
     Args:
-        raw: Raw To/CC header value.
+        raw: Raw To/Cc header value.
 
     Returns:
-        List of individual email addresses or display names.
+        One entry per recipient: ``Display Name <addr>`` when a name is
+        present, the bare address otherwise.
     """
     if not raw:
         return []
-    return [r.strip() for r in raw.split(",") if r.strip()]
+    out: list[str] = []
+    for name, addr in getaddresses([raw]):
+        display = name.strip()
+        if addr and display:
+            out.append(f"{display} <{addr}>")
+        elif addr:
+            out.append(addr)
+        elif display:
+            out.append(display)
+    return out
 
 
 def _get_body(

--- a/tests/test_pst_recipient_parsing.py
+++ b/tests/test_pst_recipient_parsing.py
@@ -1,0 +1,56 @@
+"""Recipient parsing must respect RFC 5322 quoting, not split on every comma.
+
+``_parse_recipients`` did ``raw.split(",")``. A display name may legitimately
+contain a comma -- ``"Doe, John" <john@example.com>`` is the form Outlook
+emits for a Last, First contact -- so the header
+
+    "Doe, John" <john@example.com>, jane@example.com
+
+was split into three entries, two of which are not addresses at all. The
+recipient list shown to the examiner was wrong, and a search for
+``john@example.com`` had to match a mangled fragment to succeed.
+"""
+
+from __future__ import annotations
+
+from mulder.server.tools.email import _parse_recipients
+
+
+def test_a_quoted_comma_does_not_split_a_recipient() -> None:
+    """The Last, First display name Outlook emits."""
+    parsed = _parse_recipients('"Doe, John" <john@example.com>, jane@example.com')
+
+    assert parsed == ["Doe, John <john@example.com>", "jane@example.com"]
+
+
+def test_every_address_survives_a_quoted_comma() -> None:
+    """The count itself was wrong: two recipients became three entries."""
+    parsed = _parse_recipients('"Doe, John" <john@example.com>, jane@example.com')
+
+    assert len(parsed) == 2
+
+
+def test_a_bare_address_is_unchanged() -> None:
+    """Narrowness: the common case must be untouched."""
+    assert _parse_recipients("a@example.com, b@example.com") == [
+        "a@example.com",
+        "b@example.com",
+    ]
+
+
+def test_an_unquoted_display_name_is_kept() -> None:
+    """Narrowness: names without commas still render as Name <addr>."""
+    assert _parse_recipients("Jane Roe <jane@example.com>") == ["Jane Roe <jane@example.com>"]
+
+
+def test_an_empty_header_is_an_empty_list() -> None:
+    """Narrowness: absent To/Cc must not produce a phantom recipient."""
+    assert _parse_recipients("") == []
+
+
+def test_surrounding_whitespace_is_stripped() -> None:
+    """Narrowness: the old implementation stripped, and so must this one."""
+    assert _parse_recipients("  a@example.com ,  b@example.com  ") == [
+        "a@example.com",
+        "b@example.com",
+    ]


### PR DESCRIPTION
## BLUF

- **Priority: medium.**
- A recipient whose display name contains a comma — `"Doe, John" <john@example.com>`, the form Outlook emits for a *Last, First* contact — was split into **two entries, neither of them a valid address**.
- The reported recipient count was wrong as a result: two recipients became three entries.
- Root cause: `_parse_recipients` did `raw.split(",")`, which ignores RFC 5322 quoting.
- Fix: use `email.utils.getaddresses`, the standard-library address-list parser.
- Scope: `src/mulder/server/tools/email.py`, one function. No new abstraction, no change to any other tool.

## The bug

```python
    if not raw:
        return []
    return [r.strip() for r in raw.split(",") if r.strip()]
```

For `"Doe, John" <john@example.com>, jane@example.com` that yields:

```python
['"Doe', 'John" <john@example.com>', 'jane@example.com']
```

`'"Doe'` is not an address. `'John" <john@example.com>'` carries a stray quote. Only the third entry is intact. Both `recipients_to` and `recipients_cc` are built this way, so the recipient list shown to the examiner is wrong whenever any recipient has a comma in their display name — and the count is inflated.

A comma inside a quoted display name is not an edge case; it is the default rendering of a *Last, First* contact in Outlook, which is precisely the client whose mailboxes this tool parses.

## The fix

```python
    out: list[str] = []
    for name, addr in getaddresses([raw]):
        display = name.strip()
        if addr and display:
            out.append(f"{display} <{addr}>")
        elif addr:
            out.append(addr)
        elif display:
            out.append(display)
    return out
```

`getaddresses` is the standard library's RFC 5322 address-list parser, so quoting, angle brackets and group syntax are handled by code that already exists rather than by a second regex.

Headers with no quoted comma parse exactly as before — bare addresses stay bare, unquoted display names still render as `Name <addr>`, an empty header still yields `[]`, and surrounding whitespace is still stripped. All four are pinned by narrowness tests.

## Deliberately out of scope

`fix/email-parsing` (closed #78) bundled this with five other independent defects in the same file — the lexicographic date comparison, RFC 2047 header decoding, HTML-only messages having no searchable body, `Cc` never being searched, and attachments detected only via `Content-Disposition: attachment`. Each is a separate root cause and is being submitted as its own PR.

Display names are **not** RFC 2047 decoded here: a name sent as `=?utf-8?B?…?=` still renders encoded. That is the header-decoding concern and belongs with its own fix, not this one.

Relationship to **open PR #96** (`fix/readpst-exit-code`): that one guards the case where readpst *failed*. This is the success path. Different functions, no overlap; verified conflict-free with `git merge-tree`.

### A note on merge order

This PR is one of six recovered from closed #78, each branched independently off `main`. All six merge cleanly into `main` today, and none conflicts with open #96.

Three of them — this one, `fix/pst-recipient-parsing` and `fix/pst-header-decoding` — each add a `from email...` import at the same point in the import block, so **whichever merges second will report a conflict there**. It is confined to the import lines; no two of the six change the same statement. Resolution is to keep both imports.

Flagging it here rather than leaving it to be discovered at merge time.

## Verification

- `uvx pre-commit run --all-files` (new test staged first, so the hooks actually see it) → ruff, ruff-format, mypy all pass.
- Full suite → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `email.py` restored to `origin/main` and the new tests kept, **2 of 6 fail**:

```
FAILED test_a_quoted_comma_does_not_split_a_recipient - assert ['"Doe', 'Joh...@example.com'] == ['Doe, John <...@example.com']
FAILED test_every_address_survives_a_quoted_comma     - assert 3 == 2
2 failed, 4 passed
```

The second line is the defect at its plainest: two recipients in the header, three entries out.

The four that pass on both trees are the narrowness tests, so they pin the fix rather than the bug.

## Context

Recovered from closed PR #78, which bundled six independent defects behind one title. The rejected outcome framework and `classify_tool_exit` are **not** reintroduced — this is a self-contained fix to one parser, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


