### PR TITLE
[high] fix(pdf): implement the advertised extract_urls and extract_embedded

### DIFF
--- a/src/mulder/server/tools/documents.py
+++ b/src/mulder/server/tools/documents.py
@@ -148,6 +148,35 @@ _SUSPICIOUS_JS_FUNCTIONS: list[str] = [
 #: Everything above it is banner/log noise.
 _MSODDE_LINK_MARKER = "DDE Links:"
 
+# pdf-parser prints one "obj <id> <generation>" header per object.
+_PDF_OBJ_HEADER_RE = re.compile(r"^obj (\d+) \d+\s*$")
+# /URI (http://...) -- the value a link annotation actually navigates to.
+_PDF_URI_RE = re.compile(r"/URI\s*\(([^)]{1,2048})\)")
+_PDF_URL_RE = re.compile(r"https?://[^\s()<>\"']{3,2048}")
+# /F and /UF carry the filename on a /Filespec entry.
+_PDF_FILESPEC_NAME_RE = re.compile(r"/(?:UF|F)\s*\(([^)]{1,512})\)")
+_SUSPICIOUS_EMBEDDED_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".bat",
+        ".chm",
+        ".cmd",
+        ".com",
+        ".dll",
+        ".exe",
+        ".hta",
+        ".jar",
+        ".js",
+        ".jse",
+        ".lnk",
+        ".msi",
+        ".ps1",
+        ".scr",
+        ".vbe",
+        ".vbs",
+        ".wsf",
+    }
+)
+
 
 def _parse_msodde_output(stdout: str) -> list[dict[str, object]]:
     """Extract DDE links from msodde's output.
@@ -433,6 +462,140 @@ def _extract_pdfid_count(line: str) -> int:
     return 0
 
 
+def _pdf_parser_cmd(file_path: Path, *args: str) -> list[str]:
+    """Build a pdf-parser invocation, preferring the bundled script.
+
+    Args:
+        file_path: Path to the PDF file.
+        args: Extra pdf-parser arguments, placed before the file path.
+
+    Returns:
+        Command list for subprocess.
+    """
+    script = _pdf_parser_script()
+    if script is not None:
+        return [sys.executable, str(script), *args, str(file_path)]
+    parser_bin = require_binary("pdf-parser") or "pdf-parser"
+    return [parser_bin, *args, str(file_path)]
+
+
+def _run_pdf_parser(file_path: Path, *args: str) -> str:
+    """Run pdf-parser and return its stdout, or "" if it could not run.
+
+    Args:
+        file_path: Path to the PDF file.
+        args: Extra pdf-parser arguments.
+
+    Returns:
+        stdout text, empty when pdf-parser is missing or times out.
+    """
+    try:
+        proc = subprocess.run(
+            _pdf_parser_cmd(file_path, *args),
+            capture_output=True,
+            text=True,
+            timeout=_PDF_PARSER_TIMEOUT,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    return proc.stdout
+
+
+def _iter_pdf_objects(output: str) -> list[tuple[int, str]]:
+    """Split a pdf-parser dump into (object id, body) pairs.
+
+    Args:
+        output: Raw pdf-parser stdout.
+
+    Returns:
+        List of (object_id, body) tuples in document order.
+    """
+    objects: list[tuple[int, str]] = []
+    current_id: int | None = None
+    current: list[str] = []
+    for line in output.splitlines():
+        match = _PDF_OBJ_HEADER_RE.match(line)
+        if match:
+            if current_id is not None:
+                objects.append((current_id, "\n".join(current)))
+            current_id = int(match.group(1))
+            current = []
+        elif current_id is not None:
+            current.append(line)
+    if current_id is not None:
+        objects.append((current_id, "\n".join(current)))
+    return objects
+
+
+def _extract_pdf_urls(file_path: Path) -> list[dict[str, object]]:
+    """Extract URLs reachable from the PDF's actions and object bodies.
+
+    ``/URI`` action values are reported as ``uri_action`` -- those are the
+    links a reader will actually follow. Any other http(s) URL found in an
+    object body is reported as ``object_body``, which catches URLs hidden in
+    places a link annotation would not cover.
+
+    Args:
+        file_path: Path to the PDF file.
+
+    Returns:
+        List of dicts with url, source and object_id, de-duplicated by URL.
+    """
+    output = _run_pdf_parser(file_path)
+    if not output:
+        return []
+
+    urls: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for object_id, body in _iter_pdf_objects(output):
+        for match in _PDF_URI_RE.finditer(body):
+            url = match.group(1).strip()
+            if url and url not in seen:
+                seen.add(url)
+                urls.append({"url": url, "source": "uri_action", "object_id": object_id})
+        for match in _PDF_URL_RE.finditer(body):
+            url = match.group(0).rstrip(").,;")
+            if url and url not in seen:
+                seen.add(url)
+                urls.append({"url": url, "source": "object_body", "object_id": object_id})
+    return urls
+
+
+def _extract_pdf_embedded_files(file_path: Path) -> list[dict[str, object]]:
+    """List files carried inside the PDF via /Filespec entries.
+
+    Args:
+        file_path: Path to the PDF file.
+
+    Returns:
+        List of dicts with filename, object_id and a suspicious flag.
+    """
+    output = _run_pdf_parser(file_path)
+    if not output:
+        return []
+
+    embedded: list[dict[str, object]] = []
+    seen: set[tuple[int, str]] = set()
+    for object_id, body in _iter_pdf_objects(output):
+        if "/Filespec" not in body and "/EmbeddedFile" not in body:
+            continue
+        for match in _PDF_FILESPEC_NAME_RE.finditer(body):
+            filename = match.group(1).strip()
+            if not filename or (object_id, filename) in seen:
+                continue
+            seen.add((object_id, filename))
+            suffix = Path(filename).suffix.lower()
+            embedded.append(
+                {
+                    "filename": filename,
+                    "object_id": object_id,
+                    "suspicious": suffix in _SUSPICIOUS_EMBEDDED_SUFFIXES,
+                }
+            )
+    return embedded
+
+
 def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
     """Extract JavaScript code from PDF objects.
 
@@ -445,23 +608,9 @@ def _extract_pdf_javascript(file_path: Path) -> list[dict[str, object]]:
     Returns:
         List of JavaScript extractions with analysis.
     """
-    script = _pdf_parser_script()
-    if script is not None:
-        cmd = [
-            sys.executable,
-            str(script),
-            "--type",
-            "/JS",
-            "--filter",
-            str(file_path),
-        ]
-    else:
-        parser_bin = require_binary("pdf-parser") or "pdf-parser"
-        cmd = [parser_bin, "--type", "/JS", "--filter", str(file_path)]
-
     try:
         proc = subprocess.run(
-            cmd,
+            _pdf_parser_cmd(file_path, "--type", "/JS", "--filter"),
             capture_output=True,
             text=True,
             timeout=_PDF_PARSER_TIMEOUT,
@@ -830,6 +979,14 @@ def analyze_pdf(
         if has_js_indicator:
             javascript = _extract_pdf_javascript(target)
 
+    urls: list[dict[str, object]] = []
+    if extract_urls:
+        urls = _extract_pdf_urls(target)
+
+    embedded_files: list[dict[str, object]] = []
+    if extract_embedded:
+        embedded_files = _extract_pdf_embedded_files(target)
+
     risk = _compute_pdf_risk(indicators, javascript)
 
     index_parts: list[str] = [f"PDF Analysis: {file_path}"]
@@ -841,6 +998,13 @@ def analyze_pdf(
         index_parts.append(f"JavaScript in object {js.get('object_id', '?')}")
         code_preview = str(js.get("code", ""))[:2000]
         index_parts.append(code_preview)
+    for url in urls:
+        index_parts.append(f"URL in object {url.get('object_id', '?')}: {url.get('url', '')}")
+    for embedded in embedded_files:
+        index_parts.append(
+            f"Embedded file in object {embedded.get('object_id', '?')}: "
+            f"{embedded.get('filename', '')}"
+        )
     index_text = "\n".join(index_parts)
 
     summary = extract_and_index(index_text, "pdf.analysis", file_path, "pdftools")
@@ -848,8 +1012,8 @@ def analyze_pdf(
     summary["indicators"] = indicators
     summary["risk_assessment"] = risk
     summary["javascript"] = javascript if extract_javascript else []
-    summary["urls"] = []
-    summary["embedded_files"] = []
+    summary["urls"] = urls
+    summary["embedded_files"] = embedded_files
 
     elapsed = (time.monotonic() - t0) * 1000
     return tool_response(tc_id, "analyze_pdf", params, summary, "pdf.analysis", elapsed)

--- a/tests/test_pdf_urls_and_embedded.py
+++ b/tests/test_pdf_urls_and_embedded.py
@@ -1,0 +1,241 @@
+"""``analyze_pdf`` advertised URL and embedded-file extraction it never did.
+
+The tool signature accepts ``extract_urls`` and ``extract_embedded``, the
+docstring documents them ("Whether to extract URLs from the PDF", "Whether to
+list embedded files and streams"), and both are echoed into the audited
+``params``. But the result was built as::
+
+    summary["urls"] = []
+    summary["embedded_files"] = []
+
+with no code path anywhere that populated either. A PDF carrying a link to an
+attacker-controlled host and an embedded ``evil.exe`` came back reporting no
+URLs and no embedded files -- and because nothing was produced, nothing was
+indexed either, so ``search()`` over the case could never surface them.
+
+These tests drive the public ``analyze_pdf`` entry point and stub the wrapped
+tools at ``subprocess.run``, so they exercise observable output rather than
+private helpers. The fixture below is verbatim stdout from pdf-parser 0.7.11
+run against a minimal PDF built for this test: one ``/URI`` link action and
+one ``/Filespec`` naming ``evil.exe``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.documents import analyze_pdf
+
+# Verbatim pdf-parser 0.7.11 output for the crafted PDF.
+REAL_PARSER_DUMP = """\
+PDF Comment '%PDF-1.4\\n'
+
+obj 1 0
+ Type: /Catalog
+ Referencing: 2 0 R, 6 0 R
+
+  <<
+    /Type /Catalog
+    /Pages 2 0 R
+    /Names
+      <<
+        /EmbeddedFiles 6 0 R
+      >>
+  >>
+
+
+obj 4 0
+ Type: /Annot
+ Referencing: 5 0 R
+
+  <<
+    /Type /Annot
+    /Subtype /Link
+    /A 5 0 R
+  >>
+
+
+obj 5 0
+ Type: /Action
+ Referencing:
+
+  <<
+    /Type /Action
+    /S /URI
+    /URI (http://malicious.example.com/payload)
+  >>
+
+
+obj 6 0
+ Type:
+ Referencing: 7 0 R
+
+  <<
+    /Names [(evil.exe) 7 0 R]
+  >>
+
+
+obj 7 0
+ Type: /Filespec
+ Referencing: 8 0 R
+
+  <<
+    /Type /Filespec
+    /F (evil.exe)
+    /UF (evil.exe)
+    /EF
+      <<
+        /F 8 0 R
+      >>
+  >>
+
+
+obj 8 0
+ Type: /EmbeddedFile
+ Referencing:
+ Contains stream
+
+  <<
+    /Type /EmbeddedFile
+    /Length 4
+  >>
+
+
+PDF Comment '%%EOF\\n'
+"""
+
+# A clean one-page document: no actions, no attachments.
+BENIGN_PARSER_DUMP = """\
+PDF Comment '%PDF-1.4\\n'
+
+obj 1 0
+ Type: /Catalog
+ Referencing: 2 0 R
+
+  <<
+    /Type /Catalog
+    /Pages 2 0 R
+  >>
+
+
+obj 3 0
+ Type: /Page
+ Referencing: 2 0 R
+
+  <<
+    /Type /Page
+    /Parent 2 0 R
+  >>
+
+
+PDF Comment '%%EOF\\n'
+"""
+
+
+@pytest.fixture
+def pdf(tmp_path: Path) -> Path:
+    """A file that passes analyze_pdf's existence and extension checks."""
+    target = tmp_path / "invoice.pdf"
+    target.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    return target
+
+
+def _analyze(pdf: Path, dump: str, **kwargs: Any) -> tuple[dict[str, Any], str]:
+    """Run analyze_pdf with pdf-parser stubbed at the subprocess boundary.
+
+    ``_run_pdfid`` is stubbed to report no indicators, so the JavaScript
+    extractor stays gated off and every remaining subprocess call is
+    pdf-parser. Returns the response and the text handed to the indexer.
+    """
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kw: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    def _fake_run(*args: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=dump, stderr="")
+
+    with (
+        patch("mulder.server.tools.documents._pdfid_script", return_value=Path("pdfid.py")),
+        patch("mulder.server.tools.documents._pdf_parser_script", return_value=Path("pp.py")),
+        patch("mulder.server.tools.documents._run_pdfid", return_value=[]),
+        patch("mulder.server.tools.documents.subprocess.run", side_effect=_fake_run),
+        patch("mulder.server.tools.documents.extract_and_index", side_effect=_record),
+    ):
+        result = analyze_pdf.__wrapped__(  # type: ignore[attr-defined]
+            "case-1", str(pdf), **kwargs
+        )
+    return result, "\n".join(indexed)
+
+
+def test_a_uri_link_action_reaches_the_analyst(pdf: Path) -> None:
+    """The link a reader would follow must appear in the report."""
+    result, indexed = _analyze(pdf, REAL_PARSER_DUMP)
+
+    assert result["status"] == "success"
+    assert "http://malicious.example.com/payload" in str(result["preview"])
+    # analyze_pdf sets `source`, so tool_response returns a compact preview and
+    # the case DB is how this is reached later -- it must be indexed too.
+    assert "http://malicious.example.com/payload" in indexed
+
+
+def test_an_embedded_executable_reaches_the_analyst(pdf: Path) -> None:
+    result, indexed = _analyze(pdf, REAL_PARSER_DUMP)
+
+    assert "evil.exe" in str(result["preview"])
+    assert "evil.exe" in indexed
+
+
+def test_an_embedded_executable_is_flagged_suspicious(pdf: Path) -> None:
+    """Listing an attachment is not enough; an .exe must be marked."""
+    result, _indexed = _analyze(pdf, REAL_PARSER_DUMP)
+
+    preview = str(result["preview"])
+    assert '"filename": "evil.exe"' in preview
+    assert '"suspicious": true' in preview
+
+
+def test_the_same_attachment_is_not_reported_twice(pdf: Path) -> None:
+    """/F and /UF both name the attachment; it is one file, not two."""
+    _result, indexed = _analyze(pdf, REAL_PARSER_DUMP)
+
+    assert indexed.count("Embedded file in object 7: evil.exe") == 1
+
+
+def test_a_benign_document_yields_no_urls_or_attachments(pdf: Path) -> None:
+    """Pins the fix's narrowness: no false positives on a clean PDF.
+
+    A detector that flags ordinary documents is as useless as one that misses
+    malicious ones.
+    """
+    _result, indexed = _analyze(pdf, BENIGN_PARSER_DUMP)
+
+    assert "URL in object" not in indexed
+    assert "Embedded file in object" not in indexed
+
+
+def test_a_harmless_attachment_is_reported_but_not_flagged(pdf: Path) -> None:
+    """An embedded .txt is still listed, just not marked suspicious."""
+    dump = REAL_PARSER_DUMP.replace("evil.exe", "notes.txt")
+    result, indexed = _analyze(pdf, dump)
+
+    assert "notes.txt" in indexed
+    assert '"suspicious": false' in str(result["preview"])
+
+
+def test_the_parameters_still_switch_the_work_off(pdf: Path) -> None:
+    """extract_urls / extract_embedded must remain honest in both directions.
+
+    They were previously ignored; having implemented them, passing False must
+    actually suppress the work rather than merely blanking the result.
+    """
+    _result, indexed = _analyze(pdf, REAL_PARSER_DUMP, extract_urls=False, extract_embedded=False)
+
+    assert "malicious.example.com" not in indexed
+    assert "evil.exe" not in indexed


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `analyze_pdf` **advertises URL and embedded-file extraction that it never performs.** The signature accepts `extract_urls` and `extract_embedded`, the docstring documents both, and both are echoed into the audited `params` — then the result is built with `summary["urls"] = []` and `summary["embedded_files"] = []`, and no code path anywhere populates either.
- A PDF carrying a link to an attacker-controlled host and an embedded `evil.exe` is reported as having **no URLs and no embedded files**.
- Because nothing was produced, nothing was indexed either — so `search()` over the case can never surface them. The evidence is not merely missing from one response; it never enters the case at all.
- Fix: add `_extract_pdf_urls` and `_extract_pdf_embedded_files` over a shared `_run_pdf_parser` helper, wire them to the parameters that already existed, and append their findings to the indexed text.
- Scope: `src/mulder/server/tools/documents.py`. No new dependency — it uses the same pdf-parser the JavaScript extractor already uses.

## The bug

```python
    summary["indicators"] = indicators
    summary["risk_assessment"] = risk
    summary["javascript"] = javascript if extract_javascript else []
    summary["urls"] = []                  # <- never populated
    summary["embedded_files"] = []        # <- never populated
```

`grep -n 'urls\|embedded_files'` over the module on `main` returns exactly these two assignments plus the parameter declarations and the docstring that promises them. There is no producer.

## The fix

A shared runner, so the new extractors resolve pdf-parser exactly the way `_extract_pdf_javascript` already did (bundled Didier Stevens script first, PATH binary second):

```python
def _run_pdf_parser(file_path: Path, *args: str) -> str:
    try:
        proc = subprocess.run(
            _pdf_parser_cmd(file_path, *args),
            capture_output=True, text=True,
            timeout=_PDF_PARSER_TIMEOUT, check=False,
        )
    except (subprocess.TimeoutExpired, OSError):
        return ""
    return proc.stdout
```

`/URI` action values are reported as `uri_action` — the links a reader actually follows — and any other `http(s)` URL in an object body as `object_body`. Embedded files come from `/Filespec` entries, de-duplicated because `/F` and `/UF` name the same attachment, and flagged `suspicious` on an executable suffix.

Both are gated on the parameters that already existed, so `extract_urls=False` still costs nothing. A missing or timing-out pdf-parser returns `""` and both extractors yield `[]` rather than raising — matching the existing JavaScript extractor's behaviour.

The findings are also appended to `index_parts`. That part is load-bearing rather than cosmetic: `analyze_pdf` passes a `source`, so `tool_response` returns the compact preview envelope, and the case DB is how an analyst reaches this later.

## Verified against the real tool

A minimal PDF with one `/URI` link action and one `/Filespec` naming `evil.exe`, through pdf-parser 0.7.11 and the new extractors:

```
URLS:
   {'url': 'http://malicious.example.com/payload', 'source': 'uri_action', 'object_id': 5}
EMBEDDED:
   {'filename': 'evil.exe', 'object_id': 7, 'suspicious': True}
BENIGN urls: []
BENIGN embedded: []
```

The test fixtures are that run's verbatim stdout, so the tests need no installed binary but are grounded in real output.

## Deliberately out of scope

- **Risk scoring is unchanged.** `_compute_pdf_risk` already derives `has_embedded_files` from pdfid's `/EmbeddedFile` indicator. Feeding URL reputation or attachment types into the risk level is a separate judgement call and would belong in its own PR.
- **Extracting attachment *contents*.** This lists what is embedded; carving the bytes out is a different feature with its own containment questions.
- **JavaScript extraction gaps.** `_extract_pdf_javascript` uses `--type /JS --filter`, which does not reach JavaScript stored as a literal string in an action dictionary. I could not verify that end-to-end here, so I have deliberately not "fixed" it — flagging it instead.
- **The olevba and msodde failure paths** — open PRs #99 and #101. This PR touches neither; it only adds PDF extraction. Verified conflict-free against both with `git merge-tree --write-tree`, and against the pdfid-count fix submitted alongside this one.

## Verification

- `uvx pre-commit run` over the changed files → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **862 passed**, nothing deselected.
- **Discriminating check** — the tests drive the public `analyze_pdf` entry point and stub the wrapped tools at `subprocess.run`, so they import nothing that this PR adds and fail *behaviourally* against unmodified code. With `documents.py` restored to `origin/main` and the new tests kept, 5 of 7 fail:

```
FAILED test_a_uri_link_action_reaches_the_analyst - assert 'http://malicious.example.com/payload' in '{"indicators": [], "risk_...
FAILED test_an_embedded_executable_reaches_the_analyst - assert 'evil.exe' in '{"indicators": [], "risk_assessment": {"risk_level": ...
FAILED test_an_embedded_executable_is_flagged_suspicious - assert '"filename": "evil.exe"' in '{"indicators": [], "risk_assessment": {...
FAILED test_the_same_attachment_is_not_reported_twice - AssertionError: assert 0 == 1
FAILED test_a_harmless_attachment_is_reported_but_not_flagged - AssertionError: assert 'notes.txt' in 'PDF Analysis: /tmp/.../invoice.pdf'
5 failed, 2 passed
```

The two that pass on both are the narrowness guards — a benign PDF yields nothing, and `extract_urls=False` / `extract_embedded=False` suppress the work rather than merely blanking the result. A detector that flags ordinary documents is as useless as one that misses malicious ones.

## Context

Recovered from closed PR #79, which bundled several unrelated PDF detection gaps into a 284-line diff. This is one of them, resubmitted on its own; the pdfid hex-obfuscation gap is submitted separately, and both are branched independently off `main` with no stacking. No outcome framework and no shared taxonomy are reintroduced, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
