### PR TITLE
[high] fix(case): actually decompress a gzipped disk image

### DIFF
--- a/src/mulder/server/tools/case.py
+++ b/src/mulder/server/tools/case.py
@@ -5,6 +5,8 @@ Tier 1 tools: help the agent orient before running any extractions.
 
 from __future__ import annotations
 
+import bz2
+import gzip
 import logging
 import os
 import shutil
@@ -445,6 +447,34 @@ def _extract_tar(archive: Path, dest: Path) -> list[str]:
     return [str(f.relative_to(dest)) for f in dest.rglob("*") if f.is_file()]
 
 
+def _extract_single_stream(archive: Path, dest: Path) -> list[str]:
+    """Decompress a single-member gzip/bzip2 stream into *dest*.
+
+    ``evidence.dd.gz`` is one compressed file, not an archive of files.  The
+    output keeps the name with the compression suffix removed, so
+    ``evidence.dd.gz`` becomes ``evidence.dd``.
+    """
+    opener = gzip.open if archive.suffix.lower() == ".gz" else bz2.open
+    out = dest / archive.stem
+    with opener(archive, "rb") as src, open(out, "wb") as dst:
+        shutil.copyfileobj(src, dst)
+    return [str(out.relative_to(dest))]
+
+
+def _tar_member_count(archive: Path) -> int:
+    """Return how many members *archive* yields when read as a tar, else 0.
+
+    ``tarfile.is_tarfile`` cannot answer this for a compressed file: it sees
+    the gzip wrapper and returns True for a plain ``.dd.gz`` as readily as for
+    a real ``.tar.gz``.  Counting members is the only honest test.
+    """
+    try:
+        with tarfile.open(archive, "r:*") as tf:
+            return sum(1 for _ in tf)
+    except (tarfile.TarError, OSError, EOFError):
+        return 0
+
+
 def _extract_7z(archive: Path, dest: Path) -> list[str]:
     """Extract via the ``7z`` CLI to *dest*; return paths relative to *dest*."""
     cmd = ["7z", "x", f"-o{dest}", "-y", str(archive)]
@@ -533,12 +563,16 @@ def extract_archive(
     try:
         if ext == ".zip":
             files = _extract_zip(archive, dest)
-        elif (
-            ext in (".tar", ".tgz")
-            or name_lower.endswith((".tar.gz", ".tar.bz2"))
-            or (ext in (".gz", ".bz2") and ".tar" not in name_lower)
-        ):
+        elif ext in (".tar", ".tgz") or name_lower.endswith((".tar.gz", ".tar.bz2")):
             files = _extract_tar(archive, dest)
+        elif ext in (".gz", ".bz2"):
+            # A bare .gz/.bz2 is usually one compressed file (evidence.dd.gz),
+            # but it may also be a tar that was not named .tar.gz.  Ask the
+            # archive which it is instead of guessing from the name.
+            if _tar_member_count(archive):
+                files = _extract_tar(archive, dest)
+            else:
+                files = _extract_single_stream(archive, dest)
         elif ext in (".7z", ".rar") or ".7z." in name_lower:
             if not shutil.which("7z"):
                 return error_response(

--- a/tests/test_archive_plain_gzip.py
+++ b/tests/test_archive_plain_gzip.py
@@ -1,0 +1,130 @@
+"""A gzipped disk image must actually be decompressed.
+
+``extract_archive`` routed every bare ``.gz``/``.bz2`` to the *tar* extractor:
+
+    or (ext in (".gz", ".bz2") and ".tar" not in name_lower)
+
+``evidence.dd.gz`` is one compressed file, not an archive of files.  Feeding it
+to ``tarfile`` does not raise -- tarfile opens the gzip wrapper, finds no tar
+members, and returns an empty list.  ``extract_archive`` then reported
+``status: success`` with ``total_files_extracted: 0`` and the disk image was
+never written.  A failure to unpack the central piece of evidence in a case was
+reported as a successful extraction of nothing.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import tarfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mulder.server.tools.case import extract_archive
+
+_IMAGE = b"\x00" * 4096 + b"EVIDENCE-MAGIC"
+
+
+@pytest.fixture
+def cases_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "cases"
+    d.mkdir()
+    return d
+
+
+def _invoke(cases_dir: Path, archive: Path, dest: Path) -> Any:
+    cfg = MagicMock()
+    cfg.db_dir = cases_dir
+    with (
+        patch("mulder.server.tools.case.get_cfg", return_value=cfg),
+        patch("mulder.server.tools.case.has_ctx", return_value=False),
+        patch("mulder.server.tools.case.EvidenceClassifier", create=True),
+    ):
+        return extract_archive.__wrapped__(  # type: ignore[attr-defined]
+            str(archive), extract_to=str(dest)
+        )
+
+
+def test_a_gzipped_disk_image_is_actually_decompressed(cases_dir: Path, tmp_path: Path) -> None:
+    """The headline case: evidence.dd.gz must produce evidence.dd."""
+    archive = tmp_path / "evidence.dd.gz"
+    archive.write_bytes(gzip.compress(_IMAGE))
+    dest = tmp_path / "out"
+
+    result = _invoke(cases_dir, archive, dest)
+
+    assert result["status"] == "success"
+    assert result["total_files_extracted"] == 1, f"the image was not written: {result}"
+    assert (dest / "evidence.dd").read_bytes() == _IMAGE
+
+
+def test_a_bzipped_image_is_decompressed(cases_dir: Path, tmp_path: Path) -> None:
+    archive = tmp_path / "memory.raw.bz2"
+    archive.write_bytes(bz2.compress(_IMAGE))
+    dest = tmp_path / "out"
+
+    result = _invoke(cases_dir, archive, dest)
+
+    assert result["status"] == "success"
+    assert (dest / "memory.raw").read_bytes() == _IMAGE
+
+
+def test_a_tar_gz_still_goes_to_the_tar_extractor(cases_dir: Path, tmp_path: Path) -> None:
+    """Pins narrowness: real tarballs must keep working."""
+    inner = tmp_path / "one.txt"
+    inner.write_bytes(b"1")
+    tar_gz = tmp_path / "bundle.tar.gz"
+    with tarfile.open(tar_gz, "w:gz") as tf:
+        tf.add(inner, arcname="one.txt")
+    dest = tmp_path / "out"
+
+    result = _invoke(cases_dir, tar_gz, dest)
+
+    assert result["status"] == "success"
+    assert (dest / "one.txt").read_bytes() == b"1"
+
+
+def test_a_tar_misnamed_as_plain_gz_is_still_untarred(cases_dir: Path, tmp_path: Path) -> None:
+    """The name is not authoritative, so the content is consulted.
+
+    ``tarfile.is_tarfile`` cannot help here -- it returns True for a plain
+    gzipped file too, because it only sees the gzip wrapper.
+    """
+    inner = tmp_path / "two.txt"
+    inner.write_bytes(b"2")
+    real_tar = tmp_path / "scratch.tar"
+    with tarfile.open(real_tar, "w") as tf:
+        tf.add(inner, arcname="two.txt")
+    misnamed = tmp_path / "bundle.gz"
+    misnamed.write_bytes(gzip.compress(real_tar.read_bytes()))
+    dest = tmp_path / "out"
+
+    result = _invoke(cases_dir, misnamed, dest)
+
+    assert result["status"] == "success"
+    assert (dest / "two.txt").read_bytes() == b"2"
+
+
+def test_is_tarfile_says_yes_to_a_gzipped_disk_image(tmp_path: Path) -> None:
+    """Documents why the fix counts members instead of trusting is_tarfile.
+
+    A tar header block is 512 bytes, and a disk image starts with a run of
+    zeroes, so any realistic gzipped image looks like a tar to ``is_tarfile``.
+    Verified: 512 zero bytes is already enough. Only a payload far too small to
+    be evidence (9 bytes here) is correctly rejected -- which is why the name
+    cannot be trusted and the member count must be consulted.
+    """
+    image = tmp_path / "image.gz"
+    image.write_bytes(gzip.compress(_IMAGE))
+    assert tarfile.is_tarfile(image) is True
+
+    tiny = tmp_path / "tiny.gz"
+    tiny.write_bytes(gzip.compress(b"too small"))
+    assert tarfile.is_tarfile(tiny) is False
+
+    # The member count is the honest test, and it separates them.
+    with tarfile.open(image, "r:*") as tf:
+        assert sum(1 for _ in tf) == 0


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- `extract_archive` routed every bare `.gz`/`.bz2` to the **tar** extractor. `evidence.dd.gz` is one compressed file, not an archive of files.
- It does not crash, which is the problem. `tarfile` opens the gzip wrapper, finds no tar members, and returns an empty list — so `extract_archive` reported **`status: success` with `total_files_extracted: 0`** and the disk image was never written.
- Failing to unpack the central piece of evidence in a case was reported as a successful extraction of nothing. `.dd.gz`, `.raw.gz`, `.E01.gz` and `.log.gz` are all ordinary DFIR inputs.
- Fix: send a bare `.gz`/`.bz2` to a single-stream decompressor (`evidence.dd.gz` → `evidence.dd`), and decide tar-vs-stream by **counting the members the archive actually yields**, not by its name.
- Scope: `src/mulder/server/tools/case.py` — two small helpers and the format dispatch.

## The bug

```python
        elif (
            ext in (".tar", ".tgz")
            or name_lower.endswith((".tar.gz", ".tar.bz2"))
            or (ext in (".gz", ".bz2") and ".tar" not in name_lower)   # <- here
        ):
            files = _extract_tar(archive, dest)
```

The third clause reads as if it is catching tarballs, but it catches exactly the files that are **not** tarballs. Reproduced directly:

```
>>> tarfile.open("evidence.dd.gz", "r:*").getnames()
[]
=> extract_archive would report success with total_files_extracted = 0
```

## The fix

```python
        elif ext in (".tar", ".tgz") or name_lower.endswith((".tar.gz", ".tar.bz2")):
            files = _extract_tar(archive, dest)
        elif ext in (".gz", ".bz2"):
            # A bare .gz/.bz2 is usually one compressed file (evidence.dd.gz),
            # but it may also be a tar that was not named .tar.gz.  Ask the
            # archive which it is instead of guessing from the name.
            if _tar_member_count(archive):
                files = _extract_tar(archive, dest)
            else:
                files = _extract_single_stream(archive, dest)
```

### Why `is_tarfile` is not used

The obvious probe is `tarfile.is_tarfile`, and it is wrong here. A tar header block is 512 bytes and a disk image opens with a run of zeroes, so **any realistic gzipped image reports `is_tarfile=True`**. Measured on this branch:

```
    9 zero bytes gz -> is_tarfile=False
  512 zero bytes gz -> is_tarfile=True
 4096 zero bytes gz -> is_tarfile=True
disk-image-like gz  -> is_tarfile=True
```

Only a payload far too small to be evidence is rejected correctly. `_tar_member_count` opens the archive and counts what it yields, which separates the two cases for real inputs, and a test pins that.

## Deliberately out of scope

- **`.xz` / `.lzma`** are not handled by `extract_archive` at all today — they fall through to `unsupported_format`. Adding them is a feature, not this fix; I left the supported set unchanged.
- **Destination containment, resource limits, and the partial-extraction bug** — separate PRs recovered from closed #84/#85.
- No compression-ratio zip-bomb heuristic is introduced anywhere.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **860 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `case.py` restored to `origin/main` and the tests kept:

```
FAILED test_a_gzipped_disk_image_is_actually_decompressed
  - AssertionError: the image was not written: {'tool_call_id': ..., 'status': 'success', ...}
FAILED test_a_bzipped_image_is_decompressed
  - FileNotFoundError: [Errno 2] No such file or directory: '.../memory.raw'
2 failed, 3 passed
```

The first failure is the bug verbatim: `status: success`, and no image on disk. The three that pass against **both** trees are the narrowness tests — a real `.tar.gz` still untars, a tar misnamed `.gz` still untars, and the `is_tarfile` characterisation holds — so the fix cannot be credited with more than it fixes.

## Context

Recovered from closed PR **#85** (`fix/archive-completion`), which bundled this with the partial-extraction defect and was stacked on #84. This is the gzip-routing concern only, branched fresh from current `main` (`2e5432c`) — the closed branch was not revised in place, and this branch takes a new name rather than reusing the closed one. None of the rejected outcome framework is reintroduced. Verified conflict-free against open #83 and #88, the other PRs touching this file.

## Note on the sibling PRs

This is one of four narrow PRs recovered from closed #84/#85, all touching `extract_archive` in `src/mulder/server/tools/case.py`:

| PR | Concern |
|----|---------|
| #103 | destination containment + slot collision |
| #111 | resource limits (member count / total bytes) |
| #117 | partial extraction reported as complete |
| #124 | plain `.gz`/`.bz2` routed to the tar extractor |

Each is independently branched off `main` and independently testable, and **all four are verified conflict-free against open #83 and #88**, the other PRs on this file.

They are **not** all conflict-free against each other — four of the six pairs touch overlapping lines of the same function (`git merge-tree` reports `CONFLICT (content): src/mulder/server/tools/case.py` for dest×partial, dest×gzip, limits×partial, partial×gzip). That is inherent to splitting one function's defects into one-fix-per-PR rather than shipping a bundle. Merge them in any order; whichever lands first, I will rebase the rest — say the word and I will do that immediately, or collapse any subset into a single PR if you would rather review them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
