### PR TITLE
[high] fix(phone): index the LEAPP artifacts, not just how many there were

### DIFF
--- a/src/mulder/server/tools/phone.py
+++ b/src/mulder/server/tools/phone.py
@@ -18,6 +18,7 @@ import subprocess
 import tempfile
 import time
 import xml.etree.ElementTree as ET
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -978,6 +979,41 @@ def _classify_artifact_category(artifact_type: str) -> str:
     return "other"
 
 
+# How many rows per artifact the tool response carries back. The case index is
+# not bounded by this -- the response is a preview, the index is the evidence.
+_MAX_LEAPP_RESPONSE_ROWS = 100
+
+
+def _leapp_artifact_lines(artifact: Mapping[str, Any]) -> list[str]:
+    """Render one parsed LEAPP artifact as indexable text.
+
+    ``_parse_tsv_file`` zips headers to values non-strictly, so a truncated row
+    yields a short dict. Taking the union of keys in first-seen order keeps
+    every row on the same columns instead of letting one short row shift the
+    whole artifact.
+
+    Args:
+        artifact: One entry from ``_parse_leapp_output``'s ``artifacts`` list.
+
+    Returns:
+        Lines of tab-separated text, empty if the artifact has no rows.
+    """
+    rows = artifact.get("data") or []
+    if not rows:
+        return []
+
+    columns: dict[str, None] = {}
+    for row in rows:
+        for key in row:
+            columns.setdefault(key, None)
+    headers = list(columns)
+
+    lines = [f"[{artifact.get('category', '')}] {artifact.get('artifact_type', '')}"]
+    lines.append("\t".join(headers))
+    lines.extend("\t".join(str(row.get(h, "")) for h in headers) for row in rows)
+    return lines
+
+
 def _parse_tsv_file(tsv_path: Path) -> list[dict[str, str]]:
     """Parse a TSV file into a list of row dicts.
 
@@ -1060,7 +1096,9 @@ def _parse_leapp_output(
                 "category": category,
                 "artifact_type": artifact_type,
                 "record_count": record_count,
-                "data": records[:100],
+                # Not truncated here: run_aleapp/run_ileapp index these and
+                # then bound the response, so the case database sees every row.
+                "data": records,
                 "source_files": [str(tsv_file)],
             }
         )
@@ -1223,9 +1261,20 @@ def run_aleapp(
         for cat, count in result.get("categories", {}).items():
             text_parts.append(f"  {cat}: {count} records")
 
+        # Index the parsed rows themselves. Without this the case
+        # database learned that ALEAPP found N records and
+        # nothing about what they said -- no phone number, URL,
+        # filename or timestamp was searchable.
+        for artifact in result.get("artifacts", []):
+            text_parts.extend(_leapp_artifact_lines(artifact))
+
         summary = extract_and_index(
             "\n".join(text_parts), "phone.aleapp", extraction_path, "aleapp"
         )
+
+        # The response stays a bounded preview; the index does not.
+        for artifact in result.get("artifacts", []):
+            artifact["data"] = artifact["data"][:_MAX_LEAPP_RESPONSE_ROWS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000
@@ -1381,9 +1430,20 @@ def run_ileapp(
         for cat, count in result.get("categories", {}).items():
             text_parts.append(f"  {cat}: {count} records")
 
+        # Index the parsed rows themselves. Without this the case
+        # database learned that iLEAPP found N records and
+        # nothing about what they said -- no phone number, URL,
+        # filename or timestamp was searchable.
+        for artifact in result.get("artifacts", []):
+            text_parts.extend(_leapp_artifact_lines(artifact))
+
         summary = extract_and_index(
             "\n".join(text_parts), "phone.ileapp", extraction_path, "ileapp"
         )
+
+        # The response stays a bounded preview; the index does not.
+        for artifact in result.get("artifacts", []):
+            artifact["data"] = artifact["data"][:_MAX_LEAPP_RESPONSE_ROWS]
         summary.update(result)
 
     elapsed = (time.monotonic() - t0) * 1000

--- a/tests/test_leapp_detection_indexing.py
+++ b/tests/test_leapp_detection_indexing.py
@@ -1,0 +1,203 @@
+"""ALEAPP/iLEAPP must index the artefacts themselves, not just how many.
+
+``run_aleapp`` / ``run_ileapp`` built the indexed text from counts only::
+
+    ALEAPP analysis of /evidence/phone.tar
+    Artifacts parsed: 42
+    Total records: 12000
+      messaging: 8000 records
+
+That is what reached ``extract_and_index`` and therefore the case database.
+The recovered messages, URLs, filenames and timestamps -- the evidence -- were
+never indexed, so ``search()`` over the case could not surface a single one.
+``_parse_leapp_output`` also discarded every row past the hundredth before the
+caller ever saw it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.phone import _parse_leapp_output, run_aleapp
+
+_HEADERS = "Timestamp\tPartner\tMessage"
+_ROWS = [
+    "2026-01-14 09:12:03\t+32470112233\tmeet me at the lockup",
+    "2026-01-14 09:14:51\t+32470998877\tburn the drive",
+]
+
+
+@pytest.fixture
+def extraction(tmp_path: Path) -> Path:
+    """An extraction path that exists, so the run reaches ALEAPP."""
+    path = tmp_path / "phone.tar"
+    path.write_bytes(b"\x00" * 64)
+    (tmp_path / "aleapp.py").write_text("")
+    return path
+
+
+def _tsv_tree(root: Path, rows: list[str]) -> Path:
+    """The TSV directory shape ``_parse_leapp_output`` reads from."""
+    tsv_dir = root / "tsv"
+    tsv_dir.mkdir(parents=True, exist_ok=True)
+    (tsv_dir / "sms messages.tsv").write_text(
+        _HEADERS + "\n" + "\n".join(rows) + "\n", encoding="utf-8"
+    )
+    return tsv_dir
+
+
+def _run_aleapp_over(tmpdir_contents: Any, extraction: Path) -> tuple[Any, list[str]]:
+    """Drive ``run_aleapp`` with ALEAPP replaced by a fake that writes output."""
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    def _fake_aleapp(cmd: list[str], **_: object) -> Any:
+        out = Path(cmd[cmd.index("-o") + 1])
+        tmpdir_contents(out)
+
+        class _P:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _P()
+
+    with (
+        patch(
+            "mulder.server.tools.phone._aleapp_script",
+            return_value=str(extraction.parent / "aleapp.py"),
+        ),
+        patch("mulder.server.tools.phone._find_leapp_cmd", return_value=["python", "aleapp.py"]),
+        patch("mulder.server.tools.phone.subprocess.run", side_effect=_fake_aleapp),
+        patch("mulder.server.tools.phone.extract_and_index", side_effect=_record),
+    ):
+        result = run_aleapp.__wrapped__(str(extraction))  # type: ignore[attr-defined]
+    return result, indexed
+
+
+def test_the_message_body_reaches_the_index(extraction: Path) -> None:
+    """The sharpest form: a recovered SMS must be searchable in the case."""
+    result, indexed = _run_aleapp_over(lambda out: _tsv_tree(out, _ROWS), extraction)
+
+    assert result["status"] == "success"
+    assert indexed, "nothing was indexed at all"
+    blob = indexed[0]
+    assert "meet me at the lockup" in blob
+    assert "burn the drive" in blob
+    assert "+32470112233" in blob
+
+
+def test_the_index_is_not_just_a_count_summary(extraction: Path) -> None:
+    """Counts alone are what main indexed; they must no longer be all of it."""
+    _result, indexed = _run_aleapp_over(lambda out: _tsv_tree(out, _ROWS), extraction)
+
+    blob = indexed[0]
+    # The count lines stay -- they are useful context, just not sufficient.
+    assert "Total records: 2" in blob
+    # ...but the evidence is there too.
+    assert "Partner" in blob, "column headers were not indexed"
+
+
+def test_rows_past_the_hundredth_are_indexed(extraction: Path) -> None:
+    """``data`` was truncated to 100 rows before anyone could index it.
+
+    Row 250 of a message table is evidence like any other.
+    """
+    rows = [f"2026-01-14 09:00:{i:02d}\t+3247000{i:04d}\tmessage number {i}" for i in range(300)]
+    _result, indexed = _run_aleapp_over(lambda out: _tsv_tree(out, rows), extraction)
+
+    blob = indexed[0]
+    assert "message number 250" in blob
+    assert "message number 299" in blob
+
+
+def test_the_response_stays_a_bounded_preview(extraction: Path) -> None:
+    """Pins the fix's narrowness: the MCP response must not balloon.
+
+    The index gets everything; the payload handed back keeps its 100-row cap,
+    so a 12000-row message table is not shipped through the transport.
+    """
+    rows = [f"2026-01-14 09:00:{i:02d}\t+3247000{i:04d}\tmessage number {i}" for i in range(300)]
+    captured: list[dict[str, Any]] = []
+
+    def _capture(
+        tc_id: str, name: str, params: Any, results: Any, *a: object
+    ) -> dict[str, object]:
+        captured.append(results)
+        return {"status": "success"}
+
+    def _fake_aleapp(cmd: list[str], **_: object) -> Any:
+        _tsv_tree(Path(cmd[cmd.index("-o") + 1]), rows)
+
+        class _P:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _P()
+
+    with (
+        patch(
+            "mulder.server.tools.phone._aleapp_script",
+            return_value=str(extraction.parent / "aleapp.py"),
+        ),
+        patch("mulder.server.tools.phone._find_leapp_cmd", return_value=["python", "aleapp.py"]),
+        patch("mulder.server.tools.phone.subprocess.run", side_effect=_fake_aleapp),
+        patch("mulder.server.tools.phone.extract_and_index", return_value={}),
+        patch("mulder.server.tools.phone.tool_response", side_effect=_capture),
+    ):
+        run_aleapp.__wrapped__(str(extraction))  # type: ignore[attr-defined]
+
+    assert captured, "tool_response was never reached"
+    artifact = captured[0]["artifacts"][0]
+    assert artifact["record_count"] == 300, "the true count must survive"
+    assert len(artifact["data"]) == 100, "the response payload must stay capped"
+
+
+def test_the_parser_keeps_every_row_for_indexing(tmp_path: Path) -> None:
+    """``_parse_leapp_output`` must hand the caller all rows, not the first 100."""
+    rows = [f"2026-01-14 09:00:{i:02d}\t+3247000{i:04d}\tmessage number {i}" for i in range(300)]
+    _tsv_tree(tmp_path, rows)
+
+    result = _parse_leapp_output(tmp_path, "android", "/evidence/phone.tar")
+
+    assert result["artifacts"][0]["record_count"] == 300
+    assert len(result["artifacts"][0]["data"]) == 300
+
+
+def test_a_short_row_does_not_shift_the_columns() -> None:
+    """A truncated TSV row yields a short dict; columns must stay aligned."""
+    from mulder.server.tools.phone import _leapp_artifact_lines
+
+    artifact = {
+        "category": "messaging",
+        "artifact_type": "sms",
+        "data": [
+            {"Timestamp": "t1", "Partner": "+32470", "Message": "hello"},
+            {"Timestamp": "t2"},
+            {"Timestamp": "t3", "Extra": "late column", "Message": "bye"},
+        ],
+    }
+
+    lines = _leapp_artifact_lines(artifact)
+
+    assert lines[0] == "[messaging] sms"
+    assert lines[1] == "Timestamp\tPartner\tMessage\tExtra"
+    # The short row keeps its position under Timestamp and pads the rest.
+    assert lines[3] == "t2\t\t\t"
+    assert lines[4] == "t3\t\tbye\tlate column"
+
+
+def test_an_artifact_with_no_rows_renders_nothing() -> None:
+    """Pins narrowness: an empty artefact must not emit a stray header."""
+    from mulder.server.tools.phone import _leapp_artifact_lines
+
+    assert _leapp_artifact_lines({"category": "c", "artifact_type": "a", "data": []}) == []
+    assert _leapp_artifact_lines({"category": "c", "artifact_type": "a"}) == []


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `run_aleapp` / `run_ileapp` indexed **only counts**, never the artifacts. The case database learned that ALEAPP found 12000 records and nothing about what any of them said — no phone number, URL, filename or timestamp was searchable.
- `_parse_leapp_output` also discarded every row past the hundredth *before the caller saw it*, so rows 101+ could not be indexed even in principle. Row 250 of a message table is evidence like any other.
- Fix: render each parsed artifact as tab-separated text and index it. The row cap moves to the response — the index gets every row, the MCP response stays a bounded 100-row preview, and `record_count` still reports the true total.
- Scope: `src/mulder/server/tools/phone.py` only. One private helper local to this module — **no shared helper is added**.

## The bug

```python
        text_parts = [
            f"ALEAPP analysis of {extraction_path}",
            f"Artifacts parsed: {result['total_artifacts_parsed']}",
            f"Total records: {result['total_records']}",
        ]
        for cat, count in result.get("categories", {}).items():
            text_parts.append(f"  {cat}: {count} records")

        summary = extract_and_index(
            "\n".join(text_parts), "phone.aleapp", extraction_path, "aleapp"
        )
```

That string is the entirety of what reaches `extract_and_index`, and therefore the case database:

```
ALEAPP analysis of /evidence/phone.tar
Artifacts parsed: 42
Total records: 12000
  messaging: 8000 records
```

A later `search("+32470112233")` or `search("whatsapp")` over the case returns nothing, because nothing but the arithmetic was ever stored. The same block appears verbatim in `run_ileapp`.

And upstream of it:

```python
                "record_count": record_count,
                "data": records[:100],
```

## The fix

A module-local renderer:

```python
def _leapp_artifact_lines(artifact: Mapping[str, Any]) -> list[str]:
    rows = artifact.get("data") or []
    if not rows:
        return []

    columns: dict[str, None] = {}
    for row in rows:
        for key in row:
            columns.setdefault(key, None)
    headers = list(columns)

    lines = [f"[{artifact.get('category', '')}] {artifact.get('artifact_type', '')}"]
    lines.append("\t".join(headers))
    lines.extend("\t".join(str(row.get(h, "")) for h in headers) for row in rows)
    return lines
```

fed in before indexing, with the cap moved to the response:

```python
        for artifact in result.get("artifacts", []):
            text_parts.extend(_leapp_artifact_lines(artifact))

        summary = extract_and_index(...)

        # The response stays a bounded preview; the index does not.
        for artifact in result.get("artifacts", []):
            artifact["data"] = artifact["data"][:_MAX_LEAPP_RESPONSE_ROWS]
```

The count lines are kept — they are useful context, they were just never sufficient on their own.

**Why the union of keys, in first-seen order:** `_parse_tsv_file` builds rows with `zip(headers, values, strict=False)`, so a truncated TSV line yields a short dict. Taking the union keeps every row on the same columns instead of letting one short row shift the rest of the artifact. A test pins that directly.

## Deliberately out of scope

- **`format_records` from closed PR #74.** The original diff imported a shared helper that #74 added to `extract_helpers.py`. That helper does not exist on `main`, and adding a cross-module helper is the shape the maintainer declined in #32 — so the rendering is implemented locally in `phone.py` instead.
- **The rest of #74.** It was a stacked branch that also touched `chainsaw.py`, `zircolite.py`, `helpers.py`, `extract_helpers.py`, `binary.py`, `hayabusa.py`, `mvt.py` and `carving.py`. This PR is the `phone.py` slice only.
- **Where the TSVs are found.** On current `main` `_parse_leapp_output` looks for a `tsv` directory that ALEAPP/iLEAPP never create, so it finds nothing at all. That is a separate defect, submitted alongside this one as `fix/leapp-tsv-discovery` (**critical** — the tools are dead without it). The two branches are independent (both cut from `main`, no stacking) and verified conflict-free with `git merge-tree`. **This PR's user-visible benefit depends on that one landing.**

## Verification

- `uvx pre-commit run --all-files` (new test file staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, 1 deselected (`test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps`, which writes a real 200 MB file and fails identically on unmodified `main` in this environment — an environment disk quota, not a regression).
- **Discriminating check** — with `phone.py` restored to `origin/main` and the new tests kept, 6 of 7 fail:

```
FAILED test_the_message_body_reaches_the_index - AssertionError: assert 'meet me at the lockup' in 'ALEAPP analysis of /tmp/...
FAILED test_the_index_is_not_just_a_count_summary - AssertionError: column headers were not indexed
FAILED test_rows_past_the_hundredth_are_indexed - AssertionError: assert 'message number 250' in 'ALEAPP analysis of /tmp/pyt...
FAILED test_the_parser_keeps_every_row_for_indexing - AssertionError: assert 100 == 300
FAILED test_a_short_row_does_not_shift_the_columns - ImportError: cannot import name '_leapp_artifact_lines'
FAILED test_an_artifact_with_no_rows_renders_nothing - ImportError: cannot import name '_leapp_artifact_lines'
6 failed, 1 passed
```

The one that passes on both trees is `test_the_response_stays_a_bounded_preview` — the narrowness test asserting the response payload keeps its 100-row cap — so it pins the fix rather than the bug.

## Context

Recovered from closed PR #74 (`fix/summary-only-indexing`), narrowed to one module and rebuilt on today's `main`. The rejected outcome framework is **not** reintroduced: no `classify_tool_exit`, no shared helper, no second status taxonomy. Per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Nearest open neighbour is #92 (`fix/mvt-exit-code`) — same mobile-forensics area, different module and a different concern (it stops MVT's stderr being indexed as device evidence). No overlap.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
