### PR TITLE
[critical] fix(phone): find the directory ALEAPP and iLEAPP actually write

### DIFF
--- a/src/mulder/server/tools/phone.py
+++ b/src/mulder/server/tools/phone.py
@@ -1005,6 +1005,48 @@ def _parse_tsv_file(tsv_path: Path) -> list[dict[str, str]]:
     return records
 
 
+_LEAPP_TSV_DIRNAME = "_TSV Exports"
+
+
+def _find_leapp_tsv_dir(output_dir: Path) -> Path | None:
+    """Locate the directory ALEAPP/iLEAPP wrote their TSV exports into.
+
+    Both tools create a timestamped report folder under the ``-o`` path and
+    write every TSV into a ``_TSV Exports`` directory inside it, so the layout
+    is ``<output_dir>/<TOOL>_Output_<timestamp>/_TSV Exports/*.tsv``. Looking
+    directly under *output_dir* finds nothing at all.
+
+    Args:
+        output_dir: The directory passed to the tool as ``-o``.
+
+    Returns:
+        The directory holding the ``.tsv`` files, or None if there is none.
+    """
+    nested = sorted(
+        (d for d in output_dir.glob(f"*/{_LEAPP_TSV_DIRNAME}") if d.is_dir()),
+        key=lambda d: d.parent.name,
+    )
+    if nested:
+        # A fresh temporary directory holds one run, but sort by the report
+        # folder's timestamped name so the newest wins if a caller reuses one.
+        return nested[-1]
+
+    direct = output_dir / _LEAPP_TSV_DIRNAME
+    if direct.is_dir():
+        return direct
+
+    # Older layouts, and anything that drops the files straight in.
+    legacy = output_dir / "tsv"
+    if legacy.is_dir():
+        return legacy
+    for candidate in sorted(output_dir.iterdir()) if output_dir.is_dir() else []:
+        if candidate.is_dir() and (candidate / "tsv").is_dir():
+            return candidate / "tsv"
+    if output_dir.is_dir() and any(output_dir.glob("*.tsv")):
+        return output_dir
+    return None
+
+
 def _parse_leapp_output(
     output_dir: Path,
     platform: str,
@@ -1030,16 +1072,8 @@ def _parse_leapp_output(
     categories: dict[str, int] = {}
     total_records = 0
 
-    tsv_dir = output_dir / "tsv"
-    if not tsv_dir.exists():
-        for candidate in output_dir.iterdir():
-            if candidate.is_dir() and (candidate / "tsv").exists():
-                tsv_dir = candidate / "tsv"
-                break
-        else:
-            tsv_dir = output_dir
-
-    tsv_files = sorted(tsv_dir.glob("*.tsv")) if tsv_dir.exists() else []
+    tsv_dir = _find_leapp_tsv_dir(output_dir)
+    tsv_files = sorted(tsv_dir.glob("*.tsv")) if tsv_dir is not None else []
 
     for tsv_file in tsv_files:
         artifact_type = tsv_file.stem

--- a/tests/test_leapp_tsv_discovery.py
+++ b/tests/test_leapp_tsv_discovery.py
@@ -1,0 +1,124 @@
+"""ALEAPP/iLEAPP results must actually be found on disk.
+
+Both tools create a timestamped report folder under the ``-o`` path and write
+every TSV into a ``_TSV Exports`` directory inside it::
+
+    <output_dir>/ALEAPP_Output_2026-09-08_Monday_054512/_TSV Exports/*.tsv
+
+``_parse_leapp_output`` looked for ``<output_dir>/tsv``, then for a child
+directory containing a ``tsv`` subdirectory, then fell back to globbing
+``<output_dir>/*.tsv``. All three miss the real layout, so every run of
+``run_aleapp`` / ``run_ileapp`` returned ``no_artifacts`` -- a phone full of
+evidence reported as "produced no parseable output".
+
+The layout is pinned against ALEAPP/iLEAPP v2026.3.2:
+``leapp_functions/app/output.py`` builds ``<leapp_name>_Output_<timestamp>``
+and ``scripts/ilapfuncs.py::tsv`` writes into ``_TSV Exports``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mulder.server.tools.phone import _parse_leapp_output
+
+_HEADERS = "Timestamp\tPartner\tMessage"
+_ROWS = [
+    "2026-01-14 09:12:03\t+32470112233\tmeet me at the lockup",
+    "2026-01-14 09:14:51\t+32470998877\tburn the drive",
+]
+
+
+def _write_report_tree(output_dir: Path, tool: str = "ALEAPP") -> Path:
+    """Build the real report tree the pinned tools produce under ``-o``."""
+    report = output_dir / f"{tool}_Output_2026-09-08_Monday_054512"
+    tsv_dir = report / "_TSV Exports"
+    tsv_dir.mkdir(parents=True)
+    (tsv_dir / "sms messages.tsv").write_text(
+        _HEADERS + "\n" + "\n".join(_ROWS) + "\n", encoding="utf-8"
+    )
+    # The rest of the report folder, so the fixture is not a stripped-down
+    # shape the code could accidentally rely on.
+    (report / "_HTML" / "_Script_Logs").mkdir(parents=True)
+    (report / "_HTML" / "index.html").write_text("<html></html>")
+    (report / "data").mkdir()
+    (report / "media").mkdir()
+    return report
+
+
+def test_the_real_report_layout_is_found(tmp_path: Path) -> None:
+    """The layout ALEAPP v2026.3.2 actually writes must yield artifacts."""
+    _write_report_tree(tmp_path)
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    assert result["total_artifacts_parsed"] == 1
+    assert result["total_records"] == 2
+    artifact = result["artifacts"][0]
+    assert artifact["artifact_type"] == "sms messages"
+    assert artifact["data"][0]["Partner"] == "+32470112233"
+
+
+def test_the_message_body_survives_parsing(tmp_path: Path) -> None:
+    """The evidence itself -- not just a count -- must come back."""
+    _write_report_tree(tmp_path)
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    bodies = [row["Message"] for row in result["artifacts"][0]["data"]]
+    assert bodies == ["meet me at the lockup", "burn the drive"]
+
+
+def test_the_ios_report_layout_is_found(tmp_path: Path) -> None:
+    """iLEAPP uses the same ``_TSV Exports`` convention under its own folder."""
+    _write_report_tree(tmp_path, tool="iLEAPP")
+
+    result = _parse_leapp_output(tmp_path, "ios", "/evidence/backup")
+
+    assert result["total_artifacts_parsed"] == 1
+    assert result["platform"] == "ios"
+
+
+def test_a_run_that_produced_nothing_is_still_empty(tmp_path: Path) -> None:
+    """Pins the fix's narrowness: no TSVs means no artifacts, not a crash."""
+    report = tmp_path / "ALEAPP_Output_2026-09-08_Monday_054512"
+    (report / "_TSV Exports").mkdir(parents=True)
+    (report / "_HTML").mkdir()
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    assert result["total_artifacts_parsed"] == 0
+    assert result["total_records"] == 0
+
+
+def test_an_absent_output_directory_is_handled(tmp_path: Path) -> None:
+    """A tool that wrote nothing at all must not raise."""
+    result = _parse_leapp_output(tmp_path / "nope", "android", "/evidence/phone.tar")
+
+    assert result["total_artifacts_parsed"] == 0
+
+
+def test_a_flat_tsv_directory_still_works(tmp_path: Path) -> None:
+    """Pins the fix's narrowness: the pre-existing layouts keep working.
+
+    Anything already relying on a ``tsv`` directory -- a custom output folder,
+    an older LEAPP -- must not regress.
+    """
+    tsv_dir = tmp_path / "tsv"
+    tsv_dir.mkdir()
+    (tsv_dir / "calls.tsv").write_text(_HEADERS + "\n" + _ROWS[0] + "\n", encoding="utf-8")
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    assert result["total_artifacts_parsed"] == 1
+    assert result["artifacts"][0]["artifact_type"] == "calls"
+
+
+def test_tsv_files_dropped_directly_in_the_output_dir_still_work(tmp_path: Path) -> None:
+    """The previous final fallback globbed ``<output_dir>/*.tsv``; keep it."""
+    (tmp_path / "wifi.tsv").write_text(_HEADERS + "\n" + _ROWS[0] + "\n", encoding="utf-8")
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    assert result["total_artifacts_parsed"] == 1
+    assert result["artifacts"][0]["artifact_type"] == "wifi"


### PR DESCRIPTION
## BLUF

- **Priority: critical.**
- `run_aleapp` and `run_ileapp` **never return any artifacts at all**. Every call answers `"ALEAPP produced no parseable output"` — a phone full of messages, locations and app records reported as having nothing to parse.
- Root cause: `_parse_leapp_output` looks for a directory named **`tsv`**. ALEAPP and iLEAPP write neither. Both create a timestamped report folder under the `-o` path and put every export in a **`_TSV Exports`** directory inside it.
- All three of the existing lookups miss that layout, so `tsv_files` is always empty, `artifacts` is always empty, and both tools are dead on arrival.
- Fix: look for the real layout first, keeping every previous lookup as a fallback so a custom output folder or an older LEAPP still works.
- Scope: `src/mulder/server/tools/phone.py` only — one new private helper and its call site.

## The bug

mulder invokes the tools with a temporary directory:

```python
    with tempfile.TemporaryDirectory(prefix="mulder_aleapp_") as tmpdir:
        output_dir = Path(tmpdir)
        cmd = [*aleapp_cmd, "-t", ..., "-i", str(extraction_path), "-o", str(output_dir)]
```

and then looks for results like this:

```python
    tsv_dir = output_dir / "tsv"
    if not tsv_dir.exists():
        for candidate in output_dir.iterdir():
            if candidate.is_dir() and (candidate / "tsv").exists():
                tsv_dir = candidate / "tsv"
                break
        else:
            tsv_dir = output_dir

    tsv_files = sorted(tsv_dir.glob("*.tsv")) if tsv_dir.exists() else []
```

What the tools actually produce, verified against **ALEAPP/iLEAPP v2026.3.2** — the versions the Dockerfile clones (`git clone --depth 1 --branch v2026.3.2`):

```
<output_dir>/ALEAPP_Output_2026-09-08_Monday_054512/
    _HTML/
    _TSV Exports/*.tsv        <-- every export lands here
    data/
    media/
```

`leapp_functions/app/output.py`:

```python
def default_output_folder_name():
    currenttime = datetime.now().strftime('%Y-%m-%d_%A_%H%M%S')
    return f'{leapp_name}_Output_{currenttime}'
```

`scripts/ilapfuncs.py`:

```python
def tsv(report_folder, data_headers, data_list, tsvname, source_file=None):
    report_folder_base = os.path.dirname(os.path.dirname(report_folder))
    tsv_report_folder = os.path.join(report_folder_base, '_TSV Exports')
```

iLEAPP's own tooling documents the same convention — `admin/scripts/check_artifact_output.py` reads `os.path.join(report_dir, '_TSV Exports', '*.tsv')` and describes `REPORT_DIR` as "a report folder, the one holding `_TSV Exports`".

So: `<output_dir>/tsv` does not exist; the child `ALEAPP_Output_*` contains `_TSV Exports`, not `tsv`, so the second lookup does not match either; the fallback globs `<output_dir>/*.tsv`, but the TSVs are two levels down. Zero artifacts, every time.

## The fix

```python
def _find_leapp_tsv_dir(output_dir: Path) -> Path | None:
    nested = sorted(
        (d for d in output_dir.glob(f"*/{_LEAPP_TSV_DIRNAME}") if d.is_dir()),
        key=lambda d: d.parent.name,
    )
    if nested:
        return nested[-1]
    ...
```

The real layout is tried first; the `_TSV Exports` directory directly under `-o`, the legacy `tsv` directory, a child containing `tsv`, and a flat `*.tsv` drop are all kept as fallbacks. The helper also returns `None` rather than raising when the output directory does not exist — on `main` that path raises `FileNotFoundError` from `iterdir()`, which the new tests also cover.

## Deliberately out of scope

- **Indexing the artifact content.** Even once the files are found, only counts reach the case database. That is a separate defect, recovered from closed PR #74 and submitted alongside this one as `fix/leapp-detection-indexing`. The two branches are independent (both cut from `main`, no stacking) and verified conflict-free with `git merge-tree`.
- The `_HTML`, `_KML Exports` and LAVA outputs the tools also produce; this PR changes only where the TSVs are looked for.

## Verification

- `uvx pre-commit run --all-files` (new test file staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check** — with `phone.py` restored to `origin/main` and the new tests kept, 4 of 7 fail and the 3 narrowness tests pass:

```
FAILED tests/test_leapp_tsv_discovery.py::test_the_real_report_layout_is_found - assert 0 == 1
FAILED tests/test_leapp_tsv_discovery.py::test_the_message_body_survives_parsing - IndexError: list index out of range
FAILED tests/test_leapp_tsv_discovery.py::test_the_ios_report_layout_is_found - assert 0 == 1
FAILED tests/test_leapp_tsv_discovery.py::test_an_absent_output_directory_is_handled - FileNotFoundError: [Errno 2] No such file or directory: '.../nope'
4 failed, 3 passed
```

The three that pass on both trees are the narrowness tests — the legacy `tsv` directory, a flat `*.tsv` drop, and an empty run — so they pin the fix rather than the bug.

## Context

Found while recovering the `phone.py` slice of closed PR #74. **This defect is not from #74** — that PR changed only how much of the parsed data was kept, and would have had no observable effect while the parser finds nothing. This is a new finding on current `main`.

No framework, no shared helper, no second status taxonomy — one private function in one module, in the spirit of the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
