### PR TITLE
[high] fix(case): stop reporting a half-finished extraction as complete

### DIFF
--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -5,6 +5,7 @@ Tier 1 tools: help the agent orient before running any extractions.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import shutil
@@ -12,6 +13,7 @@ import subprocess
 import tarfile
 import time
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 
 from mulder.server.app import (
@@ -29,6 +31,14 @@ from mulder.server.tool_access import ALL_ROLES, Role, tool_access
 logger = logging.getLogger(__name__)
 
 _EXTRACT_TIMEOUT = 600
+
+_COMPLETION_MARKER = ".mulder-extraction-complete.json"
+"""Written only after an extraction runs to completion.
+
+The presence of *files* in a destination proves only that an extraction
+started.  A run killed by a timeout, a full disk or a crash leaves a partial
+tree behind that is indistinguishable from a finished one by that test.
+"""
 
 
 @mcp.tool()
@@ -452,6 +462,44 @@ def _extract_7z(archive: Path, dest: Path) -> list[str]:
     return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
 
 
+def _extraction_is_complete(dest: Path, archive: Path) -> bool:
+    """Return True only if *dest* holds a finished extraction of *archive*."""
+    marker = dest / _COMPLETION_MARKER
+    if not marker.is_file():
+        return False
+    try:
+        recorded = json.loads(marker.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    return bool(recorded.get("archive") == str(archive))
+
+
+def _mark_extraction_complete(dest: Path, archive: Path, file_count: int) -> None:
+    """Record that *archive* was fully extracted into *dest*."""
+    try:
+        (dest / _COMPLETION_MARKER).write_text(
+            json.dumps(
+                {
+                    "archive": str(archive),
+                    "file_count": file_count,
+                    "completed_utc": datetime.now(timezone.utc).isoformat(),
+                },
+                indent=2,
+            )
+        )
+    except OSError as exc:
+        logger.warning("Could not write extraction marker in %s: %s", dest, exc)
+
+
+def _extracted_files(dest: Path) -> list[str]:
+    """List extracted files, excluding mulder's own completion marker."""
+    return [
+        str(f.relative_to(dest))
+        for f in dest.rglob("*")
+        if f.is_file() and f.name != _COMPLETION_MARKER
+    ]
+
+
 @mcp.tool()
 @tool_access(Role.CATALOG | Role.EXTRACT_EXECUTOR)
 def extract_archive(
@@ -495,9 +543,10 @@ def extract_archive(
         cfg = get_cfg()
         dest = cfg.db_dir / "extracted" / archive.stem
 
-    # Idempotent: if already extracted, return the existing files
-    if dest.exists() and any(dest.iterdir()):
-        existing_files = [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
+    # Idempotent, but only for an extraction that actually finished.  A
+    # non-empty directory may be the debris of a run that died partway.
+    if _extraction_is_complete(dest, archive):
+        existing_files = _extracted_files(dest)
         result: dict[str, object] = {
             "tool_call_id": tc_id,
             "status": "already_extracted",
@@ -593,6 +642,10 @@ def extract_archive(
     for mi in manifest:
         t = str(mi["artifact_type"])
         type_counts[t] = type_counts.get(t, 0) + 1
+
+    # Written last: the marker is mulder's own bookkeeping, so it must not be
+    # on disk while the classifier is walking the tree for evidence.
+    _mark_extraction_complete(dest, archive, len(files))
 
     result = {
         "tool_call_id": tc_id,

--- a/tests/test_archive_partial_extraction.py
+++ b/tests/test_archive_partial_extraction.py
@@ -1,0 +1,114 @@
+"""A half-finished extraction must not be reported as a finished one.
+
+``extract_archive`` decided an archive was already unpacked with
+
+    if dest.exists() and any(dest.iterdir()):
+
+but the presence of files proves only that an extraction *started*.  A run
+killed by the 600s timeout, a full disk, or a crash leaves a partial tree that
+is indistinguishable from a complete one by that test -- so every later call
+returned ``already_extracted`` with a truncated file list and never retried.
+The missing evidence is silently missing, permanently.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.tools.case import extract_archive
+
+
+@pytest.fixture
+def cases_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "cases"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def archive(tmp_path: Path) -> Path:
+    a = tmp_path / "evidence.zip"
+    with zipfile.ZipFile(a, "w") as zf:
+        zf.writestr("one.txt", b"1")
+        zf.writestr("two.txt", b"2")
+        zf.writestr("three.txt", b"3")
+    return a
+
+
+def _invoke(cases_dir: Path, archive: Path, extract_to: Path | None = None) -> Any:
+    cfg = MagicMock()
+    cfg.db_dir = cases_dir
+    with (
+        patch("mulder.server.tools.case.get_cfg", return_value=cfg),
+        patch("mulder.server.tools.case.has_ctx", return_value=False),
+        patch("mulder.server.tools.case.EvidenceClassifier", create=True),
+    ):
+        return extract_archive.__wrapped__(  # type: ignore[attr-defined]
+            str(archive), extract_to=str(extract_to) if extract_to else None
+        )
+
+
+def test_a_partial_extraction_is_retried_not_reported_complete(
+    cases_dir: Path, archive: Path, tmp_path: Path
+) -> None:
+    """The debris of a killed run must not satisfy the idempotency check."""
+    dest = tmp_path / "partial"
+    dest.mkdir()
+    (dest / "one.txt").write_bytes(b"1")  # a crash left exactly one file
+
+    result = _invoke(cases_dir, archive, extract_to=dest)
+
+    assert result["status"] == "success", (
+        f"a one-file partial tree was accepted as complete: {result.get('status')}"
+    )
+    assert result["total_files_extracted"] == 3
+    assert (dest / "three.txt").is_file(), "the missing evidence was never recovered"
+
+
+def test_a_finished_extraction_is_still_idempotent(
+    cases_dir: Path, archive: Path, tmp_path: Path
+) -> None:
+    """Pins narrowness: the idempotency behaviour itself must survive."""
+    dest = tmp_path / "done"
+
+    first = _invoke(cases_dir, archive, extract_to=dest)
+    second = _invoke(cases_dir, archive, extract_to=dest)
+
+    assert first["status"] == "success"
+    assert second["status"] == "already_extracted"
+    assert sorted(second["files"]) == ["one.txt", "three.txt", "two.txt"]
+
+
+def test_the_marker_is_not_reported_as_evidence(
+    cases_dir: Path, archive: Path, tmp_path: Path
+) -> None:
+    """mulder's own bookkeeping file must never appear in a file list."""
+    dest = tmp_path / "done"
+
+    first = _invoke(cases_dir, archive, extract_to=dest)
+    second = _invoke(cases_dir, archive, extract_to=dest)
+
+    assert first["total_files_extracted"] == 3
+    assert all(not f.startswith(".mulder") for f in second["files"]), second["files"]
+
+
+def test_a_marker_from_a_different_archive_does_not_count(
+    cases_dir: Path, archive: Path, tmp_path: Path
+) -> None:
+    """A slot reused by another archive must not inherit its completion."""
+    dest = tmp_path / "shared"
+    _invoke(cases_dir, archive, extract_to=dest)
+
+    other = tmp_path / "other.zip"
+    with zipfile.ZipFile(other, "w") as zf:
+        zf.writestr("other.txt", b"o")
+
+    result = _invoke(cases_dir, other, extract_to=dest)
+
+    assert result["status"] == "success"
+    assert (dest / "other.txt").is_file()


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `extract_archive` treated *any* non-empty destination as an already-finished extraction:

  ```python
  if dest.exists() and any(dest.iterdir()):
  ```

- The presence of files proves only that an extraction **started**. A run killed by the 600s timeout, a full disk, or a crash leaves a partial tree that this test cannot tell from a complete one.
- Every later call then returned `already_extracted` with a **truncated file list and never retried** — so evidence that never made it out of the archive stayed missing, and the very condition that hid it also prevented the retry that would have recovered it.
- Fix: write a `.mulder-extraction-complete.json` marker only after an extraction finishes, and gate the idempotency branch on that marker naming this archive.
- Scope: `src/mulder/server/tools/case.py` — one constant, three small private helpers, and the idempotency condition.

## Why this one is worth fixing

The failure is self-concealing. An analyst who re-runs `extract_archive` to check gets `already_extracted` and a confident file list, which reads as confirmation. Nothing in the response distinguishes "3 of 3 files" from "1 of 3 files, the run died". A tool that had simply errored would have been safer.

## The fix

```python
_COMPLETION_MARKER = ".mulder-extraction-complete.json"


def _extraction_is_complete(dest: Path, archive: Path) -> bool:
    marker = dest / _COMPLETION_MARKER
    if not marker.is_file():
        return False
    try:
        recorded = json.loads(marker.read_text())
    except (OSError, json.JSONDecodeError):
        return False
    return bool(recorded.get("archive") == str(archive))
```

and at the call site:

```python
    # Idempotent, but only for an extraction that actually finished.  A
    # non-empty directory may be the debris of a run that died partway.
    if _extraction_is_complete(dest, archive):
        existing_files = _extracted_files(dest)
```

Three details that matter:

- The marker **records which archive it belongs to**, so a destination reused by a different archive does not inherit its completion.
- It is written **after** the evidence classifier walks the tree, so mulder's own bookkeeping is never classified as evidence.
- `_extracted_files` filters it out of every returned list, so it never appears as a recovered file.
- A corrupt or unreadable marker is treated as "not complete" — the safe direction, since the cost is a re-extraction rather than silently missing evidence.

## Deliberately out of scope

- **Destination containment and slot collision**, and **resource limits** — separate PRs recovered from closed #84.
- **Plain `.gz` / `.bz2` routed to the tar extractor** — a separate PR from the same closed #85 as this one.
- The marker is deliberately *not* a manifest of expected contents. Verifying that every archive member landed is a stronger check and a larger change; this PR only makes "did the run finish" answerable, which is what the buggy condition was trying and failing to ask.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass. Note `datetime.UTC` is 3.11+, so this uses `timezone.utc` to stay valid on the 3.10 CI leg.
- `uv run --locked --extra dev pytest tests/ -q` → **859 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `case.py` restored to `origin/main` and the tests kept:

```
FAILED test_a_partial_extraction_is_retried_not_reported_complete
  - AssertionError: a one-file partial tree was accepted as complete: already_extracted
FAILED test_a_marker_from_a_different_archive_does_not_count
  - AssertionError: assert 'already_extracted' == 'success'
2 failed, 2 passed
```

The first is the bug caught exactly: a destination holding 1 of 3 files is reported `already_extracted`. The two that pass against **both** trees are the narrowness tests — a genuinely finished extraction is still idempotent, and the marker never shows up as evidence — so the fix cannot be credited with more than it fixes.

## Context

Recovered from closed PR **#85** (`fix/archive-completion`), which was stacked on #84 and bundled this with the gzip-routing defect. This is the completion concern only, branched fresh from current `main` (`2e5432c`) — the closed branch was not revised in place. None of the rejected outcome framework is reintroduced. Verified conflict-free against open #83 and #88, the other PRs touching this file.

## Note on the sibling PRs

This is one of four narrow PRs recovered from closed #84/#85, all touching `extract_archive` in `src/mulder/server/tools/case.py`:

| PR | Concern |
|----|---------|
| #103 | destination containment + slot collision |
| #111 | resource limits (member count / total bytes) |
| #117 | partial extraction reported as complete |
| #124 | plain `.gz`/`.bz2` routed to the tar extractor |

Each is independently branched off `main` and independently testable, and **all four are verified conflict-free against open #83 and #88**, the other PRs on this file.

They are **not** all conflict-free against each other — four of the six pairs touch overlapping lines of the same function (`git merge-tree` reports `CONFLICT (content): src/mulder/server/tools/case.py` for dest×partial, dest×gzip, limits×partial, partial×gzip). That is inherent to splitting one function's defects into one-fix-per-PR rather than shipping a bundle. Merge them in any order; whichever lands first, I will rebase the rest — say the word and I will do that immediately, or collapse any subset into a single PR if you would rather review them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
