### PR TITLE
[high] fix(report): escape finding titles and restore the executive summary's markup

### DIFF
--- a/src/mulder/report/renderer.py
+++ b/src/mulder/report/renderer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import html
 import json
 import logging
 import re
@@ -454,7 +455,7 @@ def _build_executive_summary(
     if tl:
         earliest, latest = _timeline_date_range(tl)
         if earliest and latest:
-            first_event = tl[0].title
+            first_event = html.escape(tl[0].title)
             first_ts = tl[0].event_time_start
             narrative = f"The attack timeline spans <strong>{earliest}</strong>"
             if earliest != latest:
@@ -466,14 +467,14 @@ def _build_executive_summary(
 
             crit_tl = [f for f in tl if f.severity == "critical"]
             if len(crit_tl) > 1:
-                mid_titles = [f.title for f in crit_tl[1:4]]
+                mid_titles = [html.escape(f.title) for f in crit_tl[1:4]]
                 narrative += (
                     " The investigation subsequently uncovered "
                     + "; ".join(f"<em>{t}</em>" for t in mid_titles)
                     + "."
                 )
 
-            last_event = tl[-1].title
+            last_event = html.escape(tl[-1].title)
             if len(tl) > 1 and last_event != first_event:
                 last_ts = tl[-1].event_time_start
                 narrative += f" The most recent activity was <em>{last_event}</em>"
@@ -483,7 +484,7 @@ def _build_executive_summary(
             sections.append(f"<p>{narrative}</p>")
 
     if critical_findings:
-        items = "".join(f"<li>{f.title}</li>" for f in critical_findings[:5])
+        items = "".join(f"<li>{html.escape(f.title)}</li>" for f in critical_findings[:5])
         sections.append(
             f'<div class="exec-threats"><strong>Key Threats</strong><ul>{items}</ul></div>'
         )

--- a/src/mulder/report/templates/report.html.j2
+++ b/src/mulder/report/templates/report.html.j2
@@ -618,7 +618,7 @@ table.data-table code { font-family: var(--mono); font-size: 0.78em; color: var(
 
   <div class="exec-summary">
     <div class="exec-summary-label">Executive Summary</div>
-    <p>{{ executive_summary }}</p>
+    <p>{{ executive_summary | safe }}</p>
   </div>
 
   <div class="stats-grid stagger-in">

--- a/tests/test_report_exec_summary_escaping.py
+++ b/tests/test_report_exec_summary_escaping.py
@@ -1,0 +1,158 @@
+"""The executive summary must render as markup, and must not carry injection.
+
+Two coupled defects on one path.
+
+``_build_executive_summary`` returns a string of pre-built HTML. The HTML
+template interpolated it as ``{{ executive_summary }}`` with no ``| safe``,
+and autoescaping is on for ``.html.j2``, so the first block an analyst reads
+showed raw ``&lt;div class=...&gt;`` tags as literal text instead of formatted
+content.
+
+The obvious fix -- marking it ``| safe`` -- is only correct once the finding
+titles interpolated into that string are escaped. Titles come straight off the
+evidence, so an attacker-chosen filename or registry value would otherwise be
+injected into the report as live markup. Neither half is right alone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import cast
+
+import jinja2
+import pytest
+
+from mulder.models import Finding
+from mulder.report.renderer import ReportRenderer, _build_executive_summary
+
+_XSS = '<script>alert("xss")</script>'
+
+
+def _finding(title: str, severity: str = "critical") -> Finding:
+    return Finding(
+        finding_id="f1",
+        case_id="case-1",
+        title=title,
+        description="d",
+        severity=severity,  # type: ignore[arg-type]
+        confidence="confirmed",
+        evidence_refs=["tc_1"],
+        sources=["src"],
+        submitted_at="2026-01-01T00:00:00",
+    )
+
+
+def _summary(**over: object) -> str:
+    kwargs: dict[str, object] = {
+        "case_id": "case-1",
+        "finding_count": 1,
+        "critical_count": 1,
+        "high_count": 0,
+        "sources_count": 1,
+        "total_tool_calls": 1,
+        "total_duration_ms": 1000.0,
+        "critical_findings": [_finding("Ransomware note")],
+    }
+    kwargs.update(over)
+    return _build_executive_summary(**kwargs)  # type: ignore[arg-type]
+
+
+def _autoescape_policy(env: object) -> Callable[[str | None], bool]:
+    """jinja2 types ``Environment.autoescape`` as ``bool``; here it is a callable."""
+    return cast("Callable[[str | None], bool]", env.autoescape)  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Half 1: the titles baked into the summary string must be escaped
+# ---------------------------------------------------------------------------
+
+
+def test_a_malicious_finding_title_cannot_inject_markup() -> None:
+    """Titles come off the evidence, so they must never become live markup."""
+    summary = _summary(critical_findings=[_finding(_XSS)])
+
+    assert "<script>" not in summary
+    assert "&lt;script&gt;" in summary
+
+
+@pytest.mark.parametrize("position", ["first", "middle", "last"])
+def test_timeline_titles_are_escaped_too(position: str) -> None:
+    """The timeline narrative bakes three more titles into the same string."""
+    titles = {
+        "first": [_XSS, "b", "c", "d"],
+        "middle": ["a", _XSS, "c", "d"],
+        "last": ["a", "b", "c", _XSS],
+    }[position]
+    tl = [_finding(t) for t in titles]
+    for i, f in enumerate(tl):
+        f.event_time_start = f"2026-01-0{i + 1}T00:00:00"
+
+    summary = _summary(timeline_findings=tl, critical_findings=[])
+
+    assert "<script>" not in summary
+    assert "&lt;script&gt;" in summary
+
+
+def test_the_summary_keeps_its_own_structural_markup() -> None:
+    """Narrowness: escaping the titles must not escape the block's own tags."""
+    summary = _summary()
+
+    assert '<div class="exec-threats">' in summary
+    assert "<li>Ransomware note</li>" in summary
+
+
+def test_a_title_is_not_double_escaped() -> None:
+    """An ampersand in a title must survive as one entity, not `&amp;amp;`."""
+    summary = _summary(critical_findings=[_finding("Rock & Roll")])
+
+    assert "Rock &amp; Roll" in summary
+    assert "&amp;amp;" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Half 2: the summary must reach the page as markup, not as escaped text
+# ---------------------------------------------------------------------------
+
+
+def _template_source() -> str:
+    env = ReportRenderer()._env
+    loader = env.loader
+    assert loader is not None
+    return loader.get_source(env, "report.html.j2")[0]
+
+
+def test_the_html_template_is_autoescaped() -> None:
+    """The premise of the regression: autoescape is on for this template."""
+    policy = _autoescape_policy(ReportRenderer()._env)
+
+    assert policy("report.html.j2") is True
+    assert policy("report.md.j2") is False
+
+
+def test_the_executive_summary_is_interpolated_as_markup() -> None:
+    """Without `| safe` an autoescaped template shows its tags as text."""
+    assert "{{ executive_summary | safe }}" in _template_source()
+
+
+def test_only_the_intended_values_are_marked_safe() -> None:
+    """`| safe` is a loaded gun; keep the count of them honest."""
+    safe_uses = [line.strip() for line in _template_source().splitlines() if "| safe" in line]
+
+    assert len(safe_uses) == 4, f"unexpected `| safe` uses: {safe_uses}"
+    assert any("executive_summary" in u for u in safe_uses)
+
+
+def test_safe_is_what_makes_the_difference_under_this_policy() -> None:
+    """Pins that the fix did not disable autoescaping to solve the display bug.
+
+    Rendered through an overlay of the real environment, so the same
+    ``select_autoescape`` policy applies to a ``.html.j2`` name.
+    """
+    env = ReportRenderer()._env.overlay(
+        loader=jinja2.DictLoader({"probe.html.j2": "{{ v }}|{{ v | safe }}"})
+    )
+
+    plain, marked = env.get_template("probe.html.j2").render(v=_XSS).split("|", 1)
+
+    assert plain == "&lt;script&gt;alert(&#34;xss&#34;)&lt;/script&gt;"
+    assert marked == _XSS


### PR DESCRIPTION
## BLUF

- **Priority: high.**
- The HTML report's **Executive Summary — the first block an analyst reads — currently renders as escaped text**, showing `&lt;div class="exec-threats"&gt;` instead of a formatted summary.
- Underneath it sits a **stored XSS**: four finding titles are interpolated into that pre-built HTML string with no escaping, and titles come straight off the evidence (filenames, registry values, carved strings).
- The two are **coupled**. Autoescaping currently neutralises the injection by accident; the obvious fix for the display bug (`| safe`) makes the XSS live. Neither half is correct alone.
- Fix: `html.escape()` on the four title interpolations, plus `| safe` on the single template use site. 9 lines in `renderer.py`, 1 token in the template.
- Scope: `src/mulder/report/renderer.py` and `report.html.j2` only.

## The bug

`_build_executive_summary` builds raw HTML with f-strings and returns it as a plain `str`:

```python
    if critical_findings:
        items = "".join(f"<li>{f.title}</li>" for f in critical_findings[:5])
        sections.append(
            f'<div class="exec-threats"><strong>Key Threats</strong><ul>{items}</ul></div>'
        )
```

Three more titles go in via the timeline narrative (`first_event`, `mid_titles`, `last_event`). `html.escape` appears **nowhere** in the module.

The template interpolates the result **without** `| safe`:

```jinja
    <p>{{ executive_summary }}</p>
```

Autoescaping is on for `.html.j2`, and exactly three values are marked trusted there (`narrative_html | safe`, `f.description_html | safe` ×2). `executive_summary` is not one of them, so its own markup is escaped and displayed as text.

## The fix

```python
            first_event = html.escape(tl[0].title)
                mid_titles = [html.escape(f.title) for f in crit_tl[1:4]]
            last_event = html.escape(tl[-1].title)
        items = "".join(f"<li>{html.escape(f.title)}</li>" for f in critical_findings[:5])
```

```jinja
    <p>{{ executive_summary | safe }}</p>
```

The `last_event != first_event` comparison still holds: both sides are escaped identically.

## Why both halves ship together

- Escaping alone → the summary still displays as literal tags.
- `| safe` alone → `<script>` in a finding title becomes live markup in the report.

A reviewer applying only one half gets either no improvement or a regression, so they are one change.

## Deliberately out of scope

- **The other `{{ f.title }}` sites in the template** (finding list, timeline, MITRE panels) need no change: autoescaping already covers them because they are interpolated as values, not as pre-built HTML. A test pins that this PR did not weaken that.
- **`_build_executive_summary_md`** feeds the markdown report, which is deliberately not autoescaped. Different output, different concern.

## Verification

- `uvx pre-commit run --all-files` (new test staged first) → ruff, ruff-format, mypy all pass.
- `uv run --locked --extra dev pytest tests/ -q` → **865 passed**, nothing deselected.
- **Discriminating check** — with `renderer.py` and `report.html.j2` restored to `origin/main` and the new tests kept, **7 of 10 fail**:

```
FAILED test_a_malicious_finding_title_cannot_inject_markup - assert '<script>' not in '<div class=...></ul></div>'
FAILED test_timeline_titles_are_escaped_too[first]  - assert '<script>' not in '<div class=...-01-04).</p>'
FAILED test_timeline_titles_are_escaped_too[middle] - assert '<script>' not in '<div class=...-01-04).</p>'
FAILED test_timeline_titles_are_escaped_too[last]   - assert '<script>' not in '<div class=...-01-04).</p>'
FAILED test_a_title_is_not_double_escaped           - assert 'Rock &amp; Roll' in '<div class="exec-meta">...
FAILED test_the_executive_summary_is_interpolated_as_markup - assert '{{ executive_summary | safe }}' in ...
FAILED test_only_the_intended_values_are_marked_safe - AssertionError: unexpected `| safe` uses: [...]
```

The three that pass on both trees are the narrowness tests — they pin the fix, not the bug.

## Context

Recovered from **closed PR #42** (`codex/pr-3.1-evidence-envelope`), which carried this fix underneath a large evidence-envelope refactor. Only the fix is taken: **no outcome framework, no envelope types, no shared helper** — the maintainer's objection in #32 was to that architecture, and none of it appears here.

The display half is a regression introduced by my own merged #73, which turned autoescaping on for `.html.j2`. #73 marked the three genuinely pre-rendered values `| safe` and missed this fourth one, which is pre-rendered HTML built in Python rather than by `markdown.markdown`.

Branched fresh from current `main` (`2e5432c`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
