### PR TITLE
[high] fix(tsk): stop every fls-driven extractor skipping deleted files

### DIFF
--- a/src/mulder/patterns.py
+++ b/src/mulder/patterns.py
@@ -7,6 +7,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NamedTuple
 
 IP_RE: re.Pattern[str] = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 
@@ -231,3 +232,80 @@ def parse_mmls_rows(mmls_text: str) -> list[tuple[int, int, str]]:
         (int(m.group(1)), int(m.group(2)), m.group(3).strip().lower())
         for m in MMLS_ROW_RE.finditer(mmls_text)
     ]
+
+
+FLS_ROW_RE: re.Pattern[str] = re.compile(
+    r"^(?P<name_type>[A-Za-z\-])/(?P<meta_type>[A-Za-z\-])\s+"
+    r"(?P<deleted>\*\s+)?"
+    r"(?P<inode>\d+(?:-\d+-\d+)?):\t"
+    r"(?P<path>.+?)\s*$",
+    re.MULTILINE,
+)
+"""One row of ``fls -r -p`` output.
+
+Verified against The Sleuth Kit 4.12.1 on a real image::
+
+    r/r 15:\tUsers/alice/NTUSER.DAT
+    r/r * 16:\tUsers/alice/capture.pcap
+    l/l 17:\tUsers/alice/link_to_passwd
+    r/r * 22:\tWindows/System32/winevt/Logs/Deleted.evtx
+    V/V 1025:\t$OrphanFiles
+
+Two things the previous ``[rd]/[rd*]`` spelling got wrong:
+
+* the deleted marker is a **separate ``*`` token after the type pair**, not a
+  character inside it, so every deleted entry failed to match;
+* the type characters are not limited to ``r`` and ``d``. TSK also emits
+  ``l`` (symlink), ``v``/``V`` (virtual, e.g. ``$OrphanFiles``), ``s``, ``c``,
+  ``b``, ``p``, ``h``, ``w`` and ``-`` (unknown); ``-/r`` in particular is
+  what an unallocated or orphaned file looks like.
+
+The separator between the inode and the path is a literal tab, which is what
+makes it safe for a path to contain spaces.
+"""
+
+
+class FlsEntry(NamedTuple):
+    """One parsed row of ``fls`` output."""
+
+    inode: str
+    path: str
+    deleted: bool
+    name_type: str
+    meta_type: str
+
+    @property
+    def base_inode(self) -> str:
+        """The inode without NTFS attribute qualifiers, as ``icat`` wants it."""
+        return self.inode.split("-")[0]
+
+
+def parse_fls_rows(fls_text: str) -> list[FlsEntry]:
+    """Parse ``fls -r -p`` output into structured entries.
+
+    Args:
+        fls_text: Raw ``fls`` output, one entry per line.
+
+    Returns:
+        Every entry in the listing, directories included, in file order.
+    """
+    return [
+        FlsEntry(
+            inode=m.group("inode"),
+            path=m.group("path").strip(),
+            deleted=m.group("deleted") is not None,
+            name_type=m.group("name_type"),
+            meta_type=m.group("meta_type"),
+        )
+        for m in FLS_ROW_RE.finditer(fls_text)
+    ]
+
+
+def fls_file_entries(fls_text: str) -> list[FlsEntry]:
+    """Parse ``fls`` output and keep only entries that can hold file content.
+
+    Directories are dropped; everything else -- including entries whose type
+    is unknown (``-``), which is how deleted and orphaned files present -- is
+    kept, because ``icat`` can still read them.
+    """
+    return [e for e in parse_fls_rows(fls_text) if e.meta_type.lower() != "d"]

--- a/src/mulder/server/tools/artifacts.py
+++ b/src/mulder/server/tools/artifacts.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from mulder.path_policy import PathPolicyError, resolve_allowed_path
-from mulder.patterns import parse_mmls_rows
+from mulder.patterns import fls_file_entries, parse_mmls_rows
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import hash_output, make_tool_call_id
@@ -113,17 +113,21 @@ def _resolve_image_and_offset() -> tuple[str, int]:
 _KV_SOURCE_OFFSET_PREFIX = "tsk_source_offset:"
 
 
-def _find_inodes_by_pattern(pattern: str) -> list[tuple[str, str, int]]:
-    """Search all fls listings for files matching a name pattern.
+def _find_inodes_by_path(path_pattern: str) -> list[tuple[str, str, int]]:
+    """Search all fls listings for files whose path matches *path_pattern*.
 
     Searches the primary ``tsk.filelist`` and any secondary partition
     sources (``tsk.filelist.p1``, etc.), returning the correct partition
     offset for each match so callers can extract via ``icat`` with the
     right offset.
 
+    Callers supply only the path pattern. The row grammar of ``fls`` output
+    lives in ``parse_fls_rows`` and is no longer restated at each call site,
+    where six copies of it had all inherited the same two mistakes.
+
     Args:
-        pattern: Regex pattern with at least two capture groups:
-            group(1) = inode string, group(2) = relative path.
+        path_pattern: Regex matched against the entry's path. Anchored at
+            neither end, so a bare filename is a substring match.
 
     Returns:
         List of ``(inode_str, relative_path, partition_offset)`` tuples.
@@ -136,7 +140,7 @@ def _find_inodes_by_pattern(pattern: str) -> list[tuple[str, str, int]]:
     )
 
     _, primary_offset = _resolve_image_and_offset()
-    pat = re.compile(pattern, re.IGNORECASE | re.MULTILINE)
+    pat = re.compile(path_pattern, re.IGNORECASE)
     results: list[tuple[str, str, int]] = []
 
     for src in fls_sources:
@@ -145,10 +149,9 @@ def _find_inodes_by_pattern(pattern: str) -> list[tuple[str, str, int]]:
 
         windows = ctx.db.get_windows_by_source(src.source_name)
         for w in windows:
-            for m in pat.finditer(w.raw_text):
-                inode_str = m.group(1).split("-")[0]
-                rel_path = m.group(2).strip()
-                results.append((inode_str, rel_path, offset))
+            for entry in fls_file_entries(w.raw_text):
+                if pat.search(entry.path):
+                    results.append((entry.base_inode, entry.path, offset))
     return results
 
 
@@ -173,20 +176,17 @@ def parse_browser_history() -> dict[str, object]:
         return {"tool_call_id": tc_id, "status": "error", "error_message": "No disk image indexed"}
 
     browser_patterns = [
-        (r"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.*?/Chrome/.*?/History)\s*$", "chrome"),
-        (
-            r"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.*?/Firefox/Profiles/.*?/places\.sqlite)\s*$",
-            "firefox",
-        ),
-        (r"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.*?/Safari/History\.db)\s*$", "safari"),
-        (r"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.*?/Google/Chrome/.*?/History)\s*$", "chrome"),
+        (r"/Chrome/.*?/History$", "chrome"),
+        (r"/Firefox/Profiles/.*?/places\.sqlite$", "firefox"),
+        (r"/Safari/History\.db$", "safari"),
+        (r"/Google/Chrome/.*?/History$", "chrome"),
     ]
 
     all_results: list[str] = []
 
     with tempfile.TemporaryDirectory(prefix="mulder_browser_") as tmpdir:
         for pattern, browser in browser_patterns:
-            matches = _find_inodes_by_pattern(pattern)
+            matches = _find_inodes_by_path(pattern)
             for inode_str, rel_path, match_offset in matches:
                 db_path = Path(tmpdir) / f"{browser}_{inode_str}.sqlite"
                 if not _icat_extract(image_path, match_offset, inode_str, db_path):
@@ -283,15 +283,14 @@ def parse_plist(plist_filter: str | None = None) -> dict[str, object]:
 
     if plist_filter:
         escaped_filter = re.escape(plist_filter)
-        pattern = rf"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.*?{escaped_filter}.*?\.plist)\s*$"
+        pattern = rf".*?{escaped_filter}.*?\.plist$"
     else:
         pattern = (
-            r"[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+"
-            r"(.*?(?:loginitems|recentitems|wifi|known-networks|"
-            r"SystemVersion|loginwindow|LaunchAgents|LaunchDaemons).*?\.plist)\s*$"
+            r".*?(?:loginitems|recentitems|wifi|known-networks|"
+            r"SystemVersion|loginwindow|LaunchAgents|LaunchDaemons).*?\.plist$"
         )
 
-    matches = _find_inodes_by_pattern(pattern)
+    matches = _find_inodes_by_path(pattern)
     all_results: list[str] = []
 
     with tempfile.TemporaryDirectory(prefix="mulder_plist_") as tmpdir:

--- a/src/mulder/server/tools/extract/app_files.py
+++ b/src/mulder/server/tools/extract/app_files.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 
 import fnmatch
 import logging
-import re
 import shutil
 import subprocess
 import time
 from typing import Any
 
+from mulder.patterns import fls_file_entries
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -57,15 +57,6 @@ _DEFAULT_EXTENSIONS: frozenset[str] = frozenset(
 _ICAT_TIMEOUT = 30
 _MAX_TEXT_BYTES = 512 * 1024
 
-_FLS_ENTRY_RE = re.compile(
-    r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+)\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
-"""Matches fls output entries, capturing inode and relative path."""
-
-_FLS_SIZE_RE = re.compile(r"\t(\d+)\t")
-"""Attempts to extract file size from fls output fields."""
-
 
 def _derive_source_name(directory_pattern: str) -> str:
     """Generate a source identifier from the directory pattern.
@@ -91,7 +82,6 @@ def _find_matching_files(
     fls_chunks: list[str],
     directory_pattern: str,
     extensions: frozenset[str],
-    max_file_size_kb: int,
     offset: int,
 ) -> list[tuple[str, str, int]]:
     """Search TSK file listing for text files under matching directories.
@@ -103,22 +93,24 @@ def _find_matching_files(
         fls_chunks: Text chunks from the TSK file listing.
         directory_pattern: Glob-style directory pattern to match paths.
         extensions: Set of allowed file extensions (lowercase, with dot).
-        max_file_size_kb: Maximum file size threshold in KB.
         offset: Partition sector offset for icat extraction.
+
+    The size threshold is not applied here: ``fls -r -p`` prints no size
+    column (that needs ``fls -l``), so it is enforced on the bytes ``icat``
+    returns instead.
 
     Returns:
         List of ``(inode_str, relative_path, partition_offset)`` tuples
         for files matching the criteria.
     """
     glob_pattern = directory_pattern.lower().replace("\\", "/").rstrip("/") + "/*"
-    max_size_bytes = max_file_size_kb * 1024
     matches: list[tuple[str, str, int]] = []
     seen_inodes: set[str] = set()
 
     for chunk in fls_chunks:
-        for m in _FLS_ENTRY_RE.finditer(chunk):
-            inode_str = m.group(1).split("-")[0]
-            rel_path = m.group(2).strip()
+        for entry in fls_file_entries(chunk):
+            inode_str = entry.base_inode
+            rel_path = entry.path
             rel_lower = rel_path.lower().replace("\\", "/")
 
             if not fnmatch.fnmatch(rel_lower, glob_pattern):
@@ -130,12 +122,6 @@ def _find_matching_files(
             ext = rel_lower[dot_pos:]
             if ext not in extensions:
                 continue
-
-            size_match = _FLS_SIZE_RE.search(m.group(0))
-            if size_match:
-                file_size = int(size_match.group(1))
-                if file_size > max_size_bytes:
-                    continue
 
             dedup_key = f"{offset}:{inode_str}"
             if dedup_key in seen_inodes:
@@ -163,6 +149,7 @@ def _extract_and_read_file(
     image_path: str,
     inode_str: str,
     offset: int,
+    max_size_bytes: int | None = None,
 ) -> str | None:
     """Extract a file via icat and return its text content.
 
@@ -173,6 +160,10 @@ def _extract_and_read_file(
         image_path: Path to the disk image.
         inode_str: TSK inode identifier.
         offset: Partition sector offset.
+        max_size_bytes: Skip the file when it is larger than this. The
+            caller's ``max_file_size_kb`` used to be checked against a size
+            field parsed out of the fls listing, but ``fls -r -p`` emits no
+            size column, so that check could never fire.
 
     Returns:
         Decoded text content or None if extraction fails or file
@@ -197,6 +188,9 @@ def _extract_and_read_file(
         return None
 
     if proc.returncode != 0 or not proc.stdout:
+        return None
+
+    if max_size_bytes is not None and len(proc.stdout) > max_size_bytes:
         return None
 
     if _is_binary_content(proc.stdout):
@@ -282,9 +276,7 @@ def index_app_files(
 
     all_matches: list[tuple[str, str, int]] = []
     for chunks, offset in chunk_groups:
-        matches = _find_matching_files(
-            chunks, directory_pattern, ext_set, max_file_size_kb, offset
-        )
+        matches = _find_matching_files(chunks, directory_pattern, ext_set, offset)
         all_matches.extend(matches)
 
     if not all_matches:
@@ -315,7 +307,7 @@ def index_app_files(
     skipped_binary = 0
 
     for inode_str, rel_path, offset in capped:
-        content = _extract_and_read_file(image_path, inode_str, offset)
+        content = _extract_and_read_file(image_path, inode_str, offset, max_file_size_kb * 1024)
         if content is None:
             skipped_binary += 1
             continue

--- a/src/mulder/server/tools/extract/disk_pcap.py
+++ b/src/mulder/server/tools/extract/disk_pcap.py
@@ -8,13 +8,13 @@ credential extraction for cleartext protocols.
 from __future__ import annotations
 
 import logging
-import re
 import subprocess
 import tempfile
 import time
 from pathlib import Path
 from typing import Any
 
+from mulder.patterns import fls_file_entries
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -41,13 +41,6 @@ _PCAP_EXTENSIONS: frozenset[str] = frozenset(
         ".snoop",
     }
 )
-
-_PCAP_FILENAME_RE = re.compile(
-    r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+"
-    r"(.+\.(?:cap|pcap|pcapng|eth|snoop))\s*$",
-    re.IGNORECASE | re.MULTILINE,
-)
-"""Matches fls entries with recognized packet capture extensions."""
 
 _ICAT_TIMEOUT = 60
 _TSHARK_TIMEOUT = 120
@@ -84,9 +77,12 @@ def _discover_pcap_files(
     seen: set[str] = set()
 
     for chunk in fls_chunks:
-        for m in _PCAP_FILENAME_RE.finditer(chunk):
-            inode_str = m.group(1).split("-")[0]
-            rel_path = m.group(2).strip()
+        for entry in fls_file_entries(chunk):
+            rel_path = entry.path
+            dot = rel_path.rfind(".")
+            if dot < 0 or rel_path[dot:].lower() not in _PCAP_EXTENSIONS:
+                continue
+            inode_str = entry.base_inode
 
             dedup_key = f"{offset}:{inode_str}"
             if dedup_key in seen:

--- a/src/mulder/server/tools/extract/evtx.py
+++ b/src/mulder/server/tools/extract/evtx.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import atexit
 import contextlib
 import logging
-import re
 import shutil
 import subprocess
 import tempfile
@@ -14,6 +13,7 @@ import time
 from pathlib import Path
 from typing import cast
 
+from mulder.patterns import fls_file_entries
 from mulder.server.app import get_cfg, get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -66,22 +66,19 @@ def _extract_evtx_from_image(image_path: str, dest_dir: str) -> list[Path]:
     if not chunk_groups:
         return []
 
-    evtx_re = re.compile(
-        r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+\.evtx)\s*$", re.IGNORECASE | re.MULTILINE
-    )
-
     extracted: list[Path] = []
     seen: set[str] = set()
     for chunks, offset in chunk_groups:
         for chunk in chunks:
-            for m in evtx_re.finditer(chunk):
-                inode_str = m.group(1).split("-")[0]
+            for entry in fls_file_entries(chunk):
+                if not entry.path.lower().endswith(".evtx"):
+                    continue
+                inode_str = entry.base_inode
                 dedup_key = f"{offset}:{inode_str}"
                 if dedup_key in seen:
                     continue
                 seen.add(dedup_key)
-                rel_path = m.group(2).strip()
-                safe_name = rel_path.replace("/", "_").replace("\\", "_")
+                safe_name = entry.path.replace("/", "_").replace("\\", "_")
                 out_path = Path(dest_dir) / safe_name
                 cmd = ["icat"]
                 if offset > 0:

--- a/src/mulder/server/tools/extract/registry.py
+++ b/src/mulder/server/tools/extract/registry.py
@@ -10,6 +10,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from mulder.patterns import fls_file_entries
 from mulder.server.app import mcp
 from mulder.server.extract_helpers import extract_and_index, mount_disk_image
 from mulder.server.helpers import (
@@ -153,11 +154,6 @@ def _discover_user_hives_via_tsk(
     if not chunk_groups:
         return [], None
 
-    inode_re = re.compile(
-        r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+)\s*$",
-        re.IGNORECASE | re.MULTILINE,
-    )
-
     ntuser_patterns = [
         "documents and settings/",
         "users/",
@@ -171,9 +167,9 @@ def _discover_user_hives_via_tsk(
 
     for chunks, chunk_offset in chunk_groups:
         for chunk in chunks:
-            for m in inode_re.finditer(chunk):
-                inode_str = m.group(1).split("-")[0]
-                rel_path = m.group(2).strip()
+            for entry in fls_file_entries(chunk):
+                inode_str = entry.base_inode
+                rel_path = entry.path
                 rel_lower = rel_path.lower().replace("\\", "/")
 
                 hive_type: str | None = None

--- a/src/mulder/server/tools/extract/tsk.py
+++ b/src/mulder/server/tools/extract/tsk.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import re
 import shutil
 import subprocess
 import tempfile
@@ -12,7 +11,7 @@ import threading
 import time
 from pathlib import Path
 
-from mulder.patterns import parse_mmls_rows
+from mulder.patterns import fls_file_entries, parse_mmls_rows
 from mulder.server.app import get_ctx, mcp
 from mulder.server.extract_helpers import extract_and_index
 from mulder.server.helpers import (
@@ -401,20 +400,15 @@ def _tsk_extract_files(
         return []
 
     ctx = get_ctx()
-    inode_re = re.compile(
-        r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+)\s*$",
-        re.IGNORECASE | re.MULTILINE,
-    )
-
     extract_dir: Path | None = None
     extracted: list[tuple[str, Path]] = []
     seen: set[str] = set()
 
     for chunks, offset in chunk_groups:
         for chunk in chunks:
-            for m in inode_re.finditer(chunk):
-                inode_str = m.group(1).split("-")[0]
-                rel_path = m.group(2).strip()
+            for entry in fls_file_entries(chunk):
+                inode_str = entry.base_inode
+                rel_path = entry.path
                 rel_lower = rel_path.lower().replace("\\", "/")
 
                 if not any(pat.lower() in rel_lower for pat in path_patterns):

--- a/tests/test_app_files.py
+++ b/tests/test_app_files.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from mulder.server.tools.extract.app_files import (
     _DEFAULT_EXTENSIONS,
     _derive_source_name,
+    _extract_and_read_file,
     _find_matching_files,
     _is_binary_content,
 )
@@ -47,7 +48,6 @@ class TestFindMatchingFiles:
             [_SAMPLE_FLS],
             "Program Files/mIRC",
             frozenset({".ini"}),
-            max_file_size_kb=512,
             offset=0,
         )
         paths = [m[1] for m in matches]
@@ -63,7 +63,6 @@ class TestFindMatchingFiles:
             [_SAMPLE_FLS],
             "Program Files/mIRC",
             _DEFAULT_EXTENSIONS,
-            max_file_size_kb=512,
             offset=0,
         )
         paths = [m[1] for m in matches]
@@ -80,7 +79,6 @@ class TestFindMatchingFiles:
             [_MULTI_USER_FLS],
             "Documents and Settings/*/Application Data/Thunderbird",
             frozenset({".ini", ".cfg", ".txt"}),
-            max_file_size_kb=512,
             offset=0,
         )
         paths = [m[1] for m in matches]
@@ -101,7 +99,6 @@ class TestFindMatchingFiles:
             [fls],
             "AppDir",
             frozenset({".sqlite", ".db"}),
-            max_file_size_kb=512,
             offset=0,
         )
         paths = [m[1] for m in matches]
@@ -110,8 +107,14 @@ class TestFindMatchingFiles:
         assert "AppDir/cache.db" in paths
         assert "AppDir/config.ini" not in paths
 
-    def test_size_limit_with_tab_delimited_sizes(self) -> None:
-        """Files with tab-delimited sizes above threshold are excluded."""
+    def test_listing_alone_cannot_apply_a_size_limit(self) -> None:
+        """``fls -r -p`` prints no size column, so discovery cannot filter.
+
+        This test previously claimed sizes "above threshold are excluded"
+        while asserting all three files matched -- because the size check
+        read a ``\\t(\\d+)\\t`` field that this output never contains. The
+        threshold is now applied to the bytes ``icat`` actually returns.
+        """
         fls = (
             "r/r 4001:\tSmallDir/small.txt\n"
             "r/r 4002:\tSmallDir/medium.txt\n"
@@ -121,7 +124,6 @@ class TestFindMatchingFiles:
             [fls],
             "SmallDir",
             frozenset({".txt"}),
-            max_file_size_kb=512,
             offset=0,
         )
         assert len(matches) == 3
@@ -134,7 +136,6 @@ class TestFindMatchingFiles:
             [_SAMPLE_FLS],
             "NonExistent/Directory",
             _DEFAULT_EXTENSIONS,
-            max_file_size_kb=512,
             offset=0,
         )
         assert matches == []
@@ -146,7 +147,6 @@ class TestFindMatchingFiles:
             [duplicate_fls],
             "AppDir",
             frozenset({".ini"}),
-            max_file_size_kb=512,
             offset=0,
         )
         assert len(matches) == 1
@@ -158,7 +158,6 @@ class TestFindMatchingFiles:
             [fls],
             "program files/myapp",
             frozenset({".ini"}),
-            max_file_size_kb=512,
             offset=0,
         )
         assert len(matches) == 1
@@ -396,3 +395,73 @@ class TestIndexAppFilesTool:
         assert result["status"] == "success"
         assert result["results"]["files_discovered"] == 2
         assert ".ini" not in str(result["results"]["sample_files"])
+
+
+class TestDeletedFilesAreDiscovered:
+    """Deleted files are what an examiner is looking for.
+
+    The previous ``[rd]/[rd*]`` row regex expected a digit where ``fls``
+    prints the ``*`` deleted marker, so every deleted entry was skipped
+    silently -- undeleted siblings in the same directory still matched.
+    """
+
+    #: Genuine ``fls -r -p`` output (TSK 4.12.1); inode 16 is deleted.
+    REAL_FLS = (
+        "r/r 15:\tUsers/alice/notes.txt\n"
+        "r/r * 16:\tUsers/alice/deleted_notes.txt\n"
+        "l/l 17:\tUsers/alice/link.txt\n"
+    )
+
+    def test_a_deleted_file_is_returned(self) -> None:
+        matches = _find_matching_files(
+            [self.REAL_FLS], "Users/alice", frozenset({".txt"}), offset=0
+        )
+        paths = [m[1] for m in matches]
+
+        assert "Users/alice/deleted_notes.txt" in paths
+        assert "Users/alice/notes.txt" in paths
+
+    def test_the_deleted_files_inode_is_usable_by_icat(self) -> None:
+        """A path is no use without the inode ``icat`` needs to read it."""
+        matches = _find_matching_files(
+            [self.REAL_FLS], "Users/alice", frozenset({".txt"}), offset=0
+        )
+        inodes = {path: inode for inode, path, _ in matches}
+
+        assert inodes["Users/alice/deleted_notes.txt"] == "16"
+
+
+class TestSizeLimitAppliesToExtractedBytes:
+    """The threshold now runs where the size is actually known."""
+
+    def _icat_returning(self, payload: bytes) -> Any:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = payload
+        return proc
+
+    def test_a_file_over_the_limit_is_skipped(self) -> None:
+        big = b"A" * 4096
+        with (
+            patch("mulder.server.tools.extract.app_files.shutil.which", return_value="/bin/icat"),
+            patch(
+                "mulder.server.tools.extract.app_files.subprocess.run",
+                return_value=self._icat_returning(big),
+            ),
+        ):
+            content = _extract_and_read_file("/img.dd", "16", 0, max_size_bytes=1024)
+
+        assert content is None
+
+    def test_a_file_under_the_limit_is_read(self) -> None:
+        small = b"hello evidence"
+        with (
+            patch("mulder.server.tools.extract.app_files.shutil.which", return_value="/bin/icat"),
+            patch(
+                "mulder.server.tools.extract.app_files.subprocess.run",
+                return_value=self._icat_returning(small),
+            ),
+        ):
+            content = _extract_and_read_file("/img.dd", "16", 0, max_size_bytes=1024)
+
+        assert content == "hello evidence"

--- a/tests/test_evtx_deleted_extraction.py
+++ b/tests/test_evtx_deleted_extraction.py
@@ -1,0 +1,116 @@
+"""A deleted Security.evtx must still be extracted from a disk image.
+
+This is the user-visible consequence of the fls row-regex bug, exercised
+through ``_extract_evtx_from_image`` -- whose signature this fix does not
+change, so these tests run unmodified against ``origin/main`` and fail there
+on the assertion rather than on an import or a signature mismatch.
+
+Clearing the Windows Security log is a standard anti-forensic step; the
+cleared original is often recoverable as a deleted entry. Missing it is
+exactly the evidence an examiner came for.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.tools.extract.evtx import _extract_evtx_from_image
+
+#: Genuine ``fls -r -p`` output (TSK 4.12.1). Inode 22 is deleted.
+FLS_WITH_DELETED_EVTX = (
+    "d/d 20:\tWindows/System32/winevt\n"
+    "d/d 21:\tWindows/System32/winevt/Logs\n"
+    "r/r * 22:\tWindows/System32/winevt/Logs/Deleted.evtx\n"
+    "r/r 23:\tWindows/System32/winevt/Logs/Security.evtx\n"
+)
+
+
+@pytest.fixture
+def icat_calls(tmp_path: Path) -> list[list[str]]:
+    """Record the argv of every icat invocation."""
+    return []
+
+
+def _run_extraction(dest: Path, calls: list[list[str]]) -> list[Path]:
+    def fake_run(cmd: list[str], **_: object) -> MagicMock:
+        calls.append(cmd)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = b"ElfFile\x00evtx-bytes"
+        return proc
+
+    with (
+        patch(
+            "mulder.server.tools.extract.evtx._collect_fls_chunks",
+            return_value=[([FLS_WITH_DELETED_EVTX], 0)],
+        ),
+        patch("mulder.server.tools.extract.evtx.subprocess.run", side_effect=fake_run),
+    ):
+        return _extract_evtx_from_image("/evidence/disk.dd", str(dest))
+
+
+def test_a_deleted_evtx_is_extracted(tmp_path: Path, icat_calls: list[list[str]]) -> None:
+    """The bug: the deleted log was skipped while its sibling was extracted."""
+    extracted = _run_extraction(tmp_path, icat_calls)
+    names = {p.name for p in extracted}
+
+    assert "Windows_System32_winevt_Logs_Deleted.evtx" in names
+
+
+def test_icat_is_asked_for_the_deleted_inode(tmp_path: Path, icat_calls: list[list[str]]) -> None:
+    """Proves the inode reached ``icat``, not merely that a name was listed."""
+    _run_extraction(tmp_path, icat_calls)
+    inodes = {cmd[-1] for cmd in icat_calls}
+
+    assert "22" in inodes, f"icat was never asked for the deleted inode: {icat_calls}"
+
+
+def test_the_undeleted_sibling_still_works(tmp_path: Path, icat_calls: list[list[str]]) -> None:
+    """Narrowness: the entries that already worked must keep working.
+
+    This is why the loss was silent -- Security.evtx in the same directory
+    matched fine, so the extraction looked successful.
+    """
+    extracted = _run_extraction(tmp_path, icat_calls)
+    names = {p.name for p in extracted}
+
+    assert "Windows_System32_winevt_Logs_Security.evtx" in names
+
+
+def test_directories_are_not_extracted(tmp_path: Path, icat_calls: list[list[str]]) -> None:
+    """Narrowness: the ``Logs`` directory itself is not a file."""
+    _run_extraction(tmp_path, icat_calls)
+    inodes = {cmd[-1] for cmd in icat_calls}
+
+    assert "21" not in inodes
+    assert "20" not in inodes
+
+
+def test_a_timeout_on_one_file_does_not_abort_the_rest(tmp_path: Path) -> None:
+    """Unchanged behaviour: one bad icat must not lose the other logs."""
+    seen: list[str] = []
+
+    def flaky(cmd: list[str], **_: object) -> MagicMock:
+        seen.append(cmd[-1])
+        if cmd[-1] == "22":
+            raise subprocess.TimeoutExpired(cmd, 30)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = b"ElfFile\x00"
+        return proc
+
+    with (
+        patch(
+            "mulder.server.tools.extract.evtx._collect_fls_chunks",
+            return_value=[([FLS_WITH_DELETED_EVTX], 0)],
+        ),
+        patch("mulder.server.tools.extract.evtx.subprocess.run", side_effect=flaky),
+    ):
+        extracted = _extract_evtx_from_image("/evidence/disk.dd", str(tmp_path))
+
+    assert "22" in seen
+    assert {p.name for p in extracted} == {"Windows_System32_winevt_Logs_Security.evtx"}

--- a/tests/test_fls_parsing.py
+++ b/tests/test_fls_parsing.py
@@ -1,0 +1,140 @@
+"""Every fls-driven extractor must see deleted files.
+
+``fls`` marks a deleted entry with a ``*`` token placed *after* the type pair
+and *before* the inode::
+
+    r/r * 22:\tWindows/System32/winevt/Logs/Deleted.evtx
+
+Eleven copies of a row regex spelled that as ``[rd]/[rd*]`` -- treating ``*``
+as a character *inside* the type pair -- so the pattern expected a digit where
+the real output has ``*`` and every deleted entry failed to match. The same
+spelling also restricted the type characters to ``r`` and ``d``, dropping
+symlinks (``l/l``) and the virtual ``$OrphanFiles`` node (``V/V``) that holds
+recovered deleted content.
+
+The fixture below is genuine output from The Sleuth Kit 4.12.1 (``fls -r -p``)
+against a purpose-built ext4 image containing two deleted files.
+"""
+
+from __future__ import annotations
+
+import re
+
+from mulder.patterns import FLS_ROW_RE, fls_file_entries, parse_fls_rows
+
+#: Verbatim ``fls -r -p`` output from TSK 4.12.1.
+REAL_FLS_OUTPUT = (
+    "d/d 13:\tUsers\n"
+    "d/d 14:\tUsers/alice\n"
+    "r/r 15:\tUsers/alice/NTUSER.DAT\n"
+    "r/r * 16:\tUsers/alice/capture.pcap\n"
+    "l/l 17:\tUsers/alice/link_to_passwd\n"
+    "d/d 11:\tlost+found\n"
+    "d/d 18:\tWindows\n"
+    "d/d 19:\tWindows/System32\n"
+    "d/d 20:\tWindows/System32/winevt\n"
+    "d/d 21:\tWindows/System32/winevt/Logs\n"
+    "r/r * 22:\tWindows/System32/winevt/Logs/Deleted.evtx\n"
+    "r/r 23:\tWindows/System32/winevt/Logs/Security.evtx\n"
+    "r/r 24:\tWindows/System32/winevt/Logs/System.evtx\n"
+    "V/V 1025:\t$OrphanFiles\n"
+)
+
+#: The regex spelling this fix replaces, kept so the tests can prove the bug.
+OLD_ROW_RE = re.compile(
+    r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def test_a_deleted_file_is_parsed() -> None:
+    """The bug: deleted entries were invisible to every extractor."""
+    paths = {e.path for e in parse_fls_rows(REAL_FLS_OUTPUT)}
+
+    assert "Windows/System32/winevt/Logs/Deleted.evtx" in paths
+    assert "Users/alice/capture.pcap" in paths
+
+
+def test_deleted_entries_are_flagged_as_deleted() -> None:
+    """The ``*`` token is data, not noise -- callers may need to report it."""
+    by_path = {e.path: e for e in parse_fls_rows(REAL_FLS_OUTPUT)}
+
+    assert by_path["Windows/System32/winevt/Logs/Deleted.evtx"].deleted is True
+    assert by_path["Users/alice/capture.pcap"].deleted is True
+    assert by_path["Windows/System32/winevt/Logs/Security.evtx"].deleted is False
+
+
+def test_the_old_spelling_really_did_miss_them() -> None:
+    """Pins the premise: this is what the eleven copies actually did.
+
+    If this ever fails, the bug being fixed was not the bug described.
+    """
+    old_paths = {m.group(2).strip() for m in OLD_ROW_RE.finditer(REAL_FLS_OUTPUT)}
+
+    assert "Windows/System32/winevt/Logs/Deleted.evtx" not in old_paths
+    assert "Users/alice/capture.pcap" not in old_paths
+    # ...while the undeleted sibling in the same directory matched fine,
+    # which is why the loss was silent.
+    assert "Windows/System32/winevt/Logs/Security.evtx" in old_paths
+
+
+def test_non_rd_type_characters_are_parsed() -> None:
+    """Symlinks and the virtual $OrphanFiles node were dropped by ``[rd]``."""
+    by_path = {e.path: e for e in parse_fls_rows(REAL_FLS_OUTPUT)}
+
+    assert by_path["Users/alice/link_to_passwd"].meta_type == "l"
+    assert by_path["$OrphanFiles"].meta_type == "V"
+
+
+def test_every_row_of_real_output_is_parsed() -> None:
+    """No row of genuine TSK output may be silently skipped."""
+    expected = {line.split(":\t", 1)[1] for line in REAL_FLS_OUTPUT.splitlines()}
+    got = {e.path for e in parse_fls_rows(REAL_FLS_OUTPUT)}
+
+    assert got == expected
+
+
+def test_directories_are_dropped_from_file_entries() -> None:
+    """``fls_file_entries`` is the extractor-facing view: content only."""
+    entries = fls_file_entries(REAL_FLS_OUTPUT)
+    paths = {e.path for e in entries}
+
+    assert "Users/alice/NTUSER.DAT" in paths
+    assert "Windows/System32/winevt/Logs/Deleted.evtx" in paths
+    assert "Windows/System32/winevt/Logs" not in paths
+    assert "Users" not in paths
+
+
+def test_ntfs_attribute_inodes_are_reduced_for_icat() -> None:
+    """NTFS inodes print as ``inode-type-id``; ``icat`` wants the base."""
+    ntfs = "r/r * 6083-128-1:\tUsers/bob/secret.docx\n"
+    (entry,) = parse_fls_rows(ntfs)
+
+    assert entry.inode == "6083-128-1"
+    assert entry.base_inode == "6083"
+    assert entry.deleted is True
+
+
+def test_a_path_containing_spaces_survives() -> None:
+    """The inode/path separator is a tab, so spaces in names are safe."""
+    row = "r/r 42:\tDocuments and Settings/All Users/My Notes.txt\n"
+    (entry,) = parse_fls_rows(row)
+
+    assert entry.path == "Documents and Settings/All Users/My Notes.txt"
+
+
+def test_the_parser_does_not_over_match() -> None:
+    """Narrowness: prose and bodyfile lines must not be read as entries."""
+    noise = (
+        "Processing image /evidence/disk.dd\n"
+        "0|/Users/alice|15|r/rrwxrwxrwx|0|0|1024|1700000000\n"
+        "r/r not-an-inode:\tnope\n"
+        "\n"
+    )
+
+    assert parse_fls_rows(noise) == []
+
+
+def test_fls_row_re_is_multiline() -> None:
+    """The parser is handed multi-row chunks, not single lines."""
+    assert FLS_ROW_RE.flags & re.MULTILINE


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- **Every fls-driven extractor silently skips deleted files.** Deleted files are the evidence an examiner came for — a cleared `Security.evtx`, recoverable as a deleted entry, was never handed to `icat`.
- Root cause: `fls` prints the deleted marker as a **separate `*` token after the type pair**, before the inode. Eleven copies of a row regex across six modules spelled that as `[rd]/[rd*]`, treating `*` as a character *inside* the type pair — so the pattern expected a digit where real output has `*`.
- The loss was **silent**: undeleted files in the same directory matched fine, so extraction looked successful.
- The same spelling also restricted types to `r` and `d`, dropping symlinks (`l/l`) and the virtual `$OrphanFiles` node (`V/V`) that holds recovered deleted content.
- Fix: one `parse_fls_rows` in `mulder/patterns.py`, mirroring the `parse_mmls_rows` merged in #68, with all eleven call sites pointed at it.

## The bug

Genuine `fls -r -p` output, The Sleuth Kit 4.12.1, from a purpose-built ext4 image with two deleted files:

```
d/d 13:	Users
d/d 14:	Users/alice
r/r 15:	Users/alice/NTUSER.DAT
r/r * 16:	Users/alice/capture.pcap
l/l 17:	Users/alice/link_to_passwd
d/d 11:	lost+found
d/d 18:	Windows
d/d 19:	Windows/System32
d/d 20:	Windows/System32/winevt
d/d 21:	Windows/System32/winevt/Logs
r/r * 22:	Windows/System32/winevt/Logs/Deleted.evtx
r/r 23:	Windows/System32/winevt/Logs/Security.evtx
r/r 24:	Windows/System32/winevt/Logs/System.evtx
V/V 1025:	$OrphanFiles
```

The regex, repeated eleven times:

```python
r"^[rd]/[rd*]\s+(\d+(?:-\d+-\d+)?):\s+(.+)\s*$"
```

Run against that output, it matches ten of the fourteen rows and misses:

```
$OrphanFiles
Users/alice/capture.pcap                          <- deleted
Users/alice/link_to_passwd                        <- symlink
Windows/System32/winevt/Logs/Deleted.evtx         <- deleted
```

`Security.evtx` and `System.evtx` in the same directory matched, which is why nothing ever looked wrong.

The eleven copies, all identical in substance:

```
src/mulder/server/tools/artifacts.py            (6 copies: browser history x4, plist x2)
src/mulder/server/tools/extract/registry.py     (1)
src/mulder/server/tools/extract/disk_pcap.py    (1)
src/mulder/server/tools/extract/app_files.py    (1)
src/mulder/server/tools/extract/evtx.py         (1)
src/mulder/server/tools/extract/tsk.py          (1)
```

## The fix

One parser in `mulder/patterns.py`, directly alongside `parse_mmls_rows`:

```python
FLS_ROW_RE: re.Pattern[str] = re.compile(
    r"^(?P<name_type>[A-Za-z\-])/(?P<meta_type>[A-Za-z\-])\s+"
    r"(?P<deleted>\*\s+)?"
    r"(?P<inode>\d+(?:-\d+-\d+)?):\t"
    r"(?P<path>.+?)\s*$",
    re.MULTILINE,
)
```

`FlsEntry` carries `deleted` as data rather than discarding it, and exposes `base_inode` (the NTFS `6083-128-1` form reduced to `6083`, which is what `icat` wants). `fls_file_entries` is the extractor-facing view: directories dropped, everything else kept — including `-` (unknown) types, which is how orphaned files present.

The separator between inode and path is a literal tab, which is what makes paths containing spaces safe to parse.

In `artifacts.py`, `_find_inodes_by_pattern` becomes `_find_inodes_by_path` — callers now pass only a path pattern:

```python
    browser_patterns = [
        (r"/Chrome/.*?/History$", "chrome"),
        (r"/Firefox/Profiles/.*?/places\.sqlite$", "firefox"),
        (r"/Safari/History\.db$", "safari"),
        (r"/Google/Chrome/.*?/History$", "chrome"),
    ]
```

The row grammar is stated once, so a future fix lands in one place.

### One adjacent dead check, removed

`app_files.py` filtered by size using `_FLS_SIZE_RE = re.compile(r"\t(\d+)\t")` against the fls listing. `fls -r -p` emits **no size column** — every row has exactly one tab — so `max_file_size_kb` could never fire. Verified against the real output above: zero matches.

Removing the duplicated row regex forces the issue, so leaving a provably-dead filter in place was not an option. The threshold now applies to the bytes `icat` returns, where the size is actually known. The repo's own test documented the inertness — `test_size_limit_with_tab_delimited_sizes` asserted all three files matched despite its name — and is renamed to say what it checks.

## Deliberately out of scope

- **`fls -r -m` bodyfile output** (`run_mactime`) is a different, pipe-delimited format and is untouched.
- **The mmls parser** is #68's concern, already merged; `disk.py` and `server/tools/tsk.py` needed no change here.
- **No framework, no new abstraction** beyond the single parser function, and no second status taxonomy.

## Verification

- **Real-tool grounding:** built an ext4 image with `mkfs.ext4 -d`, deleted two files with `debugfs` (no mount, no root), and ran the real `fls` from The Sleuth Kit 4.12.1. Both the broken and fixed patterns were run against that captured output; the fixture in `tests/test_fls_parsing.py` is that output verbatim.
- `uvx pre-commit run --all-files` — ruff, ruff-format, mypy all pass. (Staged first: `--all-files` enumerates via `git ls-files` and cannot see untracked files.)
- `pytest tests/ -q` — **874 passed, 0 failed.** No deselect was needed; `test_disk_pcap.py::...::test_size_filtering_skips_large_pcaps` passes here, so this branch is green on the full suite.
- **Premise check** — with `src/mulder/server/tools/extract/evtx.py` restored to `origin/main` and the new tests kept, the behavioural tests fail on the assertion (not on an import or signature mismatch, because `_extract_evtx_from_image`'s signature is unchanged):

```
FAILED tests/test_evtx_deleted_extraction.py::test_a_deleted_evtx_is_extracted
E   AssertionError: assert 'Windows_System32_winevt_Logs_Deleted.evtx' in {'Windows_System32_winevt_Logs_Security.evtx'}

FAILED tests/test_evtx_deleted_extraction.py::test_icat_is_asked_for_the_deleted_inode
E   AssertionError: icat was never asked for the deleted inode: [['icat', '/evidence/disk.dd', '23']]
    assert '22' in {'23'}

FAILED tests/test_evtx_deleted_extraction.py::test_a_timeout_on_one_file_does_not_abort_the_rest
E   AssertionError: assert '22' in ['23']

3 failed, 2 passed
```

The two that pass on both trees are the narrowness tests — the undeleted sibling still extracts, directories still are not — so they pin the fix rather than the bug. `test_the_old_spelling_really_did_miss_them` embeds the previous regex directly, so the premise stays pinned even after the old spelling is gone from the tree.

## Context

Recovered from closed PR #77. That branch was stacked on #68 and carried its mmls work; **#68 has since merged**, so this is rebuilt fresh from current `main` (`2e5432c`) with only the fls half — and re-verified against the real tool rather than cherry-picked.

This is the same shape as #68, which was merged: one shared parser replacing duplicated regexes that had each inherited the same misreading of a TSK output format. It is a single concern, not a framework. Checked against all fifteen open PRs: only #86 touches `artifacts.py`, for read-only SQLite URI escaping — a disjoint concern, different lines, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
