### PR TITLE
[high] fix(chainsaw): make the SRUM invocation match the CLI analyse srum declares

### DIFF
--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -208,13 +208,22 @@ def _run_chainsaw_search(
 
 
 def _run_chainsaw_srum(
-    binary: str, srum_path: Path, output_dir: Path, timeout: int = _CHAINSAW_TIMEOUT
+    binary: str,
+    srum_path: Path,
+    software_hive_path: Path,
+    output_dir: Path,
+    timeout: int = _CHAINSAW_TIMEOUT,
 ) -> Path:
     """Execute Chainsaw SRUM parsing mode.
+
+    ``analyse srum`` takes neither ``--json`` (it always writes JSON to
+    ``--output``) nor a bare database path: it requires the SOFTWARE hive to
+    resolve the SRUM extension GUIDs into table names.
 
     Args:
         binary: Resolved Chainsaw executable.
         srum_path: Path to the SRUDB.dat file.
+        software_hive_path: Path to the SOFTWARE registry hive.
         output_dir: Output directory for results.
         timeout: Subprocess timeout in seconds.
 
@@ -230,7 +239,8 @@ def _run_chainsaw_srum(
         "analyse",
         "srum",
         str(srum_path),
-        "--json",
+        "--software",
+        str(software_hive_path),
         "--output",
         str(output_file),
     ]
@@ -419,6 +429,7 @@ def run_chainsaw(
     evidence_path: str,
     mode: Literal["hunt", "search", "srum", "timeline"] = "hunt",
     sigma_rules_path: str = "",
+    software_hive_path: str = "",
     search_term: str | None = None,
     time_range_start: str | None = None,
     time_range_end: str | None = None,
@@ -440,6 +451,9 @@ def run_chainsaw(
             "timeline" dumps all events chronologically.
         sigma_rules_path: Path to the Sigma rules directory. Empty
             resolves to the rules installed by 'mulder setup'.
+        software_hive_path: Path to the SOFTWARE registry hive. Required
+            when mode="srum"; Chainsaw needs it to resolve the SRUM
+            extension GUIDs into table names.
         search_term: Required when mode="search". The keyword or
             regex pattern to search for in EVTX records.
         time_range_start: Optional ISO 8601 timestamp to filter results
@@ -454,6 +468,7 @@ def run_chainsaw(
         "evidence_path": evidence_path,
         "mode": mode,
         "sigma_rules_path": sigma_rules_path,
+        "software_hive_path": software_hive_path,
         "search_term": search_term,
         "time_range_start": time_range_start,
         "time_range_end": time_range_end,
@@ -511,6 +526,25 @@ def run_chainsaw(
             error_type="invalid_argument",
         )
 
+    if mode == "srum":
+        if not software_hive_path:
+            return error_response(
+                tc_id,
+                "run_chainsaw",
+                params,
+                "software_hive_path is required when mode='srum': Chainsaw "
+                "needs the SOFTWARE hive to resolve the SRUM extension GUIDs",
+                error_type="invalid_argument",
+            )
+        if not Path(software_hive_path).exists():
+            return error_response(
+                tc_id,
+                "run_chainsaw",
+                params,
+                f"SOFTWARE hive not found: {software_hive_path}",
+                error_type="file_not_found",
+            )
+
     rules = Path(sigma_rules_path) if sigma_rules_path else _default_sigma_rules()
 
     timeout = adaptive_timeout(evidence_path, base=_CHAINSAW_TIMEOUT)
@@ -544,7 +578,11 @@ def run_chainsaw(
                 source_name = "chainsaw.search"
             elif mode == "srum":
                 results_path = _run_chainsaw_srum(
-                    binary, Path(evidence_path), output_dir, timeout=timeout
+                    binary,
+                    Path(evidence_path),
+                    Path(software_hive_path),
+                    output_dir,
+                    timeout=timeout,
                 )
                 result = _parse_chainsaw_srum_results(results_path)
                 source_name = "chainsaw.srum"

--- a/tests/test_chainsaw_srum_cli.py
+++ b/tests/test_chainsaw_srum_cli.py
@@ -1,0 +1,195 @@
+"""Chainsaw's SRUM invocation must match the CLI ``analyse srum`` declares.
+
+``_run_chainsaw_srum`` built ``chainsaw analyse srum <SRUDB.dat> --json
+--output <file>``.  Two things are wrong with that line, and either alone is
+fatal.  Verified against the pinned release, chainsaw 2.16.0::
+
+    $ chainsaw analyse srum ./evidence/SRUDB.dat --json --output srum.json
+    error: unexpected argument '--json' found
+    Usage: chainsaw analyse srum --software <SOFTWARE_HIVE_PATH> <SRUM_PATH>
+    (exit 2)
+
+1. ``--json`` is not an option of ``analyse srum`` at all.  The subcommand
+   always writes JSON to ``--output`` (``cs_print_json!`` in chainsaw's
+   ``main.rs``), so there is no format flag to pass.
+2. ``--software <SOFTWARE_HIVE_PATH>`` is **required** -- Chainsaw needs the
+   SOFTWARE hive to resolve the SRUM extension GUIDs into table names.
+
+They are fixed together because they are one argv, and correcting either alone
+leaves SRUM parsing still failing at parse time with exit 2.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.chainsaw import run_chainsaw
+
+
+@pytest.fixture
+def srum_db(tmp_path: Path) -> Path:
+    path = tmp_path / "SRUDB.dat"
+    path.write_bytes(b"\x00" * 16)
+    return path
+
+
+@pytest.fixture
+def software_hive(tmp_path: Path) -> Path:
+    path = tmp_path / "SOFTWARE"
+    path.write_bytes(b"regf")
+    return path
+
+
+def _srum_argv(srum_db: Path, hive: Path) -> list[str]:
+    """Run srum mode with Chainsaw mocked, and return the argv it built."""
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(srum_db),
+            mode="srum",
+            software_hive_path=str(hive),
+        )
+
+    assert calls, "Chainsaw was never invoked"
+    return calls[0]
+
+
+def test_srum_passes_the_required_software_hive(srum_db: Path, software_hive: Path) -> None:
+    """``--software`` is mandatory; without it chainsaw 2.16.0 exits 2."""
+    argv = _srum_argv(srum_db, software_hive)
+
+    assert "--software" in argv, f"chainsaw 2.16.0 exits 2 on this argv: {argv}"
+    assert argv[argv.index("--software") + 1] == str(software_hive)
+
+
+def test_srum_does_not_pass_the_json_flag_it_rejects(srum_db: Path, software_hive: Path) -> None:
+    """``analyse srum`` has no ``--json``; passing it is an immediate exit 2.
+
+    The subcommand always writes JSON to ``--output``, so dropping the flag
+    loses nothing -- ``_parse_chainsaw_srum_results`` still reads JSON.
+    """
+    argv = _srum_argv(srum_db, software_hive)
+
+    assert "--json" not in argv, f"chainsaw rejects '--json' for analyse srum; argv was {argv}"
+    assert "--output" in argv
+
+
+def test_srum_never_reaches_chainsaw_carrying_json(srum_db: Path) -> None:
+    """The ``--json`` defect, provable without the new parameter.
+
+    Called the way unmodified ``main`` allows -- srum mode, no hive -- the old
+    code builds ``analyse srum <db> --json --output <f>`` and hands it to
+    chainsaw, which exits 2 on the unexpected ``--json``.  The fixed code never
+    reaches ``subprocess.run`` at all, because it asks for the hive first.
+
+    Either way the invariant is the same and is asserted directly: chainsaw is
+    never invoked with a flag its ``analyse srum`` subcommand rejects.
+    """
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        run_chainsaw.__wrapped__(str(srum_db), mode="srum")  # type: ignore[attr-defined]
+
+    for argv in calls:
+        assert "--json" not in argv, (
+            f"chainsaw 2.16.0 exits 2 on 'analyse srum ... --json'; argv was {argv}"
+        )
+
+
+def test_the_srum_argv_matches_the_declared_usage(srum_db: Path, software_hive: Path) -> None:
+    """Pins the whole shape: `analyse srum <db> --software <hive> --output <f>`."""
+    argv = _srum_argv(srum_db, software_hive)
+
+    assert argv[1:3] == ["analyse", "srum"]
+    assert argv[3] == str(srum_db)
+    assert set(argv[4:]) == {
+        "--software",
+        str(software_hive),
+        "--output",
+        argv[argv.index("--output") + 1],
+    }
+
+
+def test_a_missing_software_hive_is_reported_not_left_to_clap(srum_db: Path) -> None:
+    """Chainsaw cannot guess the hive, so the analyst must be told to supply it."""
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        result: Any = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(srum_db), mode="srum"
+        )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "invalid_argument"
+    assert "software_hive_path" in str(result["error_message"])
+
+
+def test_a_nonexistent_software_hive_is_reported(srum_db: Path, tmp_path: Path) -> None:
+    """A supplied-but-absent hive is a file_not_found, not an opaque exit 2."""
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        result: Any = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(srum_db),
+            mode="srum",
+            software_hive_path=str(tmp_path / "absent" / "SOFTWARE"),
+        )
+
+    assert result["status"] == "error"
+    assert result["error_type"] == "file_not_found"
+
+
+def test_other_modes_keep_their_json_flag(tmp_path: Path) -> None:
+    """Narrowness: ``--json`` is invalid only for ``analyse srum``.
+
+    ``hunt``, ``search`` and ``timeline`` all accept ``-j/--json``; stripping it
+    from them would be a new defect rather than a fix.
+    """
+    evidence = tmp_path / "evtx"
+    evidence.mkdir()
+    (evidence / "Security.evtx").write_bytes(b"ElfFile\x00")
+    calls: list[list[str]] = []
+
+    def _record(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.extract_and_index", return_value={}),
+    ):
+        run_chainsaw.__wrapped__(str(evidence), mode="timeline")  # type: ignore[attr-defined]
+
+    assert calls
+    assert "--json" in calls[0]
+    assert "--software" not in calls[0]


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- **Chainsaw SRUM parsing can never execute on current `main`.** The invocation is rejected by argument parsing before the database is opened.
- Two independent defects in one argv, either of them fatal:
  1. **`--json` is not an option of `analyse srum` at all** — chainsaw errors with `unexpected argument '--json' found`. The subcommand always writes JSON to `--output`, so there was never a format flag to pass.
  2. **`--software <SOFTWARE_HIVE_PATH>` is required** and was never passed — Chainsaw needs the SOFTWARE hive to resolve the SRUM extension GUIDs into table names. There was no way for a caller to supply one.
- Fix: drop the rejected flag, add the required one, and expose `software_hive_path` on the tool. Absent/not-found hives are reported as `invalid_argument` / `file_not_found` instead of surfacing as an opaque exit 2.
- Scope: `src/mulder/server/tools/chainsaw.py`, srum mode only. Hunt, search and timeline are untouched — they legitimately take `--json`.

## The bug

```python
    output_file = output_dir / "chainsaw_srum.json"
    cmd = [
        binary,
        "analyse",
        "srum",
        str(srum_path),
        "--json",
        "--output",
        str(output_file),
    ]
```

**Verified empirically against the pinned release** — I downloaded `chainsaw_x86_64-unknown-linux-gnu.tar.gz` for v2.16.0 (the version in `manifest.py`) and ran mulder's exact argv:

```console
$ ./chainsaw --version
chainsaw 2.16.0

$ ./chainsaw analyse srum ./evidence/SRUDB.dat --json --output srum.json
error: unexpected argument '--json' found

  tip: to pass '--json' as a value, use '-- --json'

Usage: chainsaw analyse srum --software <SOFTWARE_HIVE_PATH> <SRUM_PATH>
(exit 2)
```

The declared usage puts `--software` outside the brackets — it is mandatory:

```console
$ ./chainsaw analyse srum --help
Usage: chainsaw analyse srum [OPTIONS] --software <SOFTWARE_HIVE_PATH> <SRUM_PATH>

Options:
  -s, --software <SOFTWARE_HIVE_PATH>  The path to the SOFTWARE hive
      --stats-only                     Only output details about the SRUM database
  -o, --output <OUTPUT>                Save the output to a file
```

And the corrected form parses and runs (it then fails only on my throwaway 16-byte `SRUDB.dat`, i.e. well past argument parsing):

```console
$ ./chainsaw analyse srum ./evidence/SRUDB.dat --software ./evidence/SOFTWARE --output srum.json
[!] Error parsing SRUM database: unable to load the ESE database
```

**The output is still JSON.** From chainsaw's `main.rs` at `v2.16.0`, the srum branch writes with `cs_print_json!(&json)` into the `--output` path, so dropping `--json` loses nothing and `_parse_chainsaw_srum_results` keeps working unchanged.

## The fix

```python
    output_file = output_dir / "chainsaw_srum.json"
    cmd = [
        binary,
        "analyse",
        "srum",
        str(srum_path),
        "--software",
        str(software_hive_path),
        "--output",
        str(output_file),
    ]
```

with a pre-flight, beside the existing `search_term` guard:

```python
    if mode == "srum":
        if not software_hive_path:
            return error_response(
                tc_id, "run_chainsaw", params,
                "software_hive_path is required when mode='srum': Chainsaw "
                "needs the SOFTWARE hive to resolve the SRUM extension GUIDs",
                error_type="invalid_argument",
            )
        if not Path(software_hive_path).exists():
            return error_response(
                tc_id, "run_chainsaw", params,
                f"SOFTWARE hive not found: {software_hive_path}",
                error_type="file_not_found",
            )
```

### Why these two are one PR

They are a single argv and a single user-visible failure. Correcting only `--software` still leaves `--json` making chainsaw exit 2; correcting only `--json` still leaves the required argument missing. Splitting them would produce one PR that demonstrably fixes nothing, and a test for it could only assert on a flag rather than on SRUM working.

## Deliberately out of scope

- **`--stats-only`** and other srum options: not needed to make the existing mode work.
- **Surfacing the failure.** Open PR #95 (`fix/chainsaw-exit-code`) makes a failed Chainsaw run report an error rather than a clean scan. This PR and #95 are **complementary and independent** — #95 makes the failure visible, this one removes its cause — and both branch off `main`.
- **A caveat worth recording for #95's benefit:** while testing I observed that `chainsaw analyse srum` prints `[!] Error parsing SRUM database: ...` and still **exits 0**. Chainsaw's `main.rs` handles that error with `cs_eredln!` and no non-zero exit. So a returncode-based guard alone will not catch a corrupt SRUM database. Noting it here; not addressed in this PR.
- The hunt subcommand has its own separate CLI defect (a missing `--mapping`); that is a different PR against a different subcommand.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `chainsaw.py` restored to `origin/main` and the new tests kept, **6 of 7 fail**:

```
FAILED test_srum_passes_the_required_software_hive - TypeError: run_chainsaw() got an unexpected keyword argument 'software_hive...
FAILED test_srum_does_not_pass_the_json_flag_it_rejects - TypeError: run_chainsaw() got an unexpected keyword argument 'software_hive...
FAILED test_srum_never_reaches_chainsaw_carrying_json - AssertionError: chainsaw 2.16.0 exits 2 on 'analyse srum ... --json'; argv ...
FAILED test_the_srum_argv_matches_the_declared_usage - TypeError: run_chainsaw() got an unexpected keyword argument 'software_hive...
FAILED test_a_missing_software_hive_is_reported_not_left_to_clap - AssertionError: assert 'os_error' == 'invalid_argument'
FAILED test_a_nonexistent_software_hive_is_reported - TypeError: run_chainsaw() got an unexpected keyword argument 'software_hive...
6 failed, 1 passed
```

  Being precise about what those prove: four fail on `TypeError` because the parameter genuinely does not exist on `main` — that is the API gap, but it is a weak signal on its own. **`test_srum_never_reaches_chainsaw_carrying_json` is the behavioural one**: it calls srum mode the way unmodified `main` allows (no hive at all), captures the argv actually handed to `subprocess.run`, and fails because that argv carries `--json`. `test_a_missing_software_hive_is_reported_not_left_to_clap` is behavioural too — on `main` the run reaches chainsaw and comes back `os_error`.

  `test_other_modes_keep_their_json_flag` passes against both trees: it pins the fix's narrowness (only `analyse srum` rejects `--json`) rather than the bug.

## Context

Recovered from closed PR #69, which changed the CLI contract of every wrapped tool at once. This is one tool, one subcommand, one argv. The rejected outcome framework is **not** reintroduced and there is no `classify_tool_exit` or second status taxonomy here, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place, and this uses a new branch name rather than reusing the closed one.

## Merged with current `main`

`main` has since changed `_run_chainsaw_srum` to return `(path, proc)` so the
caller can tell an empty result set from a run that never produced one. The
merge keeps both changes: that tuple return and this branch's corrected argv
(`--software`, no `--json`).

One file outside this fix is touched: `tests/test_chainsaw_exit_code.py`. Its
`srum` parametrisation invoked the tool with no SOFTWARE hive, which this PR
makes mandatory, so those cases now pass one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

