### PR TITLE
[high] fix(chainsaw): index the detections, not just how many there were

### DIFF
--- a/src/mulder/server/tools/chainsaw.py
+++ b/src/mulder/server/tools/chainsaw.py
@@ -342,7 +342,7 @@ def _parse_chainsaw_hunt_results(results_path: Path) -> dict[str, Any]:
         )
 
     return {
-        "detections": detections[:500],
+        "detections": detections,
         "total_findings": len(detections),
         "severity_counts": severity_counts,
         "mitre_techniques": sorted(mitre_techniques),
@@ -382,7 +382,7 @@ def _parse_chainsaw_srum_results(results_path: Path) -> dict[str, Any]:
         )
 
     return {
-        "srum_entries": entries[:500],
+        "srum_entries": entries,
         "total_entries": len(entries),
     }
 
@@ -408,9 +408,63 @@ def _parse_chainsaw_timeline_results(results_path: Path) -> dict[str, Any]:
         raw = [raw] if raw else []
 
     return {
-        "timeline_entries": raw[:1000],
+        "timeline_entries": raw,
         "total_entries": len(raw),
     }
+
+
+_RESPONSE_RECORD_CAP = 500
+
+
+def _detection_lines(result: dict[str, Any], mode: str) -> list[str]:
+    """One searchable line per record, for the case DB.
+
+    Only counts used to be indexed, so the detections themselves -- rule names,
+    computers, event IDs, SRUM process names -- were never searchable.  This is
+    deliberately a module-local helper rather than a shared formatter: the
+    fields worth indexing differ per tool.
+    """
+    lines: list[str] = []
+    if mode in ("hunt", "search"):
+        for d in result.get("detections", []):
+            lines.append(
+                " | ".join(
+                    str(part)
+                    for part in (
+                        d.get("timestamp", ""),
+                        d.get("rule_level", ""),
+                        d.get("rule_name", ""),
+                        d.get("computer", ""),
+                        d.get("channel", ""),
+                        f"EventID={d.get('event_id', '')}",
+                        d.get("sigma_id", ""),
+                        " ".join(d.get("mitre_attack", []) or []),
+                    )
+                    if str(part)
+                )
+            )
+    elif mode == "srum":
+        for e in result.get("srum_entries", []):
+            lines.append(
+                " | ".join(str(v) for v in e.values() if str(v)) if isinstance(e, dict) else str(e)
+            )
+    else:
+        for e in result.get("timeline_entries", []):
+            lines.append(
+                " | ".join(str(v) for v in e.values() if str(v)) if isinstance(e, dict) else str(e)
+            )
+    return [line for line in lines if line.strip()]
+
+
+def _cap_records(result: dict[str, Any]) -> dict[str, Any]:
+    """Trim the record lists in the *response* only, never before indexing."""
+    capped = dict(result)
+    for key in ("detections", "srum_entries", "timeline_entries"):
+        records = capped.get(key)
+        if isinstance(records, list) and len(records) > _RESPONSE_RECORD_CAP:
+            capped[key] = records[:_RESPONSE_RECORD_CAP]
+            capped[f"{key}_truncated"] = True
+    return capped
 
 
 @mcp.tool()
@@ -589,8 +643,10 @@ def run_chainsaw(
         else:
             text_parts.append(f"Timeline entries: {result.get('total_entries', 0)}")
 
+        text_parts.extend(_detection_lines(result, mode))
+
         summary = extract_and_index("\n".join(text_parts), source_name, evidence_path, "chainsaw")
-        summary.update(result)
+        summary.update(_cap_records(result))
 
     elapsed = (time.monotonic() - t0) * 1000
     return tool_response(tc_id, "run_chainsaw", params, summary, source_name, elapsed)

--- a/tests/test_chainsaw_detection_indexing.py
+++ b/tests/test_chainsaw_detection_indexing.py
@@ -1,0 +1,189 @@
+"""Chainsaw's detections must reach the case DB, not just their count.
+
+``run_chainsaw`` indexed only a summary::
+
+    Chainsaw hunt analysis of /evidence
+    Total findings: 3
+      high: 2
+
+The detections themselves -- rule names, computers, event IDs, MITRE
+techniques -- were passed to ``tool_response`` but never to
+``extract_and_index``.  With ``source`` set, ``tool_response`` returns a compact
+preview, so a later ``search()`` over the case could not find a single Chainsaw
+detection by rule name.
+
+There was a second half to the same defect: the parsers truncated their record
+lists (``detections[:500]``, ``srum_entries[:500]``, ``timeline_entries[:1000]``)
+*before* the caller ever saw them, so on a busy host the records past the cap
+could not be indexed even in principle.  The cap belongs on the response, not on
+the index.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from mulder.server.tools.chainsaw import run_chainsaw
+
+
+@pytest.fixture
+def evidence(tmp_path: Path) -> Path:
+    evtx = tmp_path / "Security.evtx"
+    evtx.write_bytes(b"ElfFile\x00")
+    return tmp_path
+
+
+def _run(evidence: Path, mode: str, payload: list[dict[str, Any]]) -> tuple[str, Any]:
+    """Run *mode* with Chainsaw writing *payload*; return (indexed text, response)."""
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    def _write(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.write_text(json.dumps(payload))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_write),
+        patch("mulder.server.tools.chainsaw.extract_and_index", side_effect=_record),
+    ):
+        response = run_chainsaw.__wrapped__(  # type: ignore[attr-defined]
+            str(evidence), mode=mode
+        )
+
+    assert indexed, "nothing was indexed at all"
+    return indexed[0], response
+
+
+_DETECTION = {
+    "timestamp": "2024-03-01T10:00:00Z",
+    "name": "Suspicious PowerShell Encoded Command",
+    "level": "high",
+    "computer": "WORKSTATION-07",
+    "channel": "Security",
+    "event_id": 4688,
+    "rule_id": "abc-123-sigma",
+    "tags": ["attack.execution", "attack.t1059"],
+}
+
+
+def test_the_detection_itself_is_indexed_not_only_its_count(evidence: Path) -> None:
+    """The searchable text must carry what an analyst would search for."""
+    text, _response = _run(evidence, "hunt", [_DETECTION])
+
+    assert "Suspicious PowerShell Encoded Command" in text, (
+        f"the rule name never reached the case DB; indexed text was:\n{text}"
+    )
+    assert "WORKSTATION-07" in text
+    assert "4688" in text
+    assert "abc-123-sigma" in text
+    assert "attack.t1059" in text
+
+
+def test_the_summary_counts_are_still_indexed(evidence: Path) -> None:
+    """Narrowness: the existing summary lines are kept, not replaced."""
+    text, _response = _run(evidence, "hunt", [_DETECTION])
+
+    assert "Total findings: 1" in text
+    assert "Chainsaw hunt analysis of" in text
+
+
+def test_every_detection_is_indexed_past_the_response_cap(evidence: Path) -> None:
+    """The second half of the defect: records were cut before indexing.
+
+    The parsers truncated at 500 before the caller saw them, so detection 501
+    could never be indexed.  The cap belongs on the response.
+    """
+    payload = [
+        {**_DETECTION, "name": f"Rule number {i}", "computer": f"HOST-{i}"} for i in range(600)
+    ]
+
+    text, response = _run(evidence, "hunt", payload)
+
+    assert "Rule number 599" in text, "detections past the 500 cap were never indexed"
+    assert "HOST-599" in text
+    # the response stays bounded
+    detections = response["results"]["detections"] if "results" in response else None
+    if detections is None:  # compact preview envelope
+        assert response["status"] == "success"
+    else:
+        assert len(detections) == 500
+
+
+def test_the_response_is_still_capped(evidence: Path) -> None:
+    """Indexing everything must not mean returning everything to the agent."""
+    payload = [
+        {**_DETECTION, "name": f"Rule number {i}", "computer": f"HOST-{i}"} for i in range(600)
+    ]
+
+    indexed: list[str] = []
+
+    def _record(raw: str, *args: object, **kwargs: object) -> dict[str, object]:
+        indexed.append(raw)
+        return {}
+
+    def _write(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        out = Path(cmd[cmd.index("--output") + 1])
+        out.write_text(json.dumps(payload))
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    captured: dict[str, Any] = {}
+
+    def _tool_response(
+        tc_id: str,
+        tool_name: str,
+        params: Any,
+        results: Any,
+        source: Any = None,
+        elapsed_ms: float = 0,
+    ) -> dict[str, object]:
+        captured["results"] = results
+        return {"status": "success"}
+
+    with (
+        patch("mulder.server.tools.chainsaw._chainsaw_binary", return_value="/usr/bin/chainsaw"),
+        patch("mulder.server.tools.chainsaw.sources_already_indexed", return_value=[]),
+        patch("mulder.server.tools.chainsaw.subprocess.run", side_effect=_write),
+        patch("mulder.server.tools.chainsaw.extract_and_index", side_effect=_record),
+        patch("mulder.server.tools.chainsaw.tool_response", side_effect=_tool_response),
+    ):
+        run_chainsaw.__wrapped__(str(evidence), mode="hunt")  # type: ignore[attr-defined]
+
+    results = captured["results"]
+    assert len(results["detections"]) == 500, "the response must stay bounded"
+    assert results["detections_truncated"] is True
+    assert results["total_findings"] == 600, "the true count must survive the cap"
+    assert "Rule number 599" in indexed[0], "but everything must still be indexed"
+
+
+def test_timeline_entries_are_indexed(evidence: Path) -> None:
+    """The same defect applied to timeline mode, which indexed only a count."""
+    payload = [
+        {"timestamp": "2024-03-01T10:00:00Z", "event": "svchost.exe spawned cmd.exe"},
+        {"timestamp": "2024-03-01T10:00:01Z", "event": "cmd.exe spawned whoami.exe"},
+    ]
+
+    text, _response = _run(evidence, "timeline", payload)
+
+    assert "svchost.exe spawned cmd.exe" in text
+    assert "whoami.exe" in text
+    assert "Timeline entries: 2" in text
+
+
+def test_a_quiet_host_still_indexes_its_summary(evidence: Path) -> None:
+    """Narrowness: zero detections is a real result and stays indexed."""
+    text, response = _run(evidence, "hunt", [])
+
+    assert "Total findings: 0" in text
+    assert response["status"] == "success"


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- **Chainsaw's detections are not searchable in the case.** `run_chainsaw` indexed only a summary — `Total findings: 3` and the per-level counts — so a later `search()` cannot find a Chainsaw detection by rule name, host, event ID or MITRE technique.
- The records went to `tool_response`, but with `source` set that returns a **compact preview** and drops the rest. So the detections reached neither the case DB nor, in full, the agent.
- **The same defect has a second half:** the parsers truncated their record lists (`detections[:500]`, `srum_entries[:500]`, `timeline_entries[:1000]`) *before* the caller saw them. On a busy host, records past the cap could not be indexed even in principle.
- Fix: format one searchable line per record and index **all** of them; cap only the **response**, flagged with `<key>_truncated`. The cap belongs on what is returned, never on what is stored.
- Scope: `src/mulder/server/tools/chainsaw.py` only. The formatter is a **module-local helper**, not a shared abstraction.

## The bug

```python
        text_parts = [f"Chainsaw {mode} analysis of {evidence_path}"]
        if mode in ("hunt", "search"):
            text_parts.append(f"Total findings: {result.get('total_findings', 0)}")
            for level, count in result.get("severity_counts", {}).items():
                text_parts.append(f"  {level}: {count}")
        ...
        summary = extract_and_index("\n".join(text_parts), source_name, evidence_path, "chainsaw")
        summary.update(result)
```

Everything indexed is a count. A hunt that fires `Suspicious PowerShell Encoded Command` on `WORKSTATION-07` stores the sentence "Total findings: 1" and nothing an analyst would actually search for.

And in the parsers, upstream of all of it:

```python
    return {
        "detections": detections[:500],      # cut before the caller can index them
        "total_findings": len(detections),   # ... though the count stays honest
    }
```

## The fix

Records are no longer truncated in the parsers. The caller formats and indexes every one, then caps the response:

```python
        text_parts.extend(_detection_lines(result, mode))

        summary = extract_and_index("\n".join(text_parts), source_name, evidence_path, "chainsaw")
        summary.update(_cap_records(result))
```

```python
def _cap_records(result: dict[str, Any]) -> dict[str, Any]:
    """Trim the record lists in the *response* only, never before indexing."""
    capped = dict(result)
    for key in ("detections", "srum_entries", "timeline_entries"):
        records = capped.get(key)
        if isinstance(records, list) and len(records) > _RESPONSE_RECORD_CAP:
            capped[key] = records[:_RESPONSE_RECORD_CAP]
            capped[f"{key}_truncated"] = True
    return capped
```

`_detection_lines` is deliberately **module-local**. The fields worth indexing differ per tool — a Chainsaw detection is not shaped like a Zircolite one — so a shared formatter would be a cross-cutting abstraction with no second honest caller. Response size is unchanged at 500 records; the difference is that the other 100 of a 600-detection hunt are now in the case DB instead of discarded.

## Deliberately out of scope

- **The `tool_response` envelope.** Making a success response carry more than a preview is a separate concern and is not proposed here — indexing is the right place for the full records, which is exactly what this PR does.
- **The CLI defects.** Hunt mode is currently rejected by argument parsing for a missing `--mapping`, and srum for a rejected `--json` plus a missing `--software`. Those are separate PRs against separate subcommands. This PR is about what happens to detections once Chainsaw does produce them.
- **Surfacing failures.** Open PR #95 (`fix/chainsaw-exit-code`) covers that; independent of this and also branched off `main`.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **861 passed**, nothing deselected, nothing skipped.
- **Discriminating check** — with `chainsaw.py` restored to `origin/main` and the new tests kept, **4 of 6 fail, all behaviourally** (no import errors, no signature changes involved):

```
FAILED test_the_detection_itself_is_indexed_not_only_its_count - AssertionError: the rule name never reached the case DB; indexed text was:
FAILED test_every_detection_is_indexed_past_the_response_cap - AssertionError: detections past the 500 cap were never indexed
FAILED test_the_response_is_still_capped - KeyError: 'detections_truncated'
FAILED test_timeline_entries_are_indexed - AssertionError: assert 'svchost.exe spawned cmd.exe' in 'Chainsaw timeline ...
4 failed, 2 passed
```

  The two that pass on both trees are the narrowness pins: the existing summary lines are still indexed, and a hunt with zero detections is still a successful, indexed result.

  `test_the_response_is_still_capped` is the one that guards against over-correcting — it asserts the response holds exactly 500 records and `total_findings == 600`, while detection 599 is present in the indexed text.

## Context

Recovered from closed PR #74, which made this change across chainsaw, zircolite, aleapp and ileapp at once behind a shared record-formatting helper. This is one tool, and the helper is module-local — the rejected outcome framework is **not** reintroduced, and there is no `classify_tool_exit` or second status taxonomy here, per the review on #32:

> focused fixes for specific tools that currently swallow failures or lose partial-result information would be welcome.

Branched fresh from current `main` (`2e5432c`); the closed branch was not revised in place, and this uses a new branch name rather than reusing the closed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
